### PR TITLE
feat: 1-D arc-length Kalman filter for snapped buses

### DIFF
--- a/docs/BUS_KALMAN.md
+++ b/docs/BUS_KALMAN.md
@@ -1,0 +1,169 @@
+# Bus arc-length Kalman filter
+
+Why the bus motion model was changed (2026-07-31), how the filter works, and
+what every parameter means. Code: `frontend/src/realtime/bus-kalman.ts`
+(filter + arc-length geometry, pure functions, unit-tested) and
+`frontend/src/layers/buses.ts` (integration).
+
+## Why
+
+The previous motion model derived a velocity from the **last two distinct
+fixes** and dead-reckoned along it in a straight lat/lon line. Two observed
+failure modes, both rooted in trusting every fix 100%:
+
+1. **One drifted fix hijacks the motion.** BODS fixes carry urban-canyon GPS
+   drift (verified on the ground: some spots drift tens of meters,
+   consistently). A single bad fix in the two-fix pair corrupts both speed and
+   heading for the whole 45 s extrapolation window.
+2. **Straight-line extrapolation overshoots corners.** Fixes arrive ~80 s
+   apart per bus and 10–30 s stale; between them the bus flew off-street at
+   every bend (user report from a signal-processing researcher, 2026-07-30 —
+   "buses moving orthogonal to the streets").
+
+Both are addressed by filtering **along the learned route polyline**:
+
+- Projecting each fix onto the polyline **discards the lateral drift
+  component entirely** — the filter only has to manage along-route noise.
+  (This matters because the observed drift is *biased*, not zero-mean; no
+  filter can remove bias, but projection can throw its lateral part away.)
+- Between fixes the bus advances **along the polyline arc**, so it follows
+  corners by construction.
+- Each fix is folded in weighted by uncertainty (the Kalman gain), so a
+  suspect fix **nudges** the estimate instead of owning it, and the speed
+  estimate becomes a filtered state rather than a fragile two-fix difference.
+
+## What deliberately did NOT change
+
+- **The raw motion model is untouched and keeps running for every bus.** It
+  still decides snap engagement/release (hysteresis on the raw eased position,
+  SNAP_ON_M 50 / SNAP_OFF_M 80), seeds the filter, and renders the ~0.2% of
+  buses without a learned route exactly as before. The filter never votes on
+  its own engagement — that would let a confidently-wrong filter keep itself
+  alive.
+- **No uncertainty visualisation.** The filter's position variance could
+  drive icon opacity ("less sure = more transparent"); this was explicitly
+  deferred — a different presentation is planned for a future version.
+- **The learning pipeline is untouched.** It already stored
+  `quality.meanResidualM` in every learned-route JSON; the filter merely
+  starts reading it. Traces fed to the learner remain raw BODS fixes — the
+  filter is display-only and can never contaminate training data.
+- **Backend: zero changes.**
+
+## How it works
+
+State per snapped bus — 5 floats: arc length `s` (m), signed line speed `v`
+(m/s), covariance `pS, pV, pSV`. State time is the **fix timestamp** (BODS
+RecordedAtTime), never wall clock, mirroring how the raw model extrapolates
+from RecordedAtTime.
+
+```
+poll ingest (new fix)                      render tick (≤15 Hz)
+────────────────────                       ────────────────────
+project fix → arc length z                 target = s + v·(now − t)   [cap 45 s]
+PREDICT state to fix time:                 ease kfDispS toward target (τ 2.5 s)
+  s += v·dt;  P grows by Q(dt)             pointAtArclen(kfDispS) → x, y, tangent
+GATE:  |z − s| > 3σ → reject               → snapX / snapY / snapBearing
+UPDATE: K = pS/(pS+R)
+  s += K·(z−s);  v += Kv·(z−s);  P shrinks
+```
+
+Design choices worth knowing when debugging:
+
+- **Covariance math runs only per fix** (~110 updates/s fleet-wide), not per
+  tick. The per-tick path is one extrapolation + one eased scalar + an O(1)
+  amortised segment walk — cheaper than the trig the raw model already does.
+- **Prediction disambiguates projection.** The measurement projection
+  searches a local window around the filter's current segment first, so
+  self-overlapping routes (terminal loops) resolve to the branch the filter
+  expects instead of whichever is nearest.
+- **`v` is signed** and clamped to ±20 m/s. Learned polylines are usually
+  oriented along travel, but a reversed one must track as negative `v` —
+  clamping at zero would freeze those buses. Icon heading reuses the existing
+  half-plane correction against the motion-derived bearing.
+- **Gating vs reset.** A fix beyond 3σ is rejected (state advances by
+  prediction only). Three *consecutive* rejections mean the disagreement is
+  real (vehicle reassigned, GPS recovered from a cold start) — the filter
+  re-seeds at the fix, with speed from the raw two-fix model (whose fix pair
+  is post-relocation by then; the filter's own speed is exactly the estimate
+  that got rejected). One glitch can't reset it; a real relocation converges
+  in ≤3 fixes.
+- **Graceful degradation.** If the filter can't seed (the fix projects
+  off-route while the eased position is on it — rare and transient), the
+  snapped pose falls back to the pre-filter behaviour: projection of the
+  eased position. Failed seeds are memoized on the fix timestamp — the
+  full-polyline seed scan reruns only when a new fix arrives, keeping the
+  per-tick path O(1). Unsnap always nulls the filter; re-snap re-seeds it.
+
+## Parameters
+
+All in `bus-kalman.ts`, each with the derivation in a comment:
+
+| Parameter | Value | Why this value |
+|---|---|---|
+| `KF_PROCESS_NOISE_M2_S3` (q) | 0.2 m²/s³ | Continuous white-noise-acceleration model. Calibrated so a typical 80 s fix gap admits σ_v = √(q·80) ≈ 4 m/s of speed change — a bus caught by / released from a red light. Raise to trust fixes more, lower to trust motion more. |
+| `KF_GATE_SIGMA` | 3 | Standard 3σ innovation gate (~99.7% of honest fixes pass). The gate widens with elapsed time automatically — measured on a settled filter (R = 15²): half-width ≈ 140 m after a 20 s gap, ≈ 1.2 km after 120 s. Long gaps legitimately admit more, so only genuine teleports get gated. |
+| `KF_MAX_REJECTS` | 3 | Consecutive gated fixes before re-seeding. 1 would let a single glitch reset the filter; 3 costs ≤ ~4 min of frozen progress in the worst case while being robust to glitch pairs. |
+| `KF_INIT_SIGMA_S_M` | 30 m | Initial position σ — matches the learner's corridor start: a fresh snap knows the bus about this well. |
+| `KF_INIT_SIGMA_V_MS` | 3 m/s | Initial speed σ — the seed comes from the raw two-fix model, so keep healthy doubt. |
+| `KF_MEAS_SIGMA_FLOOR_M` | 8 m | Per-route σ floor: consumer GPS under open sky rarely beats this, however clean the learned residuals. |
+| `KF_DEFAULT_MEAS_SIGMA_M` | 44 m | Used when a route JSON has no usable `quality` field (older bakes may predate it). Equals the worst quality the learner's gate can ship: 35 m mean residual × 1.25 (MAD→σ) ≈ 44 — an unknown-quality route gets no more trust than the worst known one. |
+| `MAD_TO_SIGMA` | 1.25 | `meanResidualM` is a mean *absolute* deviation; for a zero-mean Gaussian σ = E\|x\|·√(π/2) ≈ 1.25·E\|x\|. |
+| `KF_MAX_SPEED_MS` | 20 m/s | Same ceiling the raw model uses (`MAX_IMPLIED_SPEED_MS`) — 72 km/h, generous for London buses. |
+
+**Measurement noise R is per-route, not global**: R = (max(8, 1.25 ×
+`quality.meanResidualM`))², read from the learned-route JSON the frontend
+already downloads. Central-London canyon routes get a large R (their fixes are
+trusted less); open suburban routes get a small one. This is the main reason
+the filter needed no new data: the learner had been measuring R all along.
+
+Reused display constants (unchanged values, same meaning in 1-D):
+`MAX_EXTRAPOLATION_S` 45 s (freeze-don't-run-away horizon), `EASE_TAU_S` 2.5 s
+(display easing), `SNAP_DISTANCE_M` 400 m (jump instead of glide),
+`MAX_CATCHUP_SPEED_MS` 120 m/s (glide cap).
+
+## Behaviour you should expect on the map
+
+- Buses on learned routes follow corners between fixes instead of cutting
+  them; heading comes from the polyline tangent.
+- A single teleporting fix visibly does ~nothing (gated); the bus keeps
+  rolling at its filtered speed.
+- After long gaps (>45 s) buses freeze rather than run away — same as before.
+- Buses without learned routes, and buses outside the snap corridor, behave
+  **exactly** as before this change.
+
+## Tuning guide (if the map looks wrong)
+
+| Symptom | Knob |
+|---|---|
+| Snapped buses lag behind reality | raise q (trust fixes more) |
+| Snapped buses jitter along the route | lower q, or check the route's `meanResidualM` is honest |
+| Buses stick when drivers genuinely divert | lower `KF_MAX_REJECTS` to 2 |
+| Occasional backwards jumps at terminal loops | widen the ingest projection window (`SNAP_LOCAL_WINDOW`) |
+
+## Testing
+
+`frontend/src/realtime/bus-kalman.test.ts` — 21 deterministic behavioural
+tests (no RNG): convergence on constant speed, stability under crafted noise,
+reversed-polyline (negative v) tracking, speed clamping, outlier gating,
+reject-counter reset, reset-after-persistent-disagreement, gate widening with
+fix gaps, out-of-order timestamps, covariance health (positive, Cauchy–Schwarz
+consistent) over a 200-step mixed run, extrapolation capping, signed
+tangent-speed seeding, and the arc-length geometry (cumulative lengths,
+interpolation, end clamping, hint walks).
+Run: `cd frontend && npx vitest run src/realtime/bus-kalman.test.ts`.
+
+Known coverage gap, accepted deliberately: the buses.ts integration glue
+(snap-state transitions, seed memoization, the reset re-seed call site) lives
+in closures inside `startBuses(map)` and has no test seam — extracting it
+would mean refactoring the layer's structure for testability alone. The glue
+is thin (every branch delegates to a tested pure function) and is exercised
+visually on the live map; revisit if it grows real branching.
+
+## Future work (explicitly out of scope here)
+
+- Uncertainty-driven presentation (deferred by design — see above).
+- MLAT aircraft (the only other layer where a filter would pay: multilaterated
+  positions jitter by hundreds of meters). Ships/ADS-B aircraft carry accurate
+  positions + velocities, so a filter's gain would sit at ≈1 — pointless; the
+  tube has no position measurements at all and its heuristic pipeline encodes
+  feed-specific pathologies a generic filter would smear over.

--- a/frontend/src/layers/buses.ts
+++ b/frontend/src/layers/buses.ts
@@ -12,11 +12,17 @@
 // short capped drift — is what keeps buses visibly moving between 15 s polls.
 // Route snapping: learned route polylines (backend learner, keyed by
 // operator:line:direction) are lazy-loaded from /api/bus-routes-index +
-// /bus-routes/learned/<key>.json. A bus with a learned route renders at its
-// projection onto the polyline while the raw eased position stays within
-// SNAP_ON_M (released past SNAP_OFF_M — hysteresis, per-bus state), and its
-// icon follows the polyline tangent. The raw motion model is untouched —
-// snapping is a pure display transform; buses without routes render as before.
+// /bus-routes/learned/<key>.json. Snap engagement is hysteresis on the RAW
+// eased position (within SNAP_ON_M, released past SNAP_OFF_M — per-bus state);
+// while snapped, the displayed pose comes from a 1-D Kalman filter running in
+// arc-length space along the polyline (realtime/bus-kalman.ts): fixes are
+// projected to an arc length and folded in weighted by per-route measurement
+// noise (quality.meanResidualM baked by the learner), so one drifted fix can
+// no longer hijack speed or heading, and between fixes the bus advances ALONG
+// the route instead of straight-line overshooting corners. The raw motion
+// model is untouched and keeps running — it still decides snap on/off, seeds
+// the filter, and renders every bus without a learned route exactly as
+// before. Full design + parameters: docs/BUS_KALMAN.md.
 // Parked indicator: each tracker keeps lastMovedAt, refreshed whenever the bus
 // drifts > 60 m from its movement anchor; > 20 min without that (lenient — a
 // worst-case jam stays red) flags parked:1 and both tiers recolor the bus
@@ -32,6 +38,17 @@ import {
 } from 'maplibre-gl';
 import { isLayerShown, makeRenderGate } from '../util/render-gate';
 import { registerPoll, symbolTierIntervalMs } from '../util/lifecycle';
+import {
+  type ArcPoint,
+  type BusKfState,
+  cumulativeLengthsM,
+  kfInit,
+  kfStep,
+  kfTargetS,
+  measurementVariance,
+  pointAtArclen,
+  tangentSpeedMs,
+} from '../realtime/bus-kalman';
 import { appendRankLine } from '../ui/rank-line';
 import { enablePopupDragToPan, isPopupTextInteracting } from '../ui/popup-drag';
 
@@ -155,6 +172,10 @@ interface BusWire {
 interface LearnedRoute {
   xs: Float64Array;
   ys: Float64Array;
+  /** Cumulative arc length at each vertex, m — the filter's 1-D coordinate. */
+  cum: Float64Array;
+  /** Kalman measurement variance R, m² — from the learner's meanResidualM. */
+  measVar: number;
 }
 
 interface RouteProjection {
@@ -212,6 +233,16 @@ interface BusTracker {
   snapX: number;
   snapY: number;
   snapBearing: number;
+  /** Arc-length Kalman filter — non-null only while snapped with a fix that
+   * projects onto the route (docs/BUS_KALMAN.md). */
+  kf: BusKfState | null;
+  /** Eased displayed arc length, m — the 1-D analogue of `disp`. */
+  kfDispS: number;
+  /** Segment the display last landed on — pointAtArclen walk hint. */
+  kfSeg: number;
+  /** lastFix.t of a failed seed attempt — initFilter's full-polyline scan is
+   * pointless until a NEW fix arrives, so don't repeat it per tick. */
+  kfSeedFixT: number;
 }
 
 const esc = (s: string): string =>
@@ -355,16 +386,31 @@ function requestRoute(fileKey: string): void {
     try {
       const res = await fetch(`/bus-routes/learned/${fileKey}.json`);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const body = (await res.json()) as { poly?: [number, number][] };
+      const body = (await res.json()) as {
+        poly?: [number, number][];
+        quality?: { meanResidualM?: number };
+      };
       const poly = body.poly;
       if (!Array.isArray(poly) || poly.length < 2) throw new Error('bad poly');
       const xs = new Float64Array(poly.length);
       const ys = new Float64Array(poly.length);
       for (let i = 0; i < poly.length; i += 1) {
-        xs[i] = poly[i][0] * M_PER_DEG_LON;
-        ys[i] = poly[i][1] * M_PER_DEG_LAT;
+        const lon = poly[i][0];
+        const lat = poly[i][1];
+        // Reject the whole route on one bad vertex: a single NaN would poison
+        // the cumulative arc-length sum from that vertex on, and NaN defeats
+        // the filter's gate comparisons (every NaN compare is false) — far
+        // worse than simply rendering this route's buses unsnapped.
+        if (!Number.isFinite(lon) || !Number.isFinite(lat)) throw new Error('bad vertex');
+        xs[i] = lon * M_PER_DEG_LON;
+        ys[i] = lat * M_PER_DEG_LAT;
       }
-      routeCache.set(fileKey, { xs, ys });
+      routeCache.set(fileKey, {
+        xs,
+        ys,
+        cum: cumulativeLengthsM(xs, ys),
+        measVar: measurementVariance(body.quality?.meanResidualM),
+      });
     } catch {
       routeCache.set(fileKey, 'absent');
     }
@@ -399,6 +445,11 @@ function projectRange(
     }
   }
   return best;
+}
+
+/** Arc length (m) of a projection: vertex cumulative + distance along its segment. */
+function arclenAt(route: LearnedRoute, proj: RouteProjection): number {
+  return route.cum[proj.seg] + Math.hypot(proj.x - route.xs[proj.seg], proj.y - route.ys[proj.seg]);
 }
 
 /** Velocity along reported bearing at the fallback speed; zero when no bearing. */
@@ -560,6 +611,10 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
         snapX: 0,
         snapY: 0,
         snapBearing: 0,
+        kf: null,
+        kfDispS: 0,
+        kfSeg: 0,
+        kfSeedFixT: 0,
       });
       return;
     }
