### PR TITLE
perf: compress API responses at the origin (egress was 86% of the bill)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "london-live-2d-backend",
       "version": "0.1.0",
       "dependencies": {
+        "@fastify/compress": "^9.1.0",
         "@fastify/cors": "^11.0.1",
         "@fastify/static": "^10.1.2",
         "fastify": "^5.3.2"
@@ -500,6 +501,29 @@
         "fast-uri": "^3.0.0"
       }
     },
+    "node_modules/@fastify/compress": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/@fastify/compress/-/compress-9.1.0.tgz",
+      "integrity": "sha512-b/rc+dHqDIDyl/KIaGzjT3l5CXmWIjEGJh2qZHyOwtVNX4htHqmnLbsUO8zz8E0n/S1cu7EVmQexBit+EUFumw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/accept-negotiator": "^2.0.0",
+        "fastify-plugin": "^6.0.0",
+        "mime-db": "^1.52.0",
+        "minipass": "^7.0.4",
+        "readable-stream": "^4.5.2"
+      }
+    },
     "node_modules/@fastify/cors": {
       "version": "11.3.0",
       "resolved": "https://registry.npmmirror.com/@fastify/cors/-/cors-11.3.0.tgz",
@@ -683,6 +707,18 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/abstract-logging/-/abstract-logging-2.0.1.tgz",
@@ -760,6 +796,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.8",
       "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.8.tgz",
@@ -770,6 +826,30 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/content-disposition": {
@@ -863,6 +943,24 @@
       "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "license": "MIT"
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmmirror.com/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
@@ -1065,6 +1163,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
@@ -1163,6 +1281,15 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.5.tgz",
@@ -1249,6 +1376,15 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmmirror.com/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmmirror.com/process-warning/-/process-warning-5.0.0.tgz",
@@ -1270,6 +1406,22 @@
       "resolved": "https://registry.npmmirror.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -1312,6 +1464,26 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmmirror.com/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/safe-regex2": {
@@ -1410,6 +1582,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/thread-stream": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fastify/compress": "^9.1.0",
     "@fastify/cors": "^11.0.1",
     "@fastify/static": "^10.1.2",
     "fastify": "^5.3.2"

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { constants as zlibConstants } from 'node:zlib';
+import compress from '@fastify/compress';
 import cors from '@fastify/cors';
 import fastifyStatic from '@fastify/static';
 import Fastify, { type FastifyInstance } from 'fastify';
@@ -50,6 +52,25 @@ const SCRIPTS_DIR = join(REPO_ROOT, 'scripts');
 /** Builds the Fastify app with all plugins and routes; exported for tests (inject()). */
 export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
   const app = Fastify({ logger: true });
+
+  // Registered first so it covers every route AND the static roots. Railway
+  // bills egress by the byte and these payloads are pure JSON: /api/arrivals is
+  // ~7.4 MB raw vs ~300 KB gzipped (24x), /api/buses ~840 KB raw. Cloudflare
+  // already compresses CDN→browser, so this buys nothing for the user — it is
+  // purely the origin→CDN leg, which was 86% of the bill while uncompressed.
+  //
+  // Brotli quality 4 rather than zlib's default 11: q11 burns seconds of CPU on
+  // a multi-MB body, and this re-runs on every cache miss. Measured on a 4.97 MB
+  // /api/arrivals body — br q4: 154 KB in 15 ms, gzip: 210 KB in 22 ms — so q4
+  // is both smaller and faster than gzip here; the CPU worry only applies to q11.
+  // Only mime-db "compressible" types are touched, so the pmtiles basemap
+  // (application/octet-stream, already compressed internally and served by range
+  // request) is left alone.
+  const BROTLI_QUALITY = 4;
+  await app.register(compress, {
+    encodings: ['br', 'gzip', 'deflate'],
+    brotliOptions: { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY } },
+  });
 
   // CORS_ORIGIN may be a single origin or a comma-separated list.
   const corsOrigins = config.corsOrigin


### PR DESCRIPTION
## Why

The Railway bill breakdown for the Jul 24 – Aug 24 cycle:

| Item | Cost | Share |
|---|---|---|
| **Egress (103.01 GB)** | **\$5.1506** | **86.6%** |
| Memory | \$0.6586 | 11.1% |
| CPU | \$0.1229 | 2.1% |
| Volume | \$0.0222 | 0.4% |

Egress dominates, and the backend had **no compression at all** — no
`@fastify/compress` dependency, no compression code anywhere in `backend/src/`.
Every API response left Railway as raw JSON.

Cloudflare compresses on the CDN→browser leg, but that leg is free. The billed
leg is origin→CDN, and it was carrying full-size payloads.

The 5 s Cloudflare edge TTL added earlier can't help here: the frontend polls
`/api/arrivals` every 10 s, so at low concurrency every poll arrives after the
cache entry has already expired. **Payload size, not request count, was the
lever that mattered.**

## What

Registers `@fastify/compress` first in `buildApp`, so it covers every route and
both static roots.

## Measured (local, against the live upstream feeds)

| Endpoint | identity | gzip | br |
|---|---|---|---|
| `/api/arrivals` | 4,972,876 B | 209,836 B (**23.7×**) | 153,802 B (**32.3×**) |
| `/api/buses` | 840,828 B | 137,704 B (6.1×) | 130,640 B (6.4×) |

## Why brotli quality 4, not the default 11

zlib's default brotli quality is 11, which spends seconds of CPU on a multi-MB
body — and this re-runs on every cache miss. At q4 brotli measured **both
smaller and faster than gzip**:

| encoding | size | time (5 requests) |
|---|---|---|
| identity | 4.97 MB | 8–9 ms |
| gzip | 210 KB | 22 ms |
| **br q4** | **154 KB** | **15 ms** |

So there is no CPU/size tradeoff at this setting — the usual "brotli is
expensive" caution applies to q11, not q4. Added overhead is ~6–13 ms per
response.

## Projected effect

At the 5 s edge TTL with sustained traffic, origin fetches are a constant
12/min regardless of visitor count:

| | egress/day | \$/day | \$/month |
|---|---|---|---|
| before | 128 GB | \$6.41 | **\$192** |
| after (gzip) | 5.2 GB | \$0.26 | **\$7.8** |

This is what keeps the \$15 hard limit from tripping within days of any
promotion traffic.

## Safety

- Only mime-db "compressible" content types are compressed, so the pmtiles
  basemap (`application/octet-stream`, already internally compressed and served
  by range request) is untouched.
- Content negotiation is by `Accept-Encoding`; clients that don't advertise
  support get identity as before.
- **No frontend change needed** — `fetch()` decompresses transparently.

## Test plan

- [x] `npm run typecheck` clean
- [x] Server boots with real BODS/TfL/AIS feeds (6,121 vehicles polled)
- [x] All three encodings verified end-to-end on `/api/arrivals` and `/api/buses`
- [x] Latency measured per encoding
- [ ] Verify `content-encoding` on production after deploy
- [ ] Confirm the egress line drops in the next Railway billing snapshot