### PR TITLE
feat: decaying-coast extrapolation with asymmetric loss for buses

### DIFF
--- a/docs/BUS_KALMAN.md
+++ b/docs/BUS_KALMAN.md
@@ -34,12 +34,14 @@ Both are addressed by filtering **along the learned route polyline**:
 
 ## What deliberately did NOT change
 
-- **The raw motion model is untouched and keeps running for every bus.** It
-  still decides snap engagement/release (hysteresis on the raw eased position,
-  SNAP_ON_M 50 / SNAP_OFF_M 80), seeds the filter, and renders the ~0.2% of
-  buses without a learned route exactly as before. The filter never votes on
-  its own engagement — that would let a confidently-wrong filter keep itself
-  alive.
+- **The raw motion model keeps running for every bus.** It still decides
+  snap engagement/release (hysteresis on the raw eased position, SNAP_ON_M
+  50 / SNAP_OFF_M 80), seeds the filter, and renders buses without a learned
+  route. The filter never votes on its own engagement — that would let a
+  confidently-wrong filter keep itself alive. (One deliberate 2026-08-01
+  exception to "untouched": the raw model's linear 45 s extrapolation horizon
+  was replaced by the same decaying coast the filter uses — see
+  "Extrapolation policy".)
 - **No uncertainty visualisation.** The filter's position variance could
   drive icon opacity ("less sure = more transparent"); this was explicitly
   deferred — a different presentation is planned for a future version.
@@ -59,13 +61,48 @@ from RecordedAtTime.
 ```
 poll ingest (new fix)                      render tick (≤15 Hz)
 ────────────────────                       ────────────────────
-project fix → arc length z                 target = s + v·(now − t)   [cap 45 s]
-PREDICT state to fix time:                 ease kfDispS toward target (τ 2.5 s)
-  s += v·dt;  P grows by Q(dt)             pointAtArclen(kfDispS) → x, y, tangent
-GATE:  |z − s| > 3σ → reject               → snapX / snapY / snapBearing
-UPDATE: K = pS/(pS+R)
-  s += K·(z−s);  v += Kv·(z−s);  P shrinks
+project fix → arc length z                 target = s + v·τ·(1−e^(−Δt/τ))
+PREDICT state to fix time:                   [decaying coast, bound v·τ]
+  s += v·dt;  P grows by Q(dt)             ease kfDispS toward target (τ 2.5 s,
+GATE:  |z − s| > 3σ → reject                 forward-only, catch-up ≤ 25 m/s)
+UPDATE: K = pS/(pS+R)                      pointAtArclen(kfDispS) → x, y, tangent
+  s += K·(z−s);  v += Kv·(z−s);  P shrinks → snapX / snapY / snapBearing
 ```
