### PR TITLE
feat: layer-derived data attribution + About tab, ODbL labelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,26 @@ implementation plan, roadmap.
 The "locate me" button uses your browser's geolocation only after you tap it (never on load).
 Your coordinates are used purely to recentre the map in your browser — they are never sent to
 the server, logged, or stored.
+
+## Data sources & licences
+
+**Powered by TfL Open Data.** Contains OS data © Crown copyright and database rights 2016
+and Geomni UK Map data © and database rights 2019. Used under the
+[TfL Open Data licence](https://tfl.gov.uk/corporate/terms-and-conditions/transport-data-service).
+
+Bus positions come from the [DfT Bus Open Data Service](https://www.bus-data.dft.gov.uk/)
+(SIRI-VM), used under the
+[Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/).
+Rail network geometry and the basemap are © [OpenStreetMap](https://www.openstreetmap.org/copyright)
+contributors (ODbL), basemap tiles by [Protomaps](https://protomaps.com). Tide gauges:
+Environment Agency (OGL v3). Ships: [aisstream.io](https://aisstream.io). Aircraft:
+[airplanes.live](https://airplanes.live) / [adsb.lol](https://adsb.lol). Rain radar:
+[RainViewer](https://www.rainviewer.com/). The in-app ℹ️ tab shows the credits that apply to
+each deployment's actual layer set.
+
+**Licensing:** the MIT licence in the repository root covers the code. The baked network
+geometry under `data/` is derived from OpenStreetMap and is licensed under the
+[ODbL v1.0](https://opendatacommons.org/licenses/odbl/1-0/) — see
+[`data/LICENSE-DATA.md`](data/LICENSE-DATA.md). *(Erratum, 11 Aug 2026: earlier revisions
+offered these files under MIT alongside the code; the OSM-derived data files were always
+ODbL and are now labelled correctly.)*

--- a/data/LICENSE-DATA.md
+++ b/data/LICENSE-DATA.md
@@ -1,0 +1,35 @@
+# Data licences
+
+The MIT licence in the repository root covers the **code** only. The baked
+data files in this directory carry the licences of the sources they were
+derived from:
+
+## OSM-derived files — ODbL v1.0
+
+The following files are derivative databases of OpenStreetMap data, produced
+by this repository's bake scripts (stitching, branch-splitting, resampling),
+and are licensed under the
+[Open Database License v1.0](https://opendatacommons.org/licenses/odbl/1-0/):
+
+- `branches/**`
+- `lines/**`
+- `stations/**`
+- `nr/**`
+- `dubai/**`
+
+© OpenStreetMap contributors. If you extract or build upon these files, the
+ODbL's share-alike terms apply to the resulting database.
+
+## TfL-derived content
+
+Stop sequences and line metadata baked from the TfL Unified API are used under
+the [TfL Open Data licence](https://tfl.gov.uk/corporate/terms-and-conditions/transport-data-service)
+(Powered by TfL Open Data; contains OS data © Crown copyright and database
+rights 2016 and Geomni UK Map data © and database rights 2019).
+
+## Runtime-learned data (not in git)
+
+Bus route geometry learned at runtime (`bus-routes/learned/`, gitignored) is
+derived from DfT Bus Open Data Service SIRI-VM GPS traces under the
+[Open Government Licence v3.0](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)
+— not from OpenStreetMap, so no ODbL obligations attach to it.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -91,6 +91,15 @@
       .legend-row.off .legend-swatch { background: #444 !important; }
       .legend-swatch { width: 14px; height: 5px; border-radius: 2px; flex: none; }
 
+      /* About tab: data sources, licences, acknowledgements */
+      .about-note {
+        padding: 5px 10px; font-size: 10.5px; line-height: 1.5; color: #9aa;
+        white-space: normal; overflow-y: auto;
+      }
+      .about-note a { color: #6ea8fe; text-decoration: none; }
+      .about-note a:hover { text-decoration: underline; }
+      .about-credit { margin-bottom: 5px; }
+
       /* Battery-saver preference row, pinned to the bottom of the Lines tab */
       .legend-saver { border-top: 1px solid #222; margin-top: 5px; padding-top: 3px; }
       .legend-saver-row { justify-content: space-between; }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -97,6 +97,21 @@ async function bootstrap(): Promise<void> {
   const basemapUrl =
     region.pmtilesUrl ?? (import.meta.env.VITE_PMTILES_URL as string | undefined) ?? '/london.pmtiles';
 
+  // Corner credit line, derived from the layer set rather than the city name —
+  // a deployment only names the licensors whose data it actually draws (TfL's
+  // terms require a visible "Powered by TfL Open Data"; Dubai must not show
+  // one). Kept short: the full licence wording lives in the panel's About tab
+  // and the README. OSM is already credited via the basemap source attribution.
+  const dataCredits = [
+    hasLayer('trainPositions') || hasLayer('stopArrivals')
+      ? '<a href="https://tfl.gov.uk/info-for/open-data-users/" target="_blank" rel="noopener">Powered by TfL Open Data</a>'
+      : null,
+    hasLayer('buses')
+      ? '<a href="https://www.bus-data.dft.gov.uk/" target="_blank" rel="noopener">DfT BODS</a>'
+      : null,
+    '<a href="https://github.com/pengrubin/london-live-2d" target="_blank" rel="noopener"><b>© PENG</b></a>',
+  ].filter((credit): credit is string => credit !== null);
+
   const map = new maplibregl.Map({
     container: 'app',
     style: {
@@ -119,10 +134,11 @@ async function bootstrap(): Promise<void> {
       [bounds[0][0], bounds[0][1]],
       [bounds[1][0], bounds[1][1]],
     ],
+    // No `compact` override: MapLibre expands the line on desktop widths and
+    // collapses to the ⓘ button on phones, which is the accepted attribution
+    // pattern for small screens.
     attributionControl: {
-      compact: true,
-      customAttribution:
-        '<a href="https://github.com/pengrubin" target="_blank"><b>© PENG</b></a>',
+      customAttribution: dataCredits,
     },
   });
   toastHost = map.getContainer();

--- a/frontend/src/ui/about.ts
+++ b/frontend/src/ui/about.ts
@@ -1,0 +1,116 @@
+// About / data-credits view for the control panel: what this map is, where
+// every layer's data comes from, and the licences that data arrives under.
+//
+// Sources are derived from the capabilities layer set (hasLayer) — the same
+// signal that decides whether a layer exists — so a deployment only credits
+// the feeds it actually draws: Dubai never claims TfL, London never hides it.
+// The map-corner attribution line stays short; this view carries the full
+// licence wording (TfL's required text, OGL, ODbL) and the acknowledgements.
+
+import { hasLayer } from '../region';
+
+const REPO_URL = 'https://github.com/pengrubin/london-live-2d';
+
+interface CreditEntry {
+  /** Show only when the deployment actually draws this data. */
+  readonly when: boolean;
+  readonly html: string;
+}
+
+function link(href: string, text: string): string {
+  return `<a href="${href}" target="_blank" rel="noopener">${text}</a>`;
+}
+
+function buildCredits(): CreditEntry[] {
+  const usesTfl =
+    hasLayer('trainPositions') ||
+    hasLayer('stopArrivals') ||
+    hasLayer('lineStatus') ||
+    hasLayer('jamCams') ||
+    hasLayer('roadDisruptions') ||
+    hasLayer('bikePoints');
+  return [
+    {
+      when: usesTfl,
+      html:
+        `${link('https://tfl.gov.uk/info-for/open-data-users/', 'Powered by TfL Open Data')}. ` +
+        'Contains OS data © Crown copyright and database rights 2016 ' +
+        'and Geomni UK Map data © and database rights 2019.',
+    },
+    {
+      when: hasLayer('buses'),
+      html:
+        `Bus positions: ${link('https://www.bus-data.dft.gov.uk/', 'DfT Bus Open Data Service')} ` +
+        `(${link('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/', 'OGL v3')}).`,
+    },
+    {
+      when: hasLayer('nationalRail'),
+      html: 'National Rail departures: Darwin, © Rail Delivery Group.',
+    },
+    {
+      when: true,
+      html:
+        `Network geometry &amp; basemap: © ${link('https://www.openstreetmap.org/copyright', 'OpenStreetMap')} contributors ` +
+        `(${link('https://opendatacommons.org/licenses/odbl/', 'ODbL')}), ` +
+        `tiles by ${link('https://protomaps.com', 'Protomaps')}.`,
+    },
+    {
+      when: hasLayer('tideGauges'),
+      html: `Tide gauges: ${link('https://environment.data.gov.uk/', 'Environment Agency')} (OGL v3).`,
+    },
+    {
+      when: hasLayer('vessels'),
+      html: `Ship positions: ${link('https://aisstream.io', 'aisstream.io')}.`,
+    },
+    {
+      when: hasLayer('aircraft'),
+      html:
+        `Aircraft: ${link('https://airplanes.live', 'airplanes.live')} / ` +
+        `${link('https://adsb.lol', 'adsb.lol')}.`,
+    },
+    {
+      when: hasLayer('rainRadar'),
+      html: `Rain radar: ${link('https://www.rainviewer.com/', 'RainViewer')}.`,
+    },
+    {
+      when: hasLayer('bikeStations'),
+      html: 'Bike share: operator GBFS feed.',
+    },
+  ];
+}
+
+/** Build the About view into `container` (a control-panel section). */
+export function addAbout(container: HTMLElement): void {
+  const intro = document.createElement('div');
+  intro.className = 'about-note';
+  intro.innerHTML =
+    'A real-time 2D transport map, estimated in your browser from open data. ' +
+    `Source on ${link(REPO_URL, 'GitHub')} — code MIT, baked network geometry ODbL.`;
+
+  const sourcesHeader = document.createElement('div');
+  sourcesHeader.className = 'legend-group';
+  sourcesHeader.textContent = 'Data sources';
+
+  const sources = document.createElement('div');
+  sources.className = 'about-note';
+  sources.innerHTML = buildCredits()
+    .filter((entry) => entry.when)
+    .map((entry) => `<div class="about-credit">${entry.html}</div>`)
+    .join('');
+
+  container.append(intro, sourcesHeader, sources);
+
+  // The countdown→position primitive behind the train layer is Zone One's idea;
+  // this project's contribution is the per-mode hardening on top of it.
+  if (hasLayer('trainPositions')) {
+    const ackHeader = document.createElement('div');
+    ackHeader.className = 'legend-group';
+    ackHeader.textContent = 'Acknowledgements';
+    const ack = document.createElement('div');
+    ack.className = 'about-note';
+    ack.innerHTML =
+      'Train positions are inferred from arrival countdowns — an approach ' +
+      `pioneered by ${link('https://london.jamespotter.dev', 'Zone One')}.`;
+    container.append(ackHeader, ack);
+  }
+}

--- a/frontend/src/ui/control-panel.ts
+++ b/frontend/src/ui/control-panel.ts
@@ -1,13 +1,15 @@
 // Shared floating control panel (docks top-left): one collapsible shell with a
-// row of top-level tabs that swap the body between three views —
+// row of top-level tabs that swap the body between four views —
 //   🏆 Board  — the leaderboard (leaderboard.ts)
 //   🚌 Filter — the bus line filter (bus-filter.ts)
 //   🗺 Lines  — the lines legend + overlays (legend.ts)
+//   ℹ️ About  — data sources, licences, acknowledgements (about.ts)
 // Merging the former two separate panels (leaderboard top-left + legend
 // top-right) into one frees screen space on phones and leaves the top-right
 // corner clear for MapLibre's zoom + geolocate controls.
 
 import type { Map as MaplibreMap } from 'maplibre-gl';
+import { addAbout } from './about';
 import { addLeaderboard, type VehicleLocator } from './leaderboard';
 import { addBusFilter } from './bus-filter';
 import { addLegend, type LegendLine, type OverlayToggle } from './legend';
@@ -17,11 +19,12 @@ import { hasLayer } from '../region';
 // the header expands it.
 const MOBILE_MEDIA_QUERY = '(max-width: 640px)';
 
-type TabKey = 'board' | 'filter' | 'lines';
+type TabKey = 'board' | 'filter' | 'lines' | 'about';
 const ALL_TABS: { key: TabKey; label: string }[] = [
   { key: 'board', label: '🏆 Board' },
   { key: 'filter', label: '🚌 Filter' },
   { key: 'lines', label: '🗺 Lines' },
+  { key: 'about', label: 'ℹ️' },
 ];
 
 export function addControlPanel(
@@ -85,6 +88,8 @@ export function addControlPanel(
   if (filterSection) addBusFilter(filterSection, map);
   const linesSection = sectionByKey.get('lines');
   if (linesSection) addLegend(linesSection, map, lines, overlays);
+  const aboutSection = sectionByKey.get('about');
+  if (aboutSection) addAbout(aboutSection);
 
   activate(defaultTab);
   if (window.matchMedia(MOBILE_MEDIA_QUERY).matches) panel.classList.add('collapsed');


### PR DESCRIPTION
## Why

Two compliance gaps, both cheap to close and both worth closing **before the TfL seminar**:

1. The map corner credited only `© PENG`. TfL's [open data licence](https://tfl.gov.uk/corporate/terms-and-conditions/transport-data-service) requires a visible **Powered by TfL Open Data** (+ the OS Crown copyright / Geomni sentence), and nothing in the site or README carried it. This is the exact surface (attribution / implied endorsement) on which TfL has acted against hobby maps before (traintimes.org.uk, 2017).
2. The 87 git-tracked files under `data/` (branches/lines/stations/nr/dubai) are **ODbL derivative databases of OSM** baked by our own scripts, but the repo offered them under the root MIT licence — a licence we have no right to grant on them.

## What

- **Corner line, derived from the layer set, never the city name** (matches the capabilities philosophy): London shows `Powered by TfL Open Data · DfT BODS · © PENG`; Dubai automatically shows only what it draws. No `compact` override → expanded on desktop, ⓘ on phones (the accepted small-screen pattern). OSM stays credited via the existing basemap source attribution.
- **New ℹ️ About tab** in the control panel: full licence wording per source (TfL incl. required OS/Geomni text, BODS/OGL, OSM/ODbL, Protomaps, EA, aisstream, airplanes.live/adsb.lol, RainViewer, GBFS), each gated by `hasLayer`, plus the **Zone One acknowledgement** for the countdown→position idea (mirrors the credit already in `position-inference.ts`).
- **`data/LICENSE-DATA.md`**: puts the OSM-derived baked files under ODbL v1.0; explicitly notes runtime-learned bus geometry is BODS/OGL-derived (no ODbL share-alike attaches). README gains a *Data sources & licences* section with a dated erratum.

## Notes

- Branched from `origin/main` (4c54f00). Local unpushed frontend commits (battery-saver etc.) touch `index.html`/`control-panel.ts` areas — a rebase may be needed; conflicts should be trivial.
- Follow-up (not in this PR, needs repo owner): a short note to the 2 existing forks about the data-licence erratum.

## Test plan

- [x] `tsc --noEmit` clean; 79 frontend tests pass; `vite build` succeeds
- [ ] Visual: desktop shows the credit line bottom-right; phone collapses to ⓘ
- [ ] Dubai deployment shows no TfL credit (layer-gated)
- [ ] About tab renders all sources on London