@@ -574,6 +629,8 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
       existing.route = null;
       existing.snapped = false;
       existing.snapSeg = -1;
+      existing.kf = null; // the filter's s-space died with the old polyline
+      existing.kfSeedFixT = 0; // new polyline: the same fix may now seed fine
     }
     if (bus.t !== existing.lastFix.t) {
       existing.prevFix = existing.lastFix;
@@ -587,6 +644,43 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
         existing.lastMovedAt = now;
         existing.moveRef.x = bus.x;
         existing.moveRef.y = bus.y;
+      }
+      // Kalman measurement update: project the new fix (not the eased display)
+      // onto the route and fold its arc length into the filter. Off-route
+      // fixes are simply not folded in — if the bus is genuinely leaving the
+      // route, the raw-position hysteresis releases the snap shortly after.
+      const route = existing.route;
+      if (existing.kf !== null && route !== null) {
+        const fx = bus.x * M_PER_DEG_LON;
+        const fy = bus.y * M_PER_DEG_LAT;
+        let proj = projectRange(
+          route,
+          fx,
+          fy,
+          existing.kfSeg - SNAP_LOCAL_WINDOW,
+          existing.kfSeg + SNAP_LOCAL_WINDOW,
+        );
+        if (proj === null || proj.dist > SNAP_OFF_M) {
+          proj = projectRange(route, fx, fy, 0, route.xs.length);
+        }
+        if (proj !== null && proj.dist <= SNAP_OFF_M) {
+          const zS = arclenAt(route, proj);
+          if (kfStep(existing.kf, zS, bus.t, route.measVar) === 'reset') {
+            // Persistent disagreement is a real relocation, not noise —
+            // re-seed at the fix. Speed comes from the RAW two-fix model
+            // (its fix pair is post-relocation by now, so it is fresh), NOT
+            // the filter's own v, which is the estimate that just produced
+            // the consecutive rejections.
+            const v0 = tangentSpeedMs(
+              route.xs,
+              route.ys,
+              proj.seg,
+              existing.velLon * M_PER_DEG_LON,
+              existing.velLat * M_PER_DEG_LAT,
+            );
+            existing.kf = kfInit(zS, v0, bus.t);
+          }
+        }
       }
     }
     // Without a track-derived velocity the reported Bearing is the best
@@ -629,7 +723,7 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
       tr.rotRef.x = tr.disp.x;
       tr.rotRef.y = tr.disp.y;
     }
-    updateSnap(tr, now);
+    updateSnap(tr, now, dtS);
   }
 
   /** Attach a learned route to the tracker once index + geometry are ready. */
@@ -643,16 +737,52 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
     if (cached !== 'pending' && cached !== 'absent') tr.route = cached;
   }
 
+  /** Scratch for pointAtArclen — per-tick path, keep it allocation-free. */
+  const arcScratch: ArcPoint = { x: 0, y: 0, seg: 0, bearing: 0 };
+
   /**
-   * Display-only route snapping with hysteresis: project the raw eased
-   * position onto the learned polyline (local window around the last hit,
-   * periodic full re-search), snap under SNAP_ON_M, release past SNAP_OFF_M.
+   * Seed the arc-length filter from the last real fix (state time = fix time,
+   * matching kfStep's time base — never the eased display position, which
+   * lags and would bake easing artefacts into the state).
    */
-  function updateSnap(tr: BusTracker, now: number): void {
+  function initFilter(tr: BusTracker, route: LearnedRoute, now: number): void {
+    const fx = tr.lastFix.x * M_PER_DEG_LON;
+    const fy = tr.lastFix.y * M_PER_DEG_LAT;
+    const proj = projectRange(route, fx, fy, 0, route.xs.length);
+    if (proj === null || proj.dist > SNAP_OFF_M) return; // fix off-route: stay legacy
+    const s0 = arclenAt(route, proj);
+    // Signed seed speed: the raw model's velocity projected onto the local
+    // tangent — negative when the polyline happens to oppose travel direction.
+    const v0 = tangentSpeedMs(
+      route.xs,
+      route.ys,
+      proj.seg,
+      tr.velLon * M_PER_DEG_LON,
+      tr.velLat * M_PER_DEG_LAT,
+    );
+    tr.kf = kfInit(s0, v0, tr.lastFix.t);
+    // Start the displayed arc length at the extrapolated target so a freshly
+    // snapped bus doesn't glide in — mirrors how ingest() seeds `disp`.
+    const total = route.cum[route.cum.length - 1];
+    tr.kfDispS = Math.max(0, Math.min(total, kfTargetS(tr.kf, now, MAX_EXTRAPOLATION_S)));
+    tr.kfSeg = proj.seg;
+  }
+
+  /**
+   * Display-only route snapping. Hysteresis is unchanged from the pre-filter
+   * design and still judged on the RAW eased position (local window around the
+   * last hit, periodic full re-search; snap under SNAP_ON_M, release past
+   * SNAP_OFF_M) — the filter never gets to vote on its own engagement.
+   * While snapped, the displayed pose comes from the arc-length Kalman filter:
+   * ease the displayed arc length toward the extrapolated state (same feel as
+   * the raw model's ease-toward-target), then resolve it to a point + tangent.
+   */
+  function updateSnap(tr: BusTracker, now: number, dtS: number): void {
     resolveRoute(tr);
     const route = tr.route;
     if (route === null) {
       tr.snapped = false;
+      tr.kf = null;
       return;
     }
     const px = tr.disp.x * M_PER_DEG_LON;
@@ -668,18 +798,51 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
     }
     if (proj === null) {
       tr.snapped = false;
+      tr.kf = null;
       return;
     }
     tr.snapSeg = proj.seg;
     if (!tr.snapped && proj.dist < SNAP_ON_M) tr.snapped = true;
     else if (tr.snapped && proj.dist > SNAP_OFF_M) tr.snapped = false;
-    if (!tr.snapped) return;
-    tr.snapX = proj.x / M_PER_DEG_LON;
-    tr.snapY = proj.y / M_PER_DEG_LAT;
+    if (!tr.snapped) {
+      tr.kf = null;
+      return;
+    }
+    // Seeding does a full-polyline scan of lastFix — memoize failures on the
+    // fix timestamp so the scan reruns only when a NEW fix could change it.
+    if (tr.kf === null && tr.lastFix.t !== tr.kfSeedFixT) {
+      initFilter(tr, route, now);
+      if (tr.kf === null) tr.kfSeedFixT = tr.lastFix.t;
+    }
+    const kf = tr.kf;
+    if (kf === null) {
+      // Filter couldn't seed (fix projects off-route while the eased position
+      // is on it — rare, transient): legacy behaviour, snap to the projection.
+      tr.snapX = proj.x / M_PER_DEG_LON;
+      tr.snapY = proj.y / M_PER_DEG_LAT;
+      const diff = Math.abs(((proj.bearing - tr.bearingDisp + 540) % 360) - 180);
+      tr.snapBearing = diff > 90 ? (proj.bearing + 180) % 360 : proj.bearing;
+      return;
+    }
+    const total = route.cum[route.cum.length - 1];
+    const target = Math.max(0, Math.min(total, kfTargetS(kf, now, MAX_EXTRAPOLATION_S)));
+    const gap = target - tr.kfDispS;
+    if (Math.abs(gap) > SNAP_DISTANCE_M) {
+      tr.kfDispS = target; // too far to glide — jump, like the raw model
+    } else {
+      const alpha = 1 - Math.exp(-dtS / EASE_TAU_S);
+      const step = gap * alpha;
+      const maxStep = MAX_CATCHUP_SPEED_MS * dtS;
+      tr.kfDispS += Math.abs(step) > maxStep ? Math.sign(gap) * maxStep : step;
+    }
+    pointAtArclen(route.xs, route.ys, route.cum, tr.kfDispS, tr.kfSeg, arcScratch);
+    tr.kfSeg = arcScratch.seg;
+    tr.snapX = arcScratch.x / M_PER_DEG_LON;
+    tr.snapY = arcScratch.y / M_PER_DEG_LAT;
     // The polyline tangent is bidirectional — keep the half-plane that agrees
     // with the motion-derived heading so buses never render nose-backwards.
-    const diff = Math.abs(((proj.bearing - tr.bearingDisp + 540) % 360) - 180);
-    tr.snapBearing = diff > 90 ? (proj.bearing + 180) % 360 : proj.bearing;
+    const diff = Math.abs(((arcScratch.bearing - tr.bearingDisp + 540) % 360) - 180);
+    tr.snapBearing = diff > 90 ? (arcScratch.bearing + 180) % 360 : arcScratch.bearing;
   }
 
   /** parked flag for feature properties: 1 after PARKED_AFTER_MS without movement. */