+
+### Extrapolation policy — asymmetric loss (field-revised 2026-08-01)
+
+The display objective is NOT "as close to the true position as possible" —
+it is "**as close as possible while staying behind it**". Showing a bus
+behind reality is cheap: the correction is a forward glide that reads as
+driving. Showing it ahead is expensive: fabricated progress (a bus sailing
+past its stop, or off the map's plausibility entirely), and the correction
+reads as a bus reversing — the single most jarring artefact. The initial
+release extrapolated at constant filtered speed with a 45 s freeze horizon
+(inherited from the raw model), and buses whose fixes stopped — urban
+canyon, dwell — kept driving at cruise speed for 45 s. Three rules replace
+that:
+
+1. **Decaying coast** (`kfCoastS`): between fixes the display advances by
+   ∫v·e^(−u/τ) = v·τ·(1−e^(−Δt/τ)). A silent bus decelerates smoothly and
+   halts within v·τ (≈ 96 m at 8 m/s) — the longer the silence, the less
+   credible "still cruising" is, and the budget spends itself accordingly.
+   The **raw x/y model coasts with the same decay** (`coastSeconds`), for two
+   reasons: unsnapped buses deserve the same honesty, and the two models must
+   stay co-located during silence or hysteresis release would yank a halted
+   bus onto a runaway linear extrapolation.
+2. **Forward-only display**: corrections landing behind the displayed
+   position hold the bus still until the state catches up — it never backs
+   up. The clamp direction follows the *established* travel direction
+   (±1 m/s lock threshold), not the instantaneous sign of v, so speed jitter
+   at a stand can't ratchet the display backwards. Genuine relocations stay
+   representable: the reset path re-seeds the displayed arc directly, and
+   corrections beyond `KF_JUMP_DISTANCE_M` (1.2 km — larger than any honest
+   coast backlog) jump as a safety valve.
+3. **Bus-plausible catch-up**: forward glides are capped at 25 m/s (~3×
+   cruise) so banked backlog reads as a fast bus, not a teleport. At sparse
+   fix cadences (60–120 s gaps) the resulting rhythm is inherently
+   drive → slow → halt → fast forward glide; that is the chosen loss
+   ordering (never ahead > low latency > smoothness), not a defect.
 
 Design choices worth knowing when debugging:
 
@@ -116,10 +153,15 @@ already downloads. Central-London canyon routes get a large R (their fixes are
 trusted less); open suburban routes get a small one. This is the main reason
 the filter needed no new data: the learner had been measuring R all along.
 
+| `KF_COAST_TAU_S` | 12 s | Coast decay constant. Total silent-coast distance is hard-bounded by v·τ (≈ 96 m at 8 m/s — under one stop spacing). The first ~2–3 s stay within ~10% of linear extrapolation; by 10 s the coasted advance is about two-thirds of linear. Worst case ahead-of-truth: the full v·τ budget (bus brakes to a stop right after a fix) until the next accepted fix pulls the state back. Shared by the raw model via `coastSeconds`. |
+| `KF_CATCHUP_SPEED_MS` | 25 m/s | Forward-glide cap (~3× cruise): clears a 300 m coast backlog in ~12 s, always outruns a real bus (so the glide converges), and reads as a fast bus rather than a teleport. |
+| `KF_JUMP_DISTANCE_M` | 1200 m | Displayed-arc jump threshold — safety valve only. Must exceed the worst *honest* coast backlog (13 m/s × 90 s gap ≈ 1000 m) so routine catch-ups always glide; genuine relocations are made visible by the reset path re-seeding the display, not by this branch. |
+
 Reused display constants (unchanged values, same meaning in 1-D):
-`MAX_EXTRAPOLATION_S` 45 s (freeze-don't-run-away horizon), `EASE_TAU_S` 2.5 s
-(display easing), `SNAP_DISTANCE_M` 400 m (jump instead of glide),
-`MAX_CATCHUP_SPEED_MS` 120 m/s (glide cap).
+`EASE_TAU_S` 2.5 s (display easing). `SNAP_DISTANCE_M` (400 m) and
+`MAX_CATCHUP_SPEED_MS` (120 m/s) now apply only to the raw x/y model's own
+ease; the old `MAX_EXTRAPOLATION_S` linear horizon is gone — both models
+coast with the same decay.
 
 ## Behaviour you should expect on the map
 
@@ -127,15 +169,22 @@ Reused display constants (unchanged values, same meaning in 1-D):
   them; heading comes from the polyline tangent.
 - A single teleporting fix visibly does ~nothing (gated); the bus keeps
   rolling at its filtered speed.
-- After long gaps (>45 s) buses freeze rather than run away — same as before.
-- Buses without learned routes, and buses outside the snap corridor, behave
-  **exactly** as before this change.
+- When a bus's fixes stop arriving (urban canyon, dwell), it decelerates
+  smoothly and halts within ~v·τ ≈ 100 m — it never sails onward at cruise
+  speed, and it never moves backwards along the route. When fixes resume,
+  it catches up as a forward glide capped at 25 m/s.
+- Buses without learned routes, and buses outside the snap corridor, keep
+  the raw x/y model — with one deliberate change: their fix-silence
+  extrapolation now decays the same way instead of running 45 s linear.
 
 ## Tuning guide (if the map looks wrong)
 
 | Symptom | Knob |
 |---|---|
 | Fleet-wide surge-and-stall rhythm (buses sprint, then crawl, in sync) | q too LOW for the stop-and-go dynamics — honest braking/departure fixes are being gated. This exact symptom occurred in production on 2026-07-31 with q = 0.2; verify with the stop-and-go simulation before touching anything else. |
+| Buses coast too far past stops when fixes pause | lower `KF_COAST_TAU_S` (tighter coast budget) |
+| Buses feel laggy on fast open corridors between fixes | raise `KF_COAST_TAU_S` (more linear extrapolation) |
+| Catch-up glides look like teleports / take too long | tune `KF_CATCHUP_SPEED_MS` (down / up respectively) |
 | Snapped buses lag behind reality | raise q (trust fixes more) |
 | Snapped buses jitter along the route | lower q, or check the route's `meanResidualM` is honest |
 | Buses stick when drivers genuinely divert | lower `KF_MAX_REJECTS` to 2 |
@@ -143,14 +192,15 @@ Reused display constants (unchanged values, same meaning in 1-D):
 
 ## Testing
 
-`frontend/src/realtime/bus-kalman.test.ts` — 21 deterministic behavioural
+`frontend/src/realtime/bus-kalman.test.ts` — 24 deterministic behavioural
 tests (no RNG): convergence on constant speed, stability under crafted noise,
 reversed-polyline (negative v) tracking, speed clamping, outlier gating,
 reject-counter reset, reset-after-persistent-disagreement, gate widening with
 fix gaps, out-of-order timestamps, covariance health (positive, Cauchy–Schwarz
-consistent) over a 200-step mixed run, extrapolation capping, signed
-tangent-speed seeding, and the arc-length geometry (cumulative lengths,
-interpolation, end clamping, hint walks).
+consistent) over a 200-step mixed run, decaying-coast behaviour (near-linear
+when fresh, decelerating, hard v·τ bound, backwards for reversed polylines),
+signed tangent-speed seeding, and the arc-length geometry (cumulative
+lengths, interpolation, end clamping, hint walks).
 Run: `cd frontend && npx vitest run src/realtime/bus-kalman.test.ts`.
 
 Known coverage gap, accepted deliberately: the buses.ts integration glue

--- a/frontend/src/layers/buses.ts
+++ b/frontend/src/layers/buses.ts
@@ -5,11 +5,13 @@
 //   • at/above 12.5 — symbol layer with oriented bus bullets, rebuilt per frame
 //     ONLY from the viewport subset (+20 % margin).
 // Motion model: a per-bus tracker (kept across polls) derives a velocity vector
-// from the last two distinct fixes, extrapolates the newest fix forward (capped
-// at 45 s), and eases the displayed position toward that target with an
-// exponential approach (tau ≈ 2.5 s). BODS fixes are often already 10–30 s old
-// on arrival, so extrapolating from RecordedAtTime with a real velocity — not a
-// short capped drift — is what keeps buses visibly moving between 15 s polls.
+// from the last two distinct fixes, coasts the newest fix forward with an
+// exponentially DECAYING speed (silence budget v·τ ≈ 100 m — see coastSeconds),
+// and eases the displayed position toward that target with an exponential
+// approach (tau ≈ 2.5 s). BODS fixes are often already 10–30 s old on arrival,
+// so coasting from RecordedAtTime with a real velocity is what keeps buses
+// visibly moving between 15 s polls — while a bus whose fixes stop glides to a
+// halt instead of sailing on at cruise speed.
 // Route snapping: learned route polylines (backend learner, keyed by
 // operator:line:direction) are lazy-loaded from /api/bus-routes-index +
 // /bus-routes/learned/<key>.json. Snap engagement is hysteresis on the RAW
@@ -41,10 +43,13 @@ import { registerPoll, symbolTierIntervalMs } from '../util/lifecycle';
 import {
   type ArcPoint,
   type BusKfState,
+  KF_CATCHUP_SPEED_MS,
+  KF_COAST_TAU_S,
+  KF_JUMP_DISTANCE_M,
   cumulativeLengthsM,
+  kfCoastS,
   kfInit,
   kfStep,
-  kfTargetS,
   measurementVariance,
   pointAtArclen,
   tangentSpeedMs,
@@ -68,10 +73,21 @@ const VELOCITY_MIN_DT_S = 3;
 const VELOCITY_MAX_DT_S = 120;
 /** Implied speeds above this are GPS glitches — fall back to Bearing. */
 const MAX_IMPLIED_SPEED_MS = 20;
-/** Never extrapolate a track-derived velocity further than this. */
-const MAX_EXTRAPOLATION_S = 45;
-/** Bearing-fallback velocity is low confidence — extrapolate it less. */
-const MAX_FALLBACK_EXTRAPOLATION_S = 20;
+/**
+ * Decayed extrapolation seconds for a fix `ageS` old: ∫e^(−u/τ)du. Both the
+ * raw model and the filter display coast with the SAME decay so their
+ * positions stay co-located during fix silence — if the raw model kept the
+ * old linear 45 s horizon it would run ~260 m ahead of the halted coast,
+ * yanking the bus onto the runaway raw position whenever hysteresis released.
+ * This also means unsnapped buses stop sailing on at cruise speed when their
+ * fixes pause — the same asymmetric loss, applied fleet-wide.
+ */
+const coastSeconds = (ageS: number): number =>
+  KF_COAST_TAU_S * (1 - Math.exp(-Math.max(ageS, 0) / KF_COAST_TAU_S));
+/** Direction lock threshold, m/s: |v| must exceed this to flip the display's
+ * forward-only clamp direction — v jittering around 0 at a stand must not
+ * ratchet the display backwards. */
+const DIRECTION_LOCK_SPEED_MS = 1;
 /** Exponential-approach time constant for displayed positions, seconds. */
 const EASE_TAU_S = 2.5;
 /** Displayed position snaps (no easing) when this far from its target. */
@@ -243,6 +259,10 @@ interface BusTracker {
   /** lastFix.t of a failed seed attempt — initFilter's full-polyline scan is
    * pointless until a NEW fix arrives, so don't repeat it per tick. */
   kfSeedFixT: number;
+  /** Established travel direction along the polyline (+1/−1). The display's
+   * forward-only clamp follows THIS, not the instantaneous sign of kf.v —
+   * a v jittering around 0 at a stand must not ratchet the display back. */
+  kfDir: 1 | -1;
 }
 
 const esc = (s: string): string =>
@@ -584,8 +604,8 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
       const fix: Fix = { x: bus.x, y: bus.y, t: bus.t };
       const fb = fallbackVelocity(bus.b);
       // Fixes are often already 10-30 s old on arrival: start the displayed
-      // position at the extrapolated target so new buses don't glide on entry.
-      const staleS = Math.min(Math.max((now - bus.t) / 1000, 0), MAX_FALLBACK_EXTRAPOLATION_S);
+      // position at the coasted target so new buses don't glide on entry.
+      const staleS = coastSeconds((now - bus.t) / 1000);
       trackers.set(bus.i, {
         prevFix: fix,
         lastFix: fix,
@@ -615,6 +635,7 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
         kfDispS: 0,
         kfSeg: 0,
         kfSeedFixT: 0,
+        kfDir: 1,
       });
       return;
     }
@@ -679,6 +700,12 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
               existing.velLat * M_PER_DEG_LAT,
             );
             existing.kf = kfInit(zS, v0, bus.t);
+            // Relocations must be visible immediately: re-seed the displayed
+            // arc as well — the forward-only clamp would otherwise hold a
+            // backward relocation at its old position indefinitely.
+            const total = route.cum[route.cum.length - 1];
+            existing.kfDispS = Math.max(0, Math.min(total, kfCoastS(existing.kf, now)));
+            existing.kfSeg = proj.seg;
           }
         }
       }
@@ -694,8 +721,7 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
    * icon by the actual displayed movement once it accumulates.
    */
   function advance(tr: BusTracker, now: number): void {
-    const horizonS = tr.hasTrackVelocity ? MAX_EXTRAPOLATION_S : MAX_FALLBACK_EXTRAPOLATION_S;
-    const extraS = Math.min(Math.max((now - tr.lastFix.t) / 1000, 0), horizonS);
+    const extraS = coastSeconds((now - tr.lastFix.t) / 1000);
     const targetX = tr.lastFix.x + tr.velLon * extraS;
     const targetY = tr.lastFix.y + tr.velLat * extraS;
     const dtS = Math.max((now - tr.dispT) / 1000, 0);
@@ -761,10 +787,10 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
       tr.velLat * M_PER_DEG_LAT,
     );
     tr.kf = kfInit(s0, v0, tr.lastFix.t);
-    // Start the displayed arc length at the extrapolated target so a freshly
+    // Start the displayed arc length at the coasted target so a freshly
     // snapped bus doesn't glide in — mirrors how ingest() seeds `disp`.
     const total = route.cum[route.cum.length - 1];
-    tr.kfDispS = Math.max(0, Math.min(total, kfTargetS(tr.kf, now, MAX_EXTRAPOLATION_S)));
+    tr.kfDispS = Math.max(0, Math.min(total, kfCoastS(tr.kf, now)));
     tr.kfSeg = proj.seg;
   }
 
@@ -824,16 +850,25 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
       tr.snapBearing = diff > 90 ? (proj.bearing + 180) % 360 : proj.bearing;
       return;
     }
+    if (kf.v > DIRECTION_LOCK_SPEED_MS) tr.kfDir = 1;
+    else if (kf.v < -DIRECTION_LOCK_SPEED_MS) tr.kfDir = -1;
     const total = route.cum[route.cum.length - 1];
-    const target = Math.max(0, Math.min(total, kfTargetS(kf, now, MAX_EXTRAPOLATION_S)));
+    const target = Math.max(0, Math.min(total, kfCoastS(kf, now)));
     const gap = target - tr.kfDispS;
-    if (Math.abs(gap) > SNAP_DISTANCE_M) {
-      tr.kfDispS = target; // too far to glide — jump, like the raw model
+    if (Math.abs(gap) > KF_JUMP_DISTANCE_M) {
+      tr.kfDispS = target; // beyond any honest backlog — safety-valve jump
     } else {
       const alpha = 1 - Math.exp(-dtS / EASE_TAU_S);
       const step = gap * alpha;
-      const maxStep = MAX_CATCHUP_SPEED_MS * dtS;
-      tr.kfDispS += Math.abs(step) > maxStep ? Math.sign(gap) * maxStep : step;
+      const maxStep = KF_CATCHUP_SPEED_MS * dtS;
+      let next = tr.kfDispS + (Math.abs(step) > maxStep ? Math.sign(gap) * maxStep : step);
+      // Never reverse along the route: when a correction lands BEHIND the
+      // displayed position, hold still and let the state catch up — waiting
+      // reads fine, a bus backing up does not (asymmetric loss). Genuine
+      // relocations bypass this via the reset path's display re-seed and the
+      // jump branch above.
+      next = tr.kfDir > 0 ? Math.max(tr.kfDispS, next) : Math.min(tr.kfDispS, next);
+      tr.kfDispS = next;
     }
     pointAtArclen(route.xs, route.ys, route.cum, tr.kfDispS, tr.kfSeg, arcScratch);
     tr.kfSeg = arcScratch.seg;

--- a/frontend/src/realtime/bus-kalman.test.ts
+++ b/frontend/src/realtime/bus-kalman.test.ts
@@ -5,14 +5,15 @@
 
 import { describe, expect, test } from 'vitest';
 import {
+  KF_COAST_TAU_S,
   KF_MAX_REJECTS,
   KF_MAX_SPEED_MS,
   KF_MEAS_SIGMA_FLOOR_M,
   KF_DEFAULT_MEAS_SIGMA_M,
   type BusKfState,
+  kfCoastS,
   kfInit,
   kfStep,
-  kfTargetS,
   measurementVariance,
   cumulativeLengthsM,
   pointAtArclen,
@@ -190,14 +191,43 @@ describe('kfStep — robustness', () => {
   });
 });
 
-describe('kfTargetS', () => {
-  test('extrapolates from the last fix time and caps at the horizon', () => {
-    const st = kfInit(1000, 10, 0);
-    expect(kfTargetS(st, 20_000, 45)).toBeCloseTo(1200, 6);
-    // 100 s stale but horizon 45 s — freeze at the cap, like the raw model.
-    expect(kfTargetS(st, 100_000, 45)).toBeCloseTo(1450, 6);
-    // Clock skew / same-ms render: never extrapolate backwards.
-    expect(kfTargetS(st, -5_000, 45)).toBeCloseTo(1000, 6);
+describe('kfCoastS — decaying coast', () => {
+  const st = kfInit(1000, 10, 0);
+
+  test('matches plain extrapolation for the first seconds after a fix', () => {
+    // Fresh fixes deserve near-full trust in v: within 2 s the decayed
+    // advance must be within ~10% of linear v·Δt.
+    const coasted = kfCoastS(st, 2_000) - 1000;
+    expect(coasted).toBeGreaterThan(10 * 2 * 0.9);
+    expect(coasted).toBeLessThanOrEqual(10 * 2);
+  });
+
+  test('slows monotonically and never exceeds the v·τ coast budget', () => {
+    let prev = kfCoastS(st, 0);
+    let prevT = 0;
+    let prevSpeed = Infinity;
+    for (const t of [5, 10, 20, 40, 80, 160, 320]) {
+      const cur = kfCoastS(st, t * 1000);
+      const speed = (cur - prev) / (t - prevT); // mean speed over the window
+      expect(cur).toBeGreaterThanOrEqual(prev); // keeps creeping forward…
+      expect(speed).toBeLessThan(prevSpeed); // …but ever slower (decelerating)
+      prev = cur;
+      prevT = t;
+      prevSpeed = speed;
+    }
+    // Hard bound: a silent bus can never coast further than v·τ.
+    expect(kfCoastS(st, 3_600_000)).toBeLessThanOrEqual(1000 + 10 * KF_COAST_TAU_S);
+    expect(kfCoastS(st, 3_600_000)).toBeCloseTo(1000 + 10 * KF_COAST_TAU_S, 1);
+  });
+
+  test('a reversed-polyline bus coasts backwards toward its own bound', () => {
+    const rev = kfInit(5000, -8, 0);
+    expect(kfCoastS(rev, 3_600_000)).toBeCloseTo(5000 - 8 * KF_COAST_TAU_S, 1);
+  });
+
+  test('clock skew / same-ms render never extrapolates backwards in time', () => {
+    expect(kfCoastS(st, -5_000)).toBeCloseTo(1000, 6);
+    expect(kfCoastS(st, 0)).toBeCloseTo(1000, 6);
   });
 });
 

--- a/frontend/src/realtime/bus-kalman.ts
+++ b/frontend/src/realtime/bus-kalman.ts
@@ -16,9 +16,10 @@
 // scalar — no matrix library, ~5 floats per bus.
 //
 // Time base: state time `t` is the FIX timestamp (BODS RecordedAtTime), never
-// wall clock — fixes arrive 10-30 s stale and display code extrapolates the
-// state forward to `now` (kfTargetS), exactly like the raw model extrapolates
-// from RecordedAtTime. Full design + parameter derivations: docs/BUS_KALMAN.md.
+// wall clock — fixes arrive 10-30 s stale and display code coasts the state
+// forward to `now` (kfCoastS) with exponentially decaying speed, so staleness
+// is compensated but a silent bus glides to a halt instead of running away.
+// Full design + parameter derivations: docs/BUS_KALMAN.md.
 
 /**
  * Process noise spectral density q, m²/s³ (continuous white-noise acceleration
@@ -63,6 +64,43 @@ export const KF_MAX_SPEED_MS = 20;
 /** Mean-absolute-deviation → σ for a zero-mean Gaussian: σ = E|x|·√(π/2) ≈
  * 1.25·E|x|. The learner's meanResidualM is a MAD, not a σ. */
 const MAD_TO_SIGMA = 1.25;
+/**
+ * Coast decay time constant τ, s. Between fixes the display advances with an
+ * exponentially decaying speed v·e^(−Δt/τ) — total silent-coast distance is
+ * hard-bounded by v·τ (8 m/s ⇒ ≈ 96 m, under one stop spacing), so a bus
+ * whose fixes stop (urban canyon, dwell) glides to a halt instead of sailing
+ * onwards at cruise speed. The value encodes an asymmetric loss: showing a
+ * bus BEHIND its true position is cheap (it catches up forwards, which reads
+ * as driving), showing it AHEAD is expensive (fabricated progress, and the
+ * correction would read as reversing). At τ = 12 the first ~2-3 s stay within
+ * ~10% of linear extrapolation; by 10 s the coasted advance is about
+ * two-thirds of linear. Worst case ahead-of-truth: the full v·τ budget (bus
+ * brakes to a stop immediately after its last fix) until the next accepted
+ * fix pulls the state back.
+ */
+export const KF_COAST_TAU_S = 12;
+/**
+ * Catch-up glide cap, m/s, for the eased displayed arc length. Conservative
+ * coasting banks a forward backlog whenever the bus actually kept cruising;
+ * the catch-up must read as "a fast bus", not a teleport. ~3× cruise clears a
+ * 300 m backlog in ~12 s and still outruns any real bus, so the glide always
+ * converges. At sparse fix cadences (60-120 s gaps) the resulting rhythm is
+ * inherently drive → slow → halt → fast forward glide — that is the CHOSEN
+ * loss ordering (never ahead > low latency > smoothness), not a defect.
+ * (The raw x/y model keeps its own larger MAX_CATCHUP_SPEED_MS.)
+ */
+export const KF_CATCHUP_SPEED_MS = 25;
+/**
+ * Displayed-arc jump threshold, m: corrections larger than this skip the
+ * glide and jump in one frame. Must exceed the worst HONEST coast backlog so
+ * routine catch-ups always glide — at 13 m/s cruise and a 90 s fix gap the
+ * backlog is ≈ 13·(90−12) ≈ 1000 m, hence 1200. Genuine relocations are
+ * handled by the reset path re-seeding the display directly; this branch is
+ * only the safety valve. (Deliberately NOT the raw model's SNAP_DISTANCE_M
+ * (400 m): the coast policy banks far larger honest backlogs than the raw
+ * model's linear extrapolation ever did.)
+ */
+export const KF_JUMP_DISTANCE_M = 1200;
 
 /** Filter state for one snapped bus. Mutated in place by kfStep — these live
  * in per-bus trackers updated from poll ingest (~110 updates/s fleet-wide). */
@@ -167,13 +205,18 @@ export function kfStep(st: BusKfState, zS: number, zTMs: number, rVar: number): 
 }
 
 /**
- * Display target: the state extrapolated from its fix time to `nowMs`, capped
- * at `horizonS` — the same "freeze rather than run away" behaviour the raw
- * model gets from MAX_EXTRAPOLATION_S. Clock skew never extrapolates backwards.
+ * Display target: the state coasted from its fix time to `nowMs` with
+ * exponentially decaying speed — ∫v·e^(−u/τ)du = v·τ·(1−e^(−Δt/τ)). Fresh
+ * fixes get near-linear extrapolation (staleness compensation, no perceived
+ * lag); a silent bus decelerates smoothly and halts within v·τ meters. See
+ * KF_COAST_TAU_S for why decay, not a hard horizon: the longer the silence,
+ * the less credible "still cruising" is, and the asymmetric loss prefers
+ * falling behind over fabricating progress. Clock skew never coasts backwards
+ * in time.
  */
-export function kfTargetS(st: BusKfState, nowMs: number, horizonS: number): number {
-  const extraS = Math.min(Math.max((nowMs - st.t) / 1000, 0), horizonS);
-  return st.s + st.v * extraS;
+export function kfCoastS(st: BusKfState, nowMs: number): number {
+  const dtS = Math.max((nowMs - st.t) / 1000, 0);
+  return st.s + st.v * KF_COAST_TAU_S * (1 - Math.exp(-dtS / KF_COAST_TAU_S));
 }
 
 /**


### PR DESCRIPTION
## What this changes

The display objective is now **"as close to the true position as possible — while staying behind it"** (user-specified asymmetric loss). Three rules replace the constant-speed 45 s extrapolation:

1. **Decaying coast** (`kfCoastS`): between fixes the display advances by v·τ·(1−e^(−Δt/τ)), τ = 12 s. A bus whose fixes stop (urban canyon, dwell) **decelerates smoothly and halts within ~v·τ ≈ 96 m** — it never sails on at cruise speed, never into the river. Fresh fixes still get staleness compensation (first 2–3 s ≈ linear).
2. **Forward-only display**: corrections landing behind the shown position hold the bus still until the state catches up — buses never visibly reverse. Direction comes from an established-travel lock (±1 m/s threshold), immune to speed jitter at stands.
3. **Bus-plausible catch-up**: banked backlog is cleared as a forward glide capped at 25 m/s; the single-frame jump branch is now a 1.2 km safety valve (routine backlogs always glide).

Also unified: **the raw x/y model coasts with the same decay** (replacing its 45 s/20 s linear horizons) — unsnapped buses get the same honesty, and the two models stay co-located during fix silence so hysteresis release can't teleport a halted bus onto a runaway linear extrapolation.

## Review

2-lens workflow (correctness + doc accuracy) with adversarial verification: 9 findings, **7 confirmed, all fixed in this PR** (the important one: with the original 400 m jump threshold, 80 s fix gaps at cruise would have made single-frame teleports the *normal* path — now routine backlogs glide), 2 refuted.

## Expected on the map

- Silent buses: glide to a stop within ~100 m, then wait — no more driving into the water
- Fixes resume: smooth forward catch-up (fast-bus glide), never a backwards jump
- Known tradeoff (documented): at sparse cadences the rhythm is drive → slow → halt → fast glide; that's the chosen loss ordering (never ahead > low latency > smoothness)

## Test plan

- [x] tsc clean; 70/70 vitest (24 module tests incl. 4 new coast-behaviour tests)
- [ ] Visual check after merge: no runaway buses during silence; no reversing; no single-frame teleports in normal traffic