### PR TITLE
feat: permanent TfL line-status archive (tube-status recorder)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -22,6 +22,7 @@ import { LearnerScheduler } from './learner-scheduler';
 import { loadNrGraph, makeCachedNrBoardFetcher, NrSampler } from './nr-sampler';
 import { RateBudget } from './rate-budget';
 import { RollupWriter } from './rollup-writer';
+import { TubeStatusRecorder } from './tube-status-recorder';
 import { TraceWriter } from './trace-writer';
 import { registerArrivalsRoute } from './routes/arrivals';
 import { registerCapabilitiesRoute } from './routes/capabilities';
@@ -151,6 +152,16 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
     app.get('/api/buses', () => []);
   }
   registerBusRoutesRoute(app, join(busDataDir, 'bus-routes', 'learned'));
+
+  // Permanent line-status archive — TfL publishes no history, so we keep our
+  // own from the day this ships. A few MB per year; never pruned.
+  if (config.tflAppKey) {
+    const tubeStatus = new TubeStatusRecorder(busDataDir, config.tflAppKey, (msg) =>
+      app.log.info(msg),
+    );
+    tubeStatus.start();
+    app.addHook('onClose', () => tubeStatus.stop());
+  }
 
   // Docked bike share (optional feature — needs a GBFS discovery URL). GBFS is
   // an open standard, so this is not specific to any city or operator.

--- a/backend/src/tfl-client.ts
+++ b/backend/src/tfl-client.ts
@@ -44,6 +44,15 @@ export async function fetchLineStatus(
   return fetchTfl(`/Line/${lineIds.join(',')}/Status`, appKey, timeoutMs);
 }
 
+/** Service status for every line of the given modes (e.g. all tube lines). */
+export async function fetchLineStatusByModes(
+  modes: readonly string[],
+  appKey: string,
+  timeoutMs: number = UPSTREAM_TIMEOUT_MS,
+): Promise<TflResponse> {
+  return fetchTfl(`/Line/Mode/${modes.join(',')}/Status`, appKey, timeoutMs);
+}
+
 /** Full stop point detail (zones, facilities, lines) — a large object. */
 export async function fetchStopDetail(
   naptanId: string,

--- a/backend/src/tube-status-recorder.test.ts
+++ b/backend/src/tube-status-recorder.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { compactStatus, shouldWrite } from './tube-status-recorder';
+
+const GOOD_SERVICE = {
+  id: 'victoria',
+  lineStatuses: [{ statusSeverity: 10, statusSeverityDescription: 'Good Service' }],
+};
+
+const PART_SUSPENDED = {
+  id: 'district',
+  lineStatuses: [
+    {
+      statusSeverity: 4,
+      statusSeverityDescription: 'Part Suspended',
+      reason: 'DISTRICT LINE: No service between Tower Hill and Barking due to a signal failure.',
+    },
+    { statusSeverity: 9, statusSeverityDescription: 'Minor Delays' },
+  ],
+};
+
+describe('compactStatus', () => {
+  it('keeps every concurrent status and its reason for a disrupted line', () => {
+    const lines = compactStatus([PART_SUSPENDED]);
+
+    expect(lines).toHaveLength(1);
+    expect(lines?.[0]?.id).toBe('district');
+    expect(lines?.[0]?.st).toHaveLength(2);
+    expect(lines?.[0]?.st[0]?.s).toBe(4);
+    expect(lines?.[0]?.st[0]?.r).toContain('signal failure');
+    expect(lines?.[0]?.st[1]?.s).toBe(9);
+    expect(lines?.[0]?.st[1]?.r).toBeUndefined();
+  });
+
+  it('sorts lines by id so serialized snapshots compare stably', () => {
+    const lines = compactStatus([PART_SUSPENDED, GOOD_SERVICE]);
+
+    expect(lines?.map((l) => l.id)).toEqual(['district', 'victoria']);
+  });
+
+  it('returns null for non-array payloads (error objects, HTML gateways)', () => {
+    expect(compactStatus({ httpStatusCode: 429, message: 'rate limited' })).toBeNull();
+    expect(compactStatus('<html>Bad Gateway</html>')).toBeNull();
+    expect(compactStatus(null)).toBeNull();
+  });
+
+  it('drops malformed entries but keeps valid ones', () => {
+    const lines = compactStatus([
+      GOOD_SERVICE,
+      { lineStatuses: [{ statusSeverity: 10 }] }, // no id
+      { id: 'bakerloo' }, // no statuses
+      { id: 'central', lineStatuses: [{ statusSeverityDescription: 'no code' }] },
+      null,
+    ]);
+
+    expect(lines?.map((l) => l.id)).toEqual(['victoria']);
+  });
+
+  it('returns null when nothing valid remains', () => {
+    expect(compactStatus([{ id: 'x' }, null])).toBeNull();
+    expect(compactStatus([])).toBeNull();
+  });
+});
+
+describe('shouldWrite', () => {
+  const T0 = 1_755_900_000_000;
+
+  it('always writes the first snapshot of a file', () => {
+    expect(shouldWrite(null, '[]', null, T0)).toBe(true);
+  });
+
+  it('writes when the status changed', () => {
+    expect(shouldWrite('[a]', '[b]', T0, T0 + 120_000)).toBe(true);
+  });
+
+  it('skips an unchanged status inside the heartbeat window', () => {
+    expect(shouldWrite('[a]', '[a]', T0, T0 + 120_000)).toBe(false);
+  });
+
+  it('writes an unchanged status once the heartbeat interval elapses', () => {
+    expect(shouldWrite('[a]', '[a]', T0, T0 + 30 * 60_000)).toBe(true);
+  });
+});

--- a/backend/src/tube-status-recorder.ts
+++ b/backend/src/tube-status-recorder.ts
@@ -1,0 +1,158 @@
+// Permanent archive of TfL line status. TfL's Unified API only serves the
+// present moment — there is no historical endpoint — so any analysis of how
+// disruptions start, spread, and recover needs its own recording, started as
+// early as possible. Snapshots are appended to <base>/tube-status/YYYY-MM-DD.jsonl
+// (UTC days), deduplicated against the previous snapshot so a quiet network
+// costs a handful of lines per day. Nothing here is ever pruned: a full year
+// of status history is a few MB.
+
+import { appendFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fetchLineStatusByModes } from './tfl-client';
+
+const POLL_INTERVAL_MS = 2 * 60_000;
+/** Unchanged status is still written this often, so gaps mean "recorder down". */
+const HEARTBEAT_INTERVAL_MS = 30 * 60_000;
+const STARTUP_DELAY_MS = 10_000;
+const STATUS_MODES = ['tube', 'overground', 'dlr', 'elizabeth-line', 'tram'] as const;
+const SUBDIR = 'tube-status';
+
+/** One concurrent status on a line (a line can carry several at once). */
+interface LineStatusEntry {
+  /** TfL statusSeverity code — 10 is Good Service, lower is worse. */
+  s: number;
+  /** Human description, e.g. "Minor Delays". */
+  d: string;
+  /** Free-text reason; only present when TfL provides one. */
+  r?: string;
+}
+
+export interface LineSnapshot {
+  id: string;
+  st: LineStatusEntry[];
+}
+
+interface TflLineStatus {
+  statusSeverity?: number;
+  statusSeverityDescription?: string;
+  reason?: string;
+}
+
+interface TflLine {
+  id?: string;
+  lineStatuses?: TflLineStatus[];
+}
+
+/**
+ * Reduces a TfL /Line/Mode/.../Status body to the compact archived form.
+ * Returns null when the body is not the expected array (error payloads,
+ * HTML gateways, etc.) — never trust upstream data.
+ */
+export function compactStatus(body: unknown): LineSnapshot[] | null {
+  if (!Array.isArray(body)) return null;
+  const lines: LineSnapshot[] = [];
+  for (const raw of body as TflLine[]) {
+    if (typeof raw?.id !== 'string' || raw.id === '') continue;
+    const statuses: LineStatusEntry[] = [];
+    for (const status of raw.lineStatuses ?? []) {
+      if (typeof status?.statusSeverity !== 'number') continue;
+      const entry: LineStatusEntry = {
+        s: status.statusSeverity,
+        d: typeof status.statusSeverityDescription === 'string' ? status.statusSeverityDescription : '',
+      };
+      const reason = typeof status.reason === 'string' ? status.reason.trim() : '';
+      if (reason !== '') entry.r = reason;
+      statuses.push(entry);
+    }
+    if (statuses.length === 0) continue;
+    lines.push({ id: raw.id, st: statuses });
+  }
+  if (lines.length === 0) return null;
+  lines.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return lines;
+}
+
+/**
+ * A snapshot is written when the status changed, when the heartbeat interval
+ * elapsed, or when nothing has been written yet (fresh start / new day file).
+ */
+export function shouldWrite(
+  prevSerialized: string | null,
+  nextSerialized: string,
+  lastWriteMs: number | null,
+  nowMs: number,
+): boolean {
+  if (prevSerialized === null || lastWriteMs === null) return true;
+  if (nextSerialized !== prevSerialized) return true;
+  return nowMs - lastWriteMs >= HEARTBEAT_INTERVAL_MS;
+}
+
+export class TubeStatusRecorder {
+  private readonly dir: string;
+  private readonly appKey: string;
+  private readonly log: (msg: string) => void;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private startTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+  /** Serialized `lines` of the last written snapshot, per current day file. */
+  private lastSerialized: string | null = null;
+  private lastWriteMs: number | null = null;
+  private lastDay: string | null = null;
+
+  constructor(baseDir: string, appKey: string, log: (msg: string) => void) {
+    this.dir = join(baseDir, SUBDIR);
+    this.appKey = appKey;
+    this.log = log;
+  }
+
+  start(): void {
+    this.startTimer = setTimeout(() => {
+      void this.poll();
+      this.timer = setInterval(() => void this.poll(), POLL_INTERVAL_MS);
+      this.timer.unref();
+    }, STARTUP_DELAY_MS);
+    this.startTimer.unref();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.startTimer) clearTimeout(this.startTimer);
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  private async poll(): Promise<void> {
+    if (this.stopped) return;
+    try {
+      const response = await fetchLineStatusByModes(STATUS_MODES, this.appKey);
+      if (response.status !== 200) {
+        this.log(`tube-status: TfL returned ${response.status}, skipping snapshot`);
+        return;
+      }
+      const lines = compactStatus(response.body);
+      if (lines === null) {
+        this.log('tube-status: unrecognised TfL payload, skipping snapshot');
+        return;
+      }
+      await this.record(lines, Date.now());
+    } catch (err) {
+      this.log(`tube-status: poll failed: ${String(err)}`);
+    }
+  }
+
+  private async record(lines: LineSnapshot[], nowMs: number): Promise<void> {
+    const day = new Date(nowMs).toISOString().slice(0, 10);
+    if (day !== this.lastDay) {
+      // Each day file opens with an unconditional snapshot so it reads standalone.
+      this.lastDay = day;
+      this.lastSerialized = null;
+      this.lastWriteMs = null;
+    }
+    const serialized = JSON.stringify(lines);
+    if (!shouldWrite(this.lastSerialized, serialized, this.lastWriteMs, nowMs)) return;
+    await mkdir(this.dir, { recursive: true });
+    const line = `{"t":${Math.floor(nowMs / 1000)},"lines":${serialized}}\n`;
+    await appendFile(join(this.dir, `${day}.jsonl`), line, 'utf8');
+    this.lastSerialized = serialized;
+    this.lastWriteMs = nowMs;
+  }
+}


### PR DESCRIPTION
## Why

TfL's Unified API only answers "what is the status *now*" — there is **no historical endpoint**. Any analysis of how disruptions start, spread, and recover (onset patterns, recovery-time distributions, whether measured headways degrade *before* the official status flips) requires a self-kept archive. Same lesson as the trace rollups (#10): **every day this isn't deployed is a day of history permanently lost**, so this ships ahead of the analysis design work.

## What

- `backend/src/tube-status-recorder.ts` — polls `/Line/Mode/tube,overground,dlr,elizabeth-line,tram/Status` every 2 min (one extra TfL request per 2 min, negligible against the existing budget) and appends compact snapshots to `<busDataDir>/tube-status/YYYY-MM-DD.jsonl` (UTC days), e.g.:

  ```json
  {"t":1755900000,"lines":[{"id":"district","st":[{"s":4,"d":"Part Suspended","r":"DISTRICT LINE: No service between …"}]},{"id":"victoria","st":[{"s":10,"d":"Good Service"}]}]}
  ```

- **Dedup + heartbeat**: identical consecutive snapshots are skipped; an unchanged network is still written every 30 min so a gap in the file always means "recorder was down", never "nothing changed". Each day file opens with an unconditional snapshot so it reads standalone.
- **Never pruned** — that is the point. A quiet day is ~50 lines; a full year is a few MB on the volume (raw bus traces are 2 GB for 7 days, for scale).
- **Capability-gated**: starts only when `tflAppKey` is configured, so Dubai is untouched.
- `fetchLineStatusByModes` added to `tfl-client.ts` alongside the existing status-by-lines fetcher.
- Upstream bodies are validated (`compactStatus` returns null on error payloads / HTML gateways); a failed poll logs and skips, never kills the loop. No egress impact (writes to the volume only), no vehicle or user data involved.

## Tests

9 new tests (`tube-status-recorder.test.ts`): concurrent-status + reason preservation, stable sort for dedup comparison, error-payload rejection, malformed-entry tolerance, and the write/skip/heartbeat decision table.

`npx vitest run`: 40/40 passed · `npm run typecheck`: clean

## Verify after merge

`tube-status/2026-08-22.jsonl` appears on the London volume within ~15 min of deploy; Dubai logs contain no `tube-status` lines.