### PR TITLE
fix: stop mobile browsers auto-zooming on the bus filter input

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,6 +141,13 @@
         font: 12px/1.4 system-ui, sans-serif;
       }
       .bf-input:focus { outline: none; border-color: #6ea8fe; }
+      /* 16px is WebKit's threshold: focusing an input below it auto-zooms the
+         page, and the zoom is unrecoverable here because MapLibre swallows the
+         pinch gesture that would undo it. Touch pointers only — desktop has no
+         auto-zoom, and 12px keeps the input in scale with the rest of the panel. */
+      @media (pointer: coarse) {
+        .bf-input { font-size: 16px; }
+      }
       .bf-chips { display: flex; flex-wrap: wrap; gap: 5px; }
       .bf-chip {
         display: inline-flex; align-items: center; gap: 4px; background: rgba(218,44,67,.16);


### PR DESCRIPTION
## Problem

On mobile Chrome, tapping the bus-filter route box zooms the page in and **there is no way back** — a page reload is the only escape.

Two mechanisms combine:

1. **The zoom in.** WebKit (iOS Safari, and Chrome on iOS, which is also WebKit) auto-zooms when an input with a computed `font-size` below **16px** receives focus. `.bf-input` was `font: 12px/1.4`, and `frontend/index.html:5` has no `maximum-scale`, so nothing blocks it.
2. **The zoom being stuck.** Pinching to zoom back out lands on the MapLibre canvas, which consumes the gesture as a *map* zoom. The browser-level visual-viewport zoom never receives it. There is no `touch-action` declaration anywhere in the project — touch handling is entirely MapLibre's.

## Fix

```css
@media (pointer: coarse) {
  .bf-input { font-size: 16px; }
}
```

Removes the trigger at the source. `pointer: coarse` targets touch devices specifically rather than narrow viewports — the bug is a touch-browser behaviour, unrelated to window width, so a desktop window dragged narrow should not be affected.

Desktop keeps 12px: it has no auto-zoom behaviour, and 16px would sit visibly out of scale in a panel built on a 10–11px baseline.

## Alternatives rejected

| Approach | Why not |
|---|---|
| `viewport` → `maximum-scale=1, user-scalable=no` | **iOS Safari 10+ deliberately ignores `user-scalable=no`**, so it does not fix the reported platform at all — and where it does apply it disables page zoom entirely, breaking WCAG 1.4.4 (Resize Text). |
| Relax `touch-action` so the browser gets the pinch | Only addresses the second half, and would break pinch-to-zoom on the map — a core gesture. |
| JS zoom reset on `blur` | No API resets the visual viewport; the viewport-meta-swap hack is janky and relies on undefined behaviour. |

## Scope

Only `<input>` in the project is `bus-filter.ts:35`; there are no `<select>` or `<textarea>` elements, so this is the only affected entry point.

## Verification

- `npm run build` (`tsc && vite build`) — passes
- `npx vitest run` — 46 tests across 3 files pass
- Media query confirmed present in `dist/index.html:148` (Vite inlines the `<style>` block rather than extracting it)
- ⚠️ **Not yet verified on a real device.** CSS-only change with no test coverage — needs a real mobile Chrome check: Filter tab → tap the route box → confirm no zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)