### PR TITLE
perf: stop polling /api/buses when nothing is drawn

### DIFF
--- a/frontend/src/layers/buses.ts
+++ b/frontend/src/layers/buses.ts
@@ -275,6 +275,9 @@ const sanitizeKey = (key: string): string => key.replace(/[^A-Za-z0-9_.-]/g, '_'
 /** Live tracker map of the running buses layer — set by startBuses. */
 let activeTrackers: ReadonlyMap<string, BusTracker> | null = null;
 
+/** Forces an out-of-band /api/buses fetch — set by startBuses. */
+let refreshBuses: (() => void) | null = null;
+
 /**
  * Displayed [lng, lat] of a live bus by operator-qualified vehicle id
  * ("OPERATOR:VehicleRef"), or null when it isn't currently tracked.
@@ -298,10 +301,23 @@ export function findBus(id: string): [number, number] | null {
 let busesOverlayOn = true; // buses ship visible (no startOff on the overlay)
 let filterLines: readonly string[] = []; // snapshot of the active filter set
 
+/**
+ * Whether either layer is currently on screen — the resolved output of the
+ * truth table above, kept as state because poll() reads it. /api/buses is by
+ * far the heaviest feed the page pulls (~60 KB brotli every 15 s, ~64% of all
+ * origin egress), so while nothing is drawn we don't fetch it at all.
+ */
+let busesVisible = true;
+
 /** Recompute layer visibility + hard filter + colouring from the two inputs. */
 function applyBusDisplay(map: MaplibreMap): void {
   const filterActive = filterLines.length > 0;
   const visible = busesOverlayOn || filterActive;
+  // Coming back on, the trackers hold whatever was true when we stopped
+  // fetching, so refresh out of band rather than showing a stale picture until
+  // the next tick.
+  const resumed = visible && !busesVisible;
+  busesVisible = visible;
   // Hard-filter to matching buses ONLY when the overlay is off but a filter is
   // set — that's the "hide the grey ones, keep just the spotlighted line" case.
   // In every other case there's no setFilter, so non-matching buses stay on the
@@ -334,6 +350,8 @@ function applyBusDisplay(map: MaplibreMap): void {
     }
     if (hasIcons) map.setLayoutProperty(BUSES_ICONS_LAYER_ID, 'icon-image', iconImageNormal());
   }
+
+  if (resumed) refreshBuses?.();
 }
 
 /**
@@ -920,6 +938,7 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
   }
 
   async function poll(): Promise<void> {
+    if (!busesVisible) return; // nothing drawn — don't pay for the feed
     try {
       const res = await fetch('/api/buses');
       if (!res.ok) return;
@@ -1038,6 +1057,7 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
   });
 
   void loadRouteIndex(); // fire-and-forget: snapping activates when it lands
+  refreshBuses = () => void poll(); // lets applyBusDisplay refetch on resume
   await poll();
   renderDots();
   registerPoll(() => void poll(), POLL_INTERVAL_MS);

--- a/frontend/src/ui/legend.ts
+++ b/frontend/src/ui/legend.ts
@@ -172,11 +172,18 @@ export function addLegend(
 
 /**
  * Battery-saver preference row (bottom of the Lines tab). Distinct from the
- * line/overlay toggles above — it doesn't touch any layer, it flips the
- * power-saver lifecycle: pause polling while the map is hidden, and (on phones)
- * ease the animation cadence. Defaults on for mobile, off for desktop.
+ * line/overlay toggles above — it doesn't touch any layer, it eases the
+ * animation cadence to spare the GPU. Defaults on.
+ *
+ * MOBILE ONLY, and deliberately so: pausing the pollers while the page is
+ * hidden used to be the other half of this switch, but that is now
+ * unconditional (see util/lifecycle), and easing the cadence is gated on
+ * isMobile. On desktop the switch would therefore do nothing at all, and a
+ * visible control that does nothing is worse than no control.
  */
 function addBatterySaver(body: HTMLElement): void {
+  if (!isMobile) return;
+
   const wrap = document.createElement('div');
   wrap.className = 'legend-saver';
 
@@ -192,9 +199,7 @@ function addBatterySaver(body: HTMLElement): void {
 
   const hint = document.createElement('div');
   hint.className = 'legend-saver-hint';
-  hint.textContent = isMobile
-    ? 'Pauses updates when the map is hidden, and eases the animation to save power.'
-    : 'Pauses updates when this tab is hidden. (Off by default on desktop.)';
+  hint.textContent = 'Eases the animation to save power. Updates always pause when the map is hidden.';
 
   function paint(): void {
     const on = isPowerSaver();

--- a/frontend/src/util/lifecycle.ts
+++ b/frontend/src/util/lifecycle.ts
@@ -1,13 +1,21 @@
-// Battery-saver lifecycle. A single user-facing switch — "power saver" —
-// defaulting ON for touch/mobile devices and OFF for desktop, drives two
-// measures:
+// Page lifecycle, driving two independent measures:
 //   (A) pause every realtime poller while the page is hidden (tab switched
-//       away, screen locked), resuming — with an immediate refresh — on return;
+//       away, window minimised), resuming — with an immediate refresh — on
+//       return. This is UNCONDITIONAL and not part of the power-saver switch:
+//       a hidden page renders nothing, so every byte it polls is wasted, and
+//       the origin is billed per byte for it. Browsers only throttle
+//       background timers (Chrome settles around one tick a minute); stopping
+//       them outright takes that to zero.
 //   (D) throttle the symbol-tier render loops on mobile so the GPU isn't
-//       redrawing moving vehicles at ~15 Hz when battery matters.
+//       redrawing moving vehicles at ~15 Hz when battery matters. This one IS
+//       the user-facing "power saver" switch — ON by default for touch/mobile
+//       devices, OFF for desktop.
 // Layers register their pollers here (registerPoll) instead of calling
-// setInterval directly, so all pausing/resuming happens in one place. Desktop
-// with the switch OFF behaves exactly as before — pollers never pause.
+// setInterval directly, so all pausing/resuming happens in one place.
+//
+// A visible window on a second monitor is NOT hidden, so leaving the map up as
+// a dashboard keeps polling at full rate — only genuinely backgrounded pages
+// stop.
 
 import { SYMBOL_TIER_INTERVAL_MS } from './render-gate';
 
@@ -31,9 +39,9 @@ const changeListeners = new Set<(on: boolean) => void>();
 // Default: save on mobile, run full-speed on desktop.
 let powerSaverOn = isMobile;
 
-/** Pollers run unless the saver is on AND the page is currently hidden. */
+/** Pollers run whenever the page is visible, saver or not. */
 function pollShouldRun(): boolean {
-  return !(powerSaverOn && document.hidden);
+  return !document.hidden;
 }
 
 function startPolls(): void {
@@ -78,11 +86,14 @@ export function symbolTierIntervalMs(): number {
   return isMobile && powerSaverOn ? POWER_SAVE_SYMBOL_INTERVAL_MS : SYMBOL_TIER_INTERVAL_MS;
 }
 
-/** Flip the power-saver preference (driven by the Lines-tab toggle). */
+/**
+ * Flip the power-saver preference (driven by the Lines-tab toggle). No sync()
+ * here: the saver no longer gates polling, only the render cadence, which the
+ * gates read live via symbolTierIntervalMs.
+ */
 export function setPowerSaver(on: boolean): void {
   if (on === powerSaverOn) return;
   powerSaverOn = on;
-  sync();
   for (const cb of changeListeners) cb(on);
 }
 


### PR DESCRIPTION
## Why

Egress is **72% of the Railway bill** — $6.88 of $9.58 this period, 137.64 GB.
Measured against production, one open tab pulls **~22.8 MB/hour**, and
`/api/buses` alone is **~64%** of that (60.5 KB brotli every 15 s, 2,480 vehicles).

Cloudflare is not absorbing it. Probing the edge for 40 s shows a clean
**6-second TTL** cycle:

```
t=2s  age=none EXPIRED     t=8s  age=none EXPIRED
t=4s  age=2    HIT         t=10s age=2    HIT
t=6s  age=4    HIT         t=12s age=4    HIT
```

6 s is **shorter than every poll interval it fronts** (buses 15 s, arrivals and
vessels 10 s), so a lone viewer's next poll always lands after the cached copy
has died. The CDN only helps when several viewers share a PoP inside the same
6 s window. Raising that TTL is a Cloudflare dashboard change and is **not** in
this PR; these two are the code-side half.

## What changed

**1. Pausing pollers while the page is hidden is now unconditional.**
It used to be a consequence of the battery-saver switch, which defaults **OFF on
desktop** — so a backgrounded desktop tab kept polling. Browsers only *throttle*
background timers (Chrome settles around one tick a minute), so this was never
free. A hidden page draws nothing, so every byte was wasted.

**2. `poll()` returns early while neither bus layer is on screen.**
Turning the Buses overlay off used to keep the heaviest feed on the wire to feed
a layer set to `visibility:none` — only *rendering* was gated (`renderDots`),
never the fetch. The resolved visibility already existed inside `applyBusDisplay`
as the truth table's output; it is now kept as state so `poll()` can read it.

**3. Knock-on: the battery-saver row is now mobile-only.**
With pausing unconditional and the cadence easing gated on `isMobile`, the switch
had nothing left to do on desktop. A visible control that does nothing is worse
than no control, so it is hidden there and its hint now says what it actually does.

## Behaviour preserved

- **Resuming refreshes immediately** — the `hidden -> visible` edge fires one
  out-of-band refetch, so coming back never shows a stale picture.
- **A visible window on a second monitor is not `hidden`**, so leaving the map up
  as a dashboard keeps polling at full rate.
- **The Filter tab still works with the overlay off** — applying a line filter
  makes buses visible again on its own (`visible = overlayOn || filterActive`),
  which resumes polling.
- **Autocomplete does not empty out** — while paused `prune()` does not run
  either, so `listActiveBusLines()` keeps its last-known route list.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 79 tests pass (5 files)
- [x] production build succeeds
- [ ] manual: background the desktop tab, confirm `/api/buses` requests stop in
      DevTools Network, and that returning triggers one immediate refetch
- [ ] manual: toggle Buses off in the Lines tab, confirm `/api/buses` stops;
      toggle back on, confirm one immediate refetch
- [ ] manual: with Buses off, apply a line filter and confirm buses reappear and
      polling resumes
- [ ] manual: confirm the battery-saver row is gone on desktop, still present on
      a phone

**Not unit-tested**, deliberately: the repo has no DOM test environment and all
five existing test files are pure logic. Adding jsdom to cover a visibility flag
was not worth the dependency — flagging it rather than hiding it.

## Not in this PR

- Raising the Cloudflare edge TTL from 6 s to ~15 s (dashboard, zero code) — the
  single biggest remaining lever, since it lets concurrent viewers share one
  origin fetch.
- Shrinking the bus payload (6dp -> 5dp coordinates; `d`/`o` are per-trip
  constants resent every 15 s). Est. 60 KB -> ~38 KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012WAo3bLv7T9PAVYDb1hEtx