--- a/frontend/src/realtime/bus-kalman.test.ts
+++ b/frontend/src/realtime/bus-kalman.test.ts
@@ -1,0 +1,258 @@
+// Behavioural spec for the 1-D arc-length Kalman filter (bus-kalman.ts).
+// Scenarios use synthetic fix sequences with hand-crafted noise (no RNG — the
+// suite must be deterministic) and assert on convergence, gating, and the
+// covariance staying healthy. See docs/BUS_KALMAN.md for parameter derivations.
+
+import { describe, expect, test } from 'vitest';
+import {
+  KF_MAX_REJECTS,
+  KF_MAX_SPEED_MS,
+  KF_MEAS_SIGMA_FLOOR_M,
+  KF_DEFAULT_MEAS_SIGMA_M,
+  type BusKfState,
+  kfInit,
+  kfStep,
+  kfTargetS,
+  measurementVariance,
+  cumulativeLengthsM,
+  pointAtArclen,
+  tangentSpeedMs,
+  type ArcPoint,
+} from './bus-kalman';
+
+/** Typical measurement variance: a decent learned route (σ ≈ 15 m). */
+const R_TYPICAL = 15 * 15;
+
+/** Feed a run of noiseless constant-speed fixes; returns the final state. */
+function runConstantSpeed(
+  st: BusKfState,
+  vTrue: number,
+  dtS: number,
+  n: number,
+  noise: readonly number[] = [],
+  r = R_TYPICAL,
+): BusKfState {
+  let truth = st.s;
+  let t = st.t;
+  for (let i = 0; i < n; i += 1) {
+    truth += vTrue * dtS;
+    t += dtS * 1000;
+    kfStep(st, truth + (noise[i % Math.max(noise.length, 1)] ?? 0), t, r);
+  }
+  return st;
+}
+
+describe('measurementVariance', () => {
+  test('typical learned-route residual maps through the 1.25 MAD→σ factor', () => {
+    // σ = 1.25 × 12.3 ≈ 15.4 m — well above the floor, so the factor applies.
+    expect(measurementVariance(12.3)).toBeCloseTo((1.25 * 12.3) ** 2, 6);
+  });
+
+  test('very clean routes are clamped to the GPS noise floor', () => {
+    expect(measurementVariance(2)).toBeCloseTo(KF_MEAS_SIGMA_FLOOR_M ** 2, 6);
+  });
+
+  test('missing or invalid residual falls back to the conservative default', () => {
+    expect(measurementVariance(undefined)).toBeCloseTo(KF_DEFAULT_MEAS_SIGMA_M ** 2, 6);
+    expect(measurementVariance(Number.NaN)).toBeCloseTo(KF_DEFAULT_MEAS_SIGMA_M ** 2, 6);
+    expect(measurementVariance(-5)).toBeCloseTo(KF_DEFAULT_MEAS_SIGMA_M ** 2, 6);
+  });
+});
+
+describe('kfInit', () => {
+  test('seeds state and clamps an implausible initial speed', () => {
+    const st = kfInit(1000, 5, 1_700_000_000_000);
+    expect(st.s).toBe(1000);
+    expect(st.v).toBe(5);
+    expect(st.t).toBe(1_700_000_000_000);
+    expect(st.rejects).toBe(0);
+    expect(st.pS).toBeGreaterThan(0);
+    expect(st.pV).toBeGreaterThan(0);
+
+    // Raw-velocity seeds can be GPS-glitch garbage — init must clamp them.
+    expect(kfInit(0, 55, 0).v).toBe(KF_MAX_SPEED_MS);
+    expect(kfInit(0, -55, 0).v).toBe(-KF_MAX_SPEED_MS);
+  });
+});
+
+describe('kfStep — convergence', () => {
+  test('locks onto a constant-speed bus from noiseless fixes', () => {
+    const st = kfInit(0, 0, 0);
+    runConstantSpeed(st, 8, 20, 10);
+    expect(st.v).toBeCloseTo(8, 0.5);
+    // s is the position at the LAST fix time (200 s → truth 1600 m).
+    expect(Math.abs(st.s - 1600)).toBeLessThan(10);
+  });
+
+  test('keeps a stable speed estimate through ±15 m measurement noise', () => {
+    const st = kfInit(0, 8, 0);
+    // Zero-mean hand-crafted noise, σ ≈ 12 m.
+    runConstantSpeed(st, 8, 20, 16, [18, -12, 9, -15, 6, -10, 14, -7]);
+    expect(Math.abs(st.v - 8)).toBeLessThan(2);
+  });
+
+  test('tracks a reversed polyline (negative arc-length velocity)', () => {
+    const st = kfInit(5000, 0, 0);
+    runConstantSpeed(st, -8, 20, 10);
+    expect(st.v).toBeLessThan(-6);
+  });
+
+  test('never exceeds the speed clamp even under persistent fast fixes', () => {
+    const st = kfInit(0, 18, 0);
+    // Fixes implying 22 m/s arrive close together (small dt keeps them in-gate).
+    let truth = 0;
+    let t = 0;
+    for (let i = 0; i < 30; i += 1) {
+      truth += 22 * 10;
+      t += 10_000;
+      kfStep(st, truth, t, R_TYPICAL);
+      expect(st.v).toBeLessThanOrEqual(KF_MAX_SPEED_MS);
+    }
+  });
+});
+
+describe('kfStep — gating', () => {
+  /** A filter that has settled on 8 m/s with fixes every 20 s. */
+  function settled(): BusKfState {
+    const st = kfInit(0, 8, 0);
+    return runConstantSpeed(st, 8, 20, 8);
+  }
+
+  test('a teleporting fix is rejected and barely moves the state', () => {
+    const st = settled();
+    const sBefore = st.s;
+    const vBefore = st.v;
+    // Next fix 20 s later but 400 m off the prediction — a GPS glitch.
+    const result = kfStep(st, sBefore + 8 * 20 + 400, st.t + 20_000, R_TYPICAL);
+    expect(result).toBe('gated');
+    expect(st.rejects).toBe(1);
+    // State advanced by prediction only (≈ v·dt), not toward the outlier.
+    expect(Math.abs(st.s - (sBefore + 8 * 20))).toBeLessThan(1);
+    expect(st.v).toBeCloseTo(vBefore, 5);
+  });
+
+  test('an accepted fix resets the consecutive-reject counter', () => {
+    const st = settled();
+    kfStep(st, st.s + 8 * 20 + 400, st.t + 20_000, R_TYPICAL); // gated
+    const good = st.s + 8 * 20; // plausible follow-up
+    expect(kfStep(st, good, st.t + 20_000, R_TYPICAL)).toBe('accepted');
+    expect(st.rejects).toBe(0);
+  });
+
+  test('persistent disagreement asks for a reset after KF_MAX_REJECTS', () => {
+    const st = settled();
+    const results: string[] = [];
+    for (let i = 1; i <= KF_MAX_REJECTS; i += 1) {
+      // Fixes consistently ~500 m ahead — the bus genuinely is elsewhere.
+      results.push(kfStep(st, st.s + 8 * 20 + 500, st.t + 20_000, R_TYPICAL));
+    }
+    expect(results.slice(0, -1).every((r) => r === 'gated')).toBe(true);
+    expect(results[results.length - 1]).toBe('reset');
+  });
+
+  test('the gate widens with the fix gap — honest 2-minute gaps are not rejected', () => {
+    const st = settled();
+    // 120 s silent, then a fix 150 m off the constant-speed prediction: within
+    // what a bus stuck at / released from a light can plausibly do.
+    const z = st.s + 8 * 120 - 150;
+    expect(kfStep(st, z, st.t + 120_000, R_TYPICAL)).toBe('accepted');
+  });
+});
+
+describe('kfStep — robustness', () => {
+  test('out-of-order fix timestamps do not crash or rewind time', () => {
+    const st = kfInit(1000, 8, 100_000);
+    const tBefore = st.t;
+    expect(() => kfStep(st, 995, 90_000, R_TYPICAL)).not.toThrow();
+    expect(st.t).toBeGreaterThanOrEqual(tBefore);
+    expect(Number.isFinite(st.s)).toBe(true);
+  });
+
+  test('covariance stays positive and consistent over a long mixed run', () => {
+    const st = kfInit(0, 0, 0);
+    const noise = [22, -19, 8, -3, 31, -27, 12, 0, -14, 6];
+    let truth = 0;
+    let t = 0;
+    for (let i = 0; i < 200; i += 1) {
+      const dt = i % 7 === 0 ? 95 : 18; // occasional long gaps
+      truth += 7 * dt;
+      t += dt * 1000;
+      kfStep(st, truth + (noise[i % noise.length] ?? 0), t, R_TYPICAL);
+      expect(st.pS).toBeGreaterThan(0);
+      expect(st.pV).toBeGreaterThan(0);
+      // Cauchy–Schwarz: the cross term can never exceed the marginals.
+      expect(st.pSV * st.pSV).toBeLessThanOrEqual(st.pS * st.pV * (1 + 1e-9));
+    }
+  });
+});
+
+describe('kfTargetS', () => {
+  test('extrapolates from the last fix time and caps at the horizon', () => {
+    const st = kfInit(1000, 10, 0);
+    expect(kfTargetS(st, 20_000, 45)).toBeCloseTo(1200, 6);
+    // 100 s stale but horizon 45 s — freeze at the cap, like the raw model.
+    expect(kfTargetS(st, 100_000, 45)).toBeCloseTo(1450, 6);
+    // Clock skew / same-ms render: never extrapolate backwards.
+    expect(kfTargetS(st, -5_000, 45)).toBeCloseTo(1000, 6);
+  });
+});
+
+describe('arc-length geometry', () => {
+  // L-shaped test line: 300 m east, then 400 m north (total 700 m).
+  const xs = new Float64Array([0, 300, 300]);
+  const ys = new Float64Array([0, 0, 400]);
+  const cum = cumulativeLengthsM(xs, ys);
+
+  test('cumulativeLengthsM accumulates per-vertex arc length', () => {
+    expect([...cum]).toEqual([0, 300, 700]);
+  });
+
+  const at = (s: number, hint = 0): ArcPoint => {
+    const out: ArcPoint = { x: 0, y: 0, seg: 0, bearing: 0 };
+    pointAtArclen(xs, ys, cum, s, hint, out);
+    return out;
+  };
+
+  test('interpolates mid-segment with the segment tangent as bearing', () => {
+    const p = at(150);
+    expect(p.x).toBeCloseTo(150, 6);
+    expect(p.y).toBeCloseTo(0, 6);
+    expect(p.seg).toBe(0);
+    expect(p.bearing).toBeCloseTo(90, 6); // due east
+
+    const q = at(500);
+    expect(q.x).toBeCloseTo(300, 6);
+    expect(q.y).toBeCloseTo(200, 6);
+    expect(q.seg).toBe(1);
+    expect(q.bearing).toBeCloseTo(0, 6); // due north
+  });
+
+  test('clamps beyond both ends of the polyline', () => {
+    const start = at(-50);
+    expect(start.x).toBeCloseTo(0, 6);
+    expect(start.y).toBeCloseTo(0, 6);
+    const end = at(9999);
+    expect(end.x).toBeCloseTo(300, 6);
+    expect(end.y).toBeCloseTo(400, 6);
+  });
+
+  test('walks to the right segment from a stale hint in either direction', () => {
+    expect(at(500, 0).seg).toBe(1); // hint behind → walks forward
+    expect(at(100, 1).seg).toBe(0); // hint ahead → walks back
+  });
+
+  test('tangentSpeedMs signs the seed speed by travel direction', () => {
+    // Segment 0 points due east: eastward velocity is positive s-direction…
+    expect(tangentSpeedMs(xs, ys, 0, 7, 0)).toBeCloseTo(7, 6);
+    // …westward is negative (reversed polyline / bus reversing at a stand)…
+    expect(tangentSpeedMs(xs, ys, 0, -7, 0)).toBeCloseTo(-7, 6);
+    // …and perpendicular motion contributes nothing along the route.
+    expect(tangentSpeedMs(xs, ys, 0, 0, 5)).toBeCloseTo(0, 6);
+  });
+
+  test('tangentSpeedMs returns 0 on a degenerate zero-length segment', () => {
+    const dxs = new Float64Array([10, 10]);
+    const dys = new Float64Array([20, 20]);
+    expect(tangentSpeedMs(dxs, dys, 0, 9, 9)).toBe(0);
+  });
+});

--- a/frontend/src/realtime/bus-kalman.ts
+++ b/frontend/src/realtime/bus-kalman.ts
@@ -1,0 +1,225 @@
+// 1-D Kalman filter along a learned bus-route polyline, plus the arc-length
+// geometry it needs. Consumed by layers/buses.ts for snapped buses only; buses
+// without a learned route keep the straight-line dead-reckoning model.
+//
+// Why a filter at all: BODS fixes are sparse (~80 s per bus) and carry urban
+// GPS drift, and the previous model derived velocity from the last two fixes —
+// one drifted fix could fully hijack speed AND heading for the whole
+// extrapolation window. The filter weights every fix by uncertainty instead,
+// so a suspect fix nudges the estimate rather than owning it.
+//
+// Why 1-D: the learned polyline (backend learner, quality-gated at
+// mean residual ≤ 35 m) already answers "where can this bus be" — projecting
+// each fix onto it discards the lateral drift component entirely, and the
+// filter then only has to manage along-route noise. State is (s, v): arc
+// length in meters and signed line speed in m/s. All covariance math is
+// scalar — no matrix library, ~5 floats per bus.
+//
+// Time base: state time `t` is the FIX timestamp (BODS RecordedAtTime), never
+// wall clock — fixes arrive 10-30 s stale and display code extrapolates the
+// state forward to `now` (kfTargetS), exactly like the raw model extrapolates
+// from RecordedAtTime. Full design + parameter derivations: docs/BUS_KALMAN.md.
+
+/**
+ * Process noise spectral density q, m²/s³ (continuous white-noise acceleration
+ * model). Calibrated so that after a typical 80 s fix gap the filter admits
+ * σ_v ≈ √(q·80) ≈ 4 m/s of speed change — a bus caught by a red light or
+ * released from a stop. Larger q = trust fixes more; smaller = trust motion.
+ */
+export const KF_PROCESS_NOISE_M2_S3 = 0.2;
+/** Innovation gate, in σ of the innovation variance: reject beyond 3σ (~99.7%). */
+export const KF_GATE_SIGMA = 3;
+/** Consecutive gated fixes before the caller should re-seed the filter — the
+ * bus genuinely IS elsewhere (rerouted / GPS recovered), not glitching. */
+export const KF_MAX_REJECTS = 3;
+/** Initial position σ, m — matches the learner's corridor start (30 m): a
+ * fresh snap knows the bus roughly this well. */
+export const KF_INIT_SIGMA_S_M = 30;
+/** Initial speed σ, m/s — the raw-model seed is a two-fix difference, so keep
+ * healthy doubt about it. */
+export const KF_INIT_SIGMA_V_MS = 3;
+/** Per-route measurement σ floor, m — consumer GPS under open sky rarely does
+ * better, however clean the learned residuals look. */
+export const KF_MEAS_SIGMA_FLOOR_M = 8;
+/** Measurement σ when the route JSON carries no usable quality field, m —
+ * the worst residual the learner's gate ships is 35 m, i.e. σ = 1.25·35 ≈ 44:
+ * an unknown-quality route gets no more trust than the worst known one. */
+export const KF_DEFAULT_MEAS_SIGMA_M = 44;
+/** |v| clamp, m/s — same ceiling the raw model uses (MAX_IMPLIED_SPEED_MS).
+ * Signed: learned polylines are usually oriented along travel, but a reversed
+ * one must track as negative v, not freeze at zero. */
+export const KF_MAX_SPEED_MS = 20;
+/** Mean-absolute-deviation → σ for a zero-mean Gaussian: σ = E|x|·√(π/2) ≈
+ * 1.25·E|x|. The learner's meanResidualM is a MAD, not a σ. */
+const MAD_TO_SIGMA = 1.25;
+
+/** Filter state for one snapped bus. Mutated in place by kfStep — these live
+ * in per-bus trackers updated from poll ingest (~110 updates/s fleet-wide). */
+export interface BusKfState {
+  /** Arc length along the learned polyline at time t, m. */
+  s: number;
+  /** Signed line speed, m/s (negative = travelling toward decreasing s). */
+  v: number;
+  /** Covariance: var(s), var(v), cov(s,v). */
+  pS: number;
+  pV: number;
+  pSV: number;
+  /** Timestamp of the state estimate — the last processed fix, epoch ms. */
+  t: number;
+  /** Consecutive gated (rejected) fixes; kfStep asks for a reset at the cap. */
+  rejects: number;
+}
+
+export type KfStepResult = 'accepted' | 'gated' | 'reset';
+
+/** Point on a polyline resolved from an arc length — reused per call site to
+ * keep the per-tick display path allocation-free. */
+export interface ArcPoint {
+  x: number; // meters
+  y: number; // meters
+  seg: number;
+  /** Polyline tangent at the point, degrees clockwise from north, oriented
+   * along increasing s. Callers half-plane-correct against the bus heading. */
+  bearing: number;
+}
+
+/** Fresh filter state from a projected fix (s0, m), a seed speed (v0, m/s —
+ * clamped, it comes from the raw two-fix model) and the fix timestamp. */
+export function kfInit(s0: number, v0: number, tMs: number): BusKfState {
+  return {
+    s: s0,
+    v: Math.max(-KF_MAX_SPEED_MS, Math.min(KF_MAX_SPEED_MS, v0)),
+    pS: KF_INIT_SIGMA_S_M * KF_INIT_SIGMA_S_M,
+    pV: KF_INIT_SIGMA_V_MS * KF_INIT_SIGMA_V_MS,
+    pSV: 0,
+    t: tMs,
+    rejects: 0,
+  };
+}
+
+/**
+ * Measurement variance R (m²) for a learned route, from the learner's stored
+ * mean residual. Uses the MAD→σ factor, floored at consumer-GPS noise;
+ * missing/invalid quality falls back to a conservative default.
+ */
+export function measurementVariance(meanResidualM: number | undefined): number {
+  const sigma =
+    meanResidualM !== undefined && Number.isFinite(meanResidualM) && meanResidualM >= 0
+      ? Math.max(KF_MEAS_SIGMA_FLOOR_M, MAD_TO_SIGMA * meanResidualM)
+      : KF_DEFAULT_MEAS_SIGMA_M;
+  return sigma * sigma;
+}
+
+/**
+ * Fold one projected fix (arc length zS at fix time zTMs) into the state:
+ * predict to the fix time, gate the innovation at KF_GATE_SIGMA, and correct
+ * (s, v) by the Kalman gain. Mutates `st` in place.
+ *
+ * Returns 'accepted' (normal), 'gated' (fix rejected as an outlier — state
+ * advanced by prediction only), or 'reset' (KF_MAX_REJECTS consecutive gated
+ * fixes: stop filtering and re-seed from this fix — the disagreement is real).
+ */
+export function kfStep(st: BusKfState, zS: number, zTMs: number, rVar: number): KfStepResult {
+  // Out-of-order fixes (BODS occasionally rewinds RecordedAtTime): treat as
+  // same-time — never step time backwards, the gate still judges the value.
+  const dt = Math.max(0, (zTMs - st.t) / 1000);
+  const q = KF_PROCESS_NOISE_M2_S3;
+
+  // Predict to the fix time (constant-velocity model, continuous white-noise
+  // acceleration: Q = q·[[dt³/3, dt²/2], [dt²/2, dt]]).
+  st.s += st.v * dt;
+  st.pS += 2 * st.pSV * dt + st.pV * dt * dt + (q * dt * dt * dt) / 3;
+  st.pSV += st.pV * dt + (q * dt * dt) / 2;
+  st.pV += q * dt;
+  if (zTMs > st.t) st.t = zTMs;
+
+  // Gate: innovation beyond KF_GATE_SIGMA·σ is an outlier, not information.
+  const y = zS - st.s;
+  const S = st.pS + rVar;
+  if (y * y > KF_GATE_SIGMA * KF_GATE_SIGMA * S) {
+    st.rejects += 1;
+    return st.rejects >= KF_MAX_REJECTS ? 'reset' : 'gated';
+  }
+  st.rejects = 0;
+
+  // Correct. H = [1, 0] (we only measure position), so the gain is scalar.
+  const kS = st.pS / S;
+  const kV = st.pSV / S;
+  st.s += kS * y;
+  st.v = Math.max(-KF_MAX_SPEED_MS, Math.min(KF_MAX_SPEED_MS, st.v + kV * y));
+  // P ← (I − K·H)·P; pSV must be read before it is overwritten for pV.
+  const pSVold = st.pSV;
+  st.pS *= 1 - kS;
+  st.pSV *= 1 - kS;
+  st.pV -= kV * pSVold;
+  return 'accepted';
+}
+
+/**
+ * Display target: the state extrapolated from its fix time to `nowMs`, capped
+ * at `horizonS` — the same "freeze rather than run away" behaviour the raw
+ * model gets from MAX_EXTRAPOLATION_S. Clock skew never extrapolates backwards.
+ */
+export function kfTargetS(st: BusKfState, nowMs: number, horizonS: number): number {
+  const extraS = Math.min(Math.max((nowMs - st.t) / 1000, 0), horizonS);
+  return st.s + st.v * extraS;
+}
+
+/**
+ * Signed speed (m/s) of a meter-space velocity vector along segment `seg` of
+ * a polyline: the projection onto the local tangent, positive toward
+ * increasing arc length. Seeds the filter's v from the raw model's velocity —
+ * both on first snap and on reset re-seed, where the filter's own v must NOT
+ * be reused (it is exactly the estimate that just got rejected). Returns 0
+ * for a degenerate zero-length segment.
+ */
+export function tangentSpeedMs(
+  xs: Float64Array,
+  ys: Float64Array,
+  seg: number,
+  vxMs: number,
+  vyMs: number,
+): number {
+  const dx = xs[seg + 1] - xs[seg];
+  const dy = ys[seg + 1] - ys[seg];
+  const len = Math.hypot(dx, dy);
+  return len > 0 ? (vxMs * dx + vyMs * dy) / len : 0;
+}
+
+/** Cumulative arc length (m) at each vertex of a meter-space polyline. */
+export function cumulativeLengthsM(xs: Float64Array, ys: Float64Array): Float64Array {
+  const cum = new Float64Array(xs.length);
+  for (let i = 1; i < xs.length; i += 1) {
+    cum[i] = cum[i - 1] + Math.hypot(xs[i] - xs[i - 1], ys[i] - ys[i - 1]);
+  }
+  return cum;
+}
+
+/**
+ * Resolve an arc length to a point on the polyline. `hint` is the segment the
+ * caller last landed on — s moves a few meters per tick, so the walk is O(1)
+ * amortised. Fills `out` (no allocation — this runs per snapped bus per tick)
+ * and clamps s beyond either end to the endpoints.
+ */
+export function pointAtArclen(
+  xs: Float64Array,
+  ys: Float64Array,
+  cum: Float64Array,
+  s: number,
+  hint: number,
+  out: ArcPoint,
+): void {
+  const lastSeg = xs.length - 2;
+  const sc = Math.max(0, Math.min(cum[cum.length - 1], s));
+  let seg = Math.max(0, Math.min(lastSeg, hint));
+  while (seg > 0 && cum[seg] > sc) seg -= 1;
+  while (seg < lastSeg && cum[seg + 1] < sc) seg += 1;
+  const segLen = cum[seg + 1] - cum[seg];
+  const u = segLen > 0 ? (sc - cum[seg]) / segLen : 0;
+  const dx = xs[seg + 1] - xs[seg];
+  const dy = ys[seg + 1] - ys[seg];
+  out.x = xs[seg] + dx * u;
+  out.y = ys[seg] + dy * u;
+  out.seg = seg;
+  out.bearing = ((Math.atan2(dx, dy) * 180) / Math.PI + 360) % 360;
+}


### PR DESCRIPTION
## What

Replaces the snapped-bus display motion with a **1-D Kalman filter in arc-length space** along the learned route polylines. Full design + parameter derivations: `docs/BUS_KALMAN.md`.

**Why:** the old model derived velocity from the last two fixes and dead-reckoned in a straight lat/lon line — one drifted fix hijacked speed and heading for the whole 45 s window, and buses cut corners between sparse (~80 s) fixes. Now fixes are projected onto the polyline (lateral drift discarded), folded in weighted by per-route measurement noise (`quality.meanResidualM`, already baked by the learner — no data changes needed), and between fixes buses advance **along** the route.

## What deliberately did NOT change

- Raw motion model + snap hysteresis: untouched, still decide snap on/off; the filter only supplies the snapped pose
- Buses without learned routes (~0.2%): render exactly as before
- No opacity/uncertainty visualisation (deferred by design)
- Backend + learner: zero changes

## Review

Implemented TDD (tests first), then a 16-agent five-lens review (independent math re-derivation, TypeScript, silent failures, comment accuracy, test coverage) with adversarial verification: **math lens found zero defects in the filter equations**; 8 findings confirmed and all fixed in this PR (route-vertex NaN validation, reset re-seed from raw velocity, seed-scan memoization, corrected default-R derivation 20→44 m, corrected doc gate-width numbers), 3 refuted.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 67/67 vitest (46 existing + 21 new deterministic filter/geometry tests)
- [ ] Visual check on the live map after merge (buses follow corners; no jitter; teleporting fixes ignored)