### PR TITLE
fix: AIS error handler crashes the process on failed connect (Railway crash 2026-08-22)

### DIFF
--- a/backend/src/ais-client.test.ts
+++ b/backend/src/ais-client.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AisClient } from './ais-client';
+
+// Mimics the undici behaviour that crashed production (2026-08-22): calling
+// close() on a socket that is still CONNECTING "fails the connection", which
+// synchronously fires 'error' again. An error handler that responds to
+// 'error' by closing therefore recurses until the stack overflows.
+class FakeWebSocket extends EventTarget {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static instances: FakeWebSocket[] = [];
+
+  readyState: number = FakeWebSocket.CONNECTING;
+  closeCalls = 0;
+
+  constructor(_url: string) {
+    super();
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(_data: string): void {}
+
+  close(): void {
+    this.closeCalls += 1;
+    if (this.readyState === FakeWebSocket.CONNECTING) {
+      this.dispatchEvent(new Event('error'));
+      return;
+    }
+    this.readyState = FakeWebSocket.CLOSED;
+    this.dispatchEvent(new Event('close'));
+  }
+}
+
+const BBOX = { minLat: 51.3, minLon: -0.55, maxLat: 51.62, maxLon: 0.45 };
+
+const instance = (i: number): FakeWebSocket => {
+  const ws = FakeWebSocket.instances[i];
+  if (!ws) throw new Error(`no FakeWebSocket instance ${i}`);
+  return ws;
+};
+
+describe('AisClient error handling', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('does not close a CONNECTING socket on error (stack-overflow regression)', () => {
+    const client = new AisClient('key', BBOX, () => {});
+    client.start();
+
+    const ws = instance(0);
+    expect(ws.readyState).toBe(FakeWebSocket.CONNECTING);
+
+    // With the old handler this recursed FakeWebSocket.close ↔ 'error'
+    // until RangeError: Maximum call stack size exceeded.
+    ws.dispatchEvent(new Event('error'));
+
+    expect(ws.closeCalls).toBe(0);
+    client.stop();
+  });
+
+  it('still closes an OPEN socket on error', () => {
+    const client = new AisClient('key', BBOX, () => {});
+    client.start();
+
+    const ws = instance(0);
+    ws.readyState = FakeWebSocket.OPEN;
+    ws.dispatchEvent(new Event('error'));
+
+    expect(ws.closeCalls).toBe(1);
+    client.stop();
+  });
+
+  it('reconnects after a failed connect via the close event', () => {
+    vi.useFakeTimers();
+    const client = new AisClient('key', BBOX, () => {});
+    client.start();
+
+    // A failed connect fires 'error' then 'close' on its own (WHATWG order).
+    const ws = instance(0);
+    ws.dispatchEvent(new Event('error'));
+    ws.dispatchEvent(new Event('close'));
+
+    vi.advanceTimersByTime(15_000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    client.stop();
+  });
+});

--- a/backend/src/ais-client.ts
+++ b/backend/src/ais-client.ts
@@ -114,7 +114,12 @@ export class AisClient {
       this.scheduleReconnect();
     });
     this.socket.addEventListener('error', () => {
-      this.socket?.close();
+      // Never close() a socket that hasn't finished connecting: undici treats
+      // close-during-CONNECTING as "fail the connection", which fires 'error'
+      // again — a synchronous mutual recursion that overflows the stack and
+      // kills the process. A failed connect fires 'close' by itself, so the
+      // reconnect in the close handler still runs.
+      if (this.socket?.readyState === WebSocket.OPEN) this.socket.close();
     });
   }
 


### PR DESCRIPTION
## What happened

The dubai deployment crashed on 2026-08-22 19:34 with `RangeError: Maximum call stack size exceeded`. The stack trace loops through `ais-client.ts:117` ↔ undici's `failWebsocketConnection`.

## Root cause

```ts
this.socket.addEventListener('error', () => {
  this.socket?.close();   // ← the bug
});
```

Per the WHATWG spec, calling `close()` on a socket that is still **CONNECTING** means "fail the connection" — and undici fails a connection by firing `error` again, synchronously. Handler and undici call each other until the stack overflows; the uncaught `RangeError` kills the process.

Trigger sequence: aisstream.io dropped the stream → `close` → reconnect after 15 s → that connect attempt was **refused before the handshake completed** → `error` on a CONNECTING socket → recursion. This is why the 2026-08-11 aisstream outage (connected fine, zero messages) never crashed anything: the recursion needs a *failed connect*, not a silent stream. **The London deployment runs the same code and has the same exposure.**

## Fix

Only close sockets that finished connecting:

```ts
if (this.socket?.readyState === WebSocket.OPEN) this.socket.close();
```

A failed connect fires `close` by itself (WHATWG event order: error → close), so the reconnect in the close handler still runs — verified by test.

## Tests

New `ais-client.test.ts` with a fake WebSocket that mirrors undici's close-during-CONNECTING behaviour:

- **Regression**: `error` while CONNECTING must not call `close()` — against the old handler this test reproduces the exact production `RangeError` (verified red before the fix, green after)
- `error` while OPEN still closes the socket (old behaviour preserved)
- After a failed connect, the `close` event still schedules the 15 s reconnect

`npx vitest run`: 25/25 passed · `npm run typecheck`: clean

## Deploy note

Until this merges, a Railway **Restart Deployment** brings dubai back up, but if aisstream refuses the connect again it can crash again ~15 s after the stream first drops. Merging + redeploy (both regions) removes the crash entirely.