### PR TITLE
fix: raise Kalman process noise q 0.2 → 2 for stop-and-go dynamics

### DIFF
--- a/docs/BUS_KALMAN.md
+++ b/docs/BUS_KALMAN.md
@@ -100,8 +100,8 @@ All in `bus-kalman.ts`, each with the derivation in a comment:
 
 | Parameter | Value | Why this value |
 |---|---|---|
-| `KF_PROCESS_NOISE_M2_S3` (q) | 0.2 m²/s³ | Continuous white-noise-acceleration model. Calibrated so a typical 80 s fix gap admits σ_v = √(q·80) ≈ 4 m/s of speed change — a bus caught by / released from a red light. Raise to trust fixes more, lower to trust motion more. |
-| `KF_GATE_SIGMA` | 3 | Standard 3σ innovation gate (~99.7% of honest fixes pass). The gate widens with elapsed time automatically — measured on a settled filter (R = 15²): half-width ≈ 140 m after a 20 s gap, ≈ 1.2 km after 120 s. Long gaps legitimately admit more, so only genuine teleports get gated. |
+| `KF_PROCESS_NOISE_M2_S3` (q) | 2 m²/s³ | Continuous white-noise-acceleration model. London buses are stop-and-go (a stop every 300–400 m): speed swings the full 0↔8–13 m/s within one 20–30 s fix gap, so σ_v(25 s) = √(q·25) ≈ 7 m/s ⇒ q ≈ 2. **Field-revised 2026-07-31** from 0.2 (a smooth-cruising derivation over the average 80 s cadence): the tight model made the 3σ gate reject 20–36% of honest braking/departure fixes in stop-and-go simulation, which in production showed as fleet-wide surge-and-stall — buses sailing past stops on stale speed, snapping back on reset, then sprinting to catch up. |
+| `KF_GATE_SIGMA` | 3 | Standard 3σ innovation gate (~99.7% of honest fixes pass). The gate widens with elapsed time automatically; at q = 2 a settled filter's half-width is roughly 250 m after a 20 s gap and grows steeply with longer gaps, so only genuine teleports get gated. Note the gate also widens after each *rejected* fix (gated predicts inflate the covariance) — moderate persistent offsets get wide-gated back in within a fix or two, which is reset-in-all-but-name; the explicit reset path is the backstop for cross-town relocations. |
 | `KF_MAX_REJECTS` | 3 | Consecutive gated fixes before re-seeding. 1 would let a single glitch reset the filter; 3 costs ≤ ~4 min of frozen progress in the worst case while being robust to glitch pairs. |
 | `KF_INIT_SIGMA_S_M` | 30 m | Initial position σ — matches the learner's corridor start: a fresh snap knows the bus about this well. |
 | `KF_INIT_SIGMA_V_MS` | 3 m/s | Initial speed σ — the seed comes from the raw two-fix model, so keep healthy doubt. |
@@ -135,6 +135,7 @@ Reused display constants (unchanged values, same meaning in 1-D):
 
 | Symptom | Knob |
 |---|---|
+| Fleet-wide surge-and-stall rhythm (buses sprint, then crawl, in sync) | q too LOW for the stop-and-go dynamics — honest braking/departure fixes are being gated. This exact symptom occurred in production on 2026-07-31 with q = 0.2; verify with the stop-and-go simulation before touching anything else. |
 | Snapped buses lag behind reality | raise q (trust fixes more) |
 | Snapped buses jitter along the route | lower q, or check the route's `meanResidualM` is honest |
 | Buses stick when drivers genuinely divert | lower `KF_MAX_REJECTS` to 2 |

--- a/frontend/src/realtime/bus-kalman.test.ts
+++ b/frontend/src/realtime/bus-kalman.test.ts
@@ -143,8 +143,12 @@ describe('kfStep — gating', () => {
     const st = settled();
     const results: string[] = [];
     for (let i = 1; i <= KF_MAX_REJECTS; i += 1) {
-      // Fixes consistently ~500 m ahead — the bus genuinely is elsewhere.
-      results.push(kfStep(st, st.s + 8 * 20 + 500, st.t + 20_000, R_TYPICAL));
+      // Fixes consistently ~5 km ahead — a cross-town relocation (vehicle
+      // reassigned). It must stay OUTSIDE the gate for all three fixes: each
+      // gated predict widens the gate (that's by design — moderate offsets
+      // get wide-gated back in, which is reset-in-all-but-name), so only a
+      // disagreement that outruns the widening exercises the reset path.
+      results.push(kfStep(st, st.s + 8 * 20 + 5_000, st.t + 20_000, R_TYPICAL));
     }
     expect(results.slice(0, -1).every((r) => r === 'gated')).toBe(true);
     expect(results[results.length - 1]).toBe('reset');

--- a/frontend/src/realtime/bus-kalman.ts
+++ b/frontend/src/realtime/bus-kalman.ts
@@ -22,11 +22,22 @@
 
 /**
  * Process noise spectral density q, m²/s³ (continuous white-noise acceleration
- * model). Calibrated so that after a typical 80 s fix gap the filter admits
- * σ_v ≈ √(q·80) ≈ 4 m/s of speed change — a bus caught by a red light or
- * released from a stop. Larger q = trust fixes more; smaller = trust motion.
+ * model). London buses are stop-and-go — a stop every 300-400 m means speed
+ * swings the FULL 0↔8-13 m/s range within a single 20-30 s fix gap, so that
+ * swing must be statistically unsurprising: σ_v(25 s) = √(q·25) ≈ 7 m/s ⇒
+ * q ≈ 2. Larger q = trust fixes more; smaller = trust motion more.
+ *
+ * Field revision 2026-07-31: the initial 0.2 (derived as σ_v(80 s) ≈ 4 m/s,
+ * i.e. a smooth-cruising model over the AVERAGE fix cadence) made the 3σ gate
+ * reject honest braking/departure fixes — simulated stop-and-go showed 20-36%
+ * of fixes gated, and in production every bus stop triggered gate→reset
+ * cycles that displayed as fleet-wide surge-and-stall (buses sailing past
+ * stops on stale speed, snapping back on reset, then sprinting to catch up).
+ * At q = 2 the same simulations gate zero honest fixes, at 8 AND 13 m/s
+ * cruise speeds. The lost smoothing is acceptable: the filter's real jobs
+ * (along-route motion, tangent heading, teleport gating) don't depend on it.
  */
-export const KF_PROCESS_NOISE_M2_S3 = 0.2;
+export const KF_PROCESS_NOISE_M2_S3 = 2;
 /** Innovation gate, in σ of the innovation variance: reject beyond 3σ (~99.7%). */
 export const KF_GATE_SIGMA = 3;
 /** Consecutive gated fixes before the caller should re-seed the filter — the


### PR DESCRIPTION
## Symptom (production, reported immediately after #3 went live)

Fleet-wide surge-and-stall: every ~5–15 s all buses sprint, then crawl, in sync.

## Root cause

q = 0.2 was derived for smooth cruising over the *average* 80 s fix cadence. London buses are stop-and-go (a stop every 300–400 m): speed swings the full 0↔8–13 m/s within a single 20–30 s fix gap. Under the tight model the 3σ innovation gate **rejected honest braking/departure fixes** — deterministic stop-and-go simulation shows **20% of fixes gated at 8 m/s cruise, 36% at 13 m/s**. Filters then sailed past stops on stale speed, snapped back on reset, and sprinted to catch up — at every bus stop, fleet-wide.

## Fix

`KF_PROCESS_NOISE_M2_S3`: 0.2 → **2** (σ_v(25 s) ≈ 7 m/s ⇒ a full stop-to-cruise swing inside one gap is statistically unsurprising). Same simulations at q = 2: **zero honest fixes gated** at both cruise speeds. The lost smoothing is acceptable — the filter's real jobs (along-route motion, tangent heading, teleport gating) don't depend on it.

One test recalibrated: the reset-path test now uses a cross-town (5 km) offset, because gated predicts widen the gate fast enough that moderate offsets get wide-gated back in (reset-in-all-but-name) — documented in the test and docs.

Docs updated: parameter derivation + field-revision note, gate-width numbers, and a tuning-guide entry pinning this exact symptom to this knob.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] 67/67 vitest
- [x] Stop-and-go simulation sweep (q ∈ {0.2, 0.5, 1, 2, 4} × {8, 13} m/s): q = 2 is the smallest value with zero gated honest fixes at both speeds
- [ ] Visual check after merge: surge-and-stall rhythm gone; buses still follow corners; teleports still ignored