### PR TITLE
feat: token-guarded bulk export for local analysis (traces, rollups, tube status)

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -45,6 +45,7 @@ import {
 } from './routes/external';
 import { registerAircraftPhotoRoute } from './routes/aircraft-photo';
 import { registerBusRoutesRoute } from './routes/bus-routes';
+import { registerDataExportRoute } from './routes/data-export';
 import { registerShipPhotoRoute } from './routes/ship-photo';
 
 /** Repo layout anchors — data/ and scripts/ sit beside backend/. */
@@ -151,6 +152,12 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
     app.get('/api/buses', () => []);
   }
   registerBusRoutesRoute(app, join(busDataDir, 'bus-routes', 'learned'));
+
+  // Token-guarded bulk export of the day-partitioned archives (traces, rollups,
+  // tube status) for local analysis. Off unless ADMIN_EXPORT_TOKEN is set.
+  if (config.adminExportToken) {
+    registerDataExportRoute(app, busDataDir, config.adminExportToken);
+  }
 
   // Docked bike share (optional feature — needs a GBFS discovery URL). GBFS is
   // an open standard, so this is not specific to any city or operator.

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -22,6 +22,7 @@ import { LearnerScheduler } from './learner-scheduler';
 import { loadNrGraph, makeCachedNrBoardFetcher, NrSampler } from './nr-sampler';
 import { RateBudget } from './rate-budget';
 import { RollupWriter } from './rollup-writer';
+import { TubeStatusRecorder } from './tube-status-recorder';
 import { TraceWriter } from './trace-writer';
 import { registerArrivalsRoute } from './routes/arrivals';
 import { registerCapabilitiesRoute } from './routes/capabilities';
@@ -151,6 +152,16 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
     app.get('/api/buses', () => []);
   }
   registerBusRoutesRoute(app, join(busDataDir, 'bus-routes', 'learned'));
+
+  // Permanent line-status archive — TfL publishes no history, so we keep our
+  // own from the day this ships. A few MB per year; never pruned.
+  if (config.tflAppKey) {
+    const tubeStatus = new TubeStatusRecorder(busDataDir, config.tflAppKey, (msg) =>
+      app.log.info(msg),
+    );
+    tubeStatus.start();
+    app.addHook('onClose', () => tubeStatus.stop());
+  }
 
   // Docked bike share (optional feature — needs a GBFS discovery URL). GBFS is
   // an open standard, so this is not specific to any city or operator.

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -32,6 +32,12 @@ export interface AppConfig {
    * state survives redeploys; unset locally, where state stays under data/.
    */
   readonly persistDir: string | undefined;
+  /**
+   * Bearer token for the bulk data-export endpoints (/api/export/*). Raw traces
+   * contain vehicle IDs, so this must stay private; the routes are simply not
+   * registered when it is unset.
+   */
+  readonly adminExportToken: string | undefined;
   /** The geography this deployment serves — London unless REGION_* overrides it. */
   readonly region: RegionConfig;
 }
@@ -182,6 +188,8 @@ export function loadConfig(): AppConfig {
   const bodsApiKey = readEnv('BODS_API_KEY');
   const gbfsUrl = readEnv('GBFS_URL');
   const persistDir = readEnv('PERSIST_DIR');
+  const rawExportToken = readEnv('ADMIN_EXPORT_TOKEN');
+  const adminExportToken = rawExportToken === '' ? undefined : rawExportToken;
   const region = loadRegion(readEnv);
 
   return {
@@ -193,6 +201,7 @@ export function loadConfig(): AppConfig {
     bodsApiKey,
     gbfsUrl,
     persistDir,
+    adminExportToken,
     region,
   };
 }

--- a/backend/src/routes/data-export.test.ts
+++ b/backend/src/routes/data-export.test.ts
@@ -1,0 +1,89 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { registerDataExportRoute } from './data-export';
+
+const TOKEN = 'test-export-token';
+const AUTH = { authorization: `Bearer ${TOKEN}` };
+
+describe('data export routes', () => {
+  let app: FastifyInstance;
+  let baseDir: string;
+
+  beforeEach(async () => {
+    baseDir = await mkdtemp(join(tmpdir(), 'export-test-'));
+    await mkdir(join(baseDir, 'bus-traces'), { recursive: true });
+    await writeFile(
+      join(baseDir, 'bus-traces', '2026-08-20.jsonl'),
+      '{"k":"TFLO:88:outbound","i":"V1","x":-0.1,"y":51.5,"t":1755640000}\n',
+    );
+    await writeFile(join(baseDir, 'bus-traces', 'not-a-day.jsonl'), '{}\n');
+    app = Fastify();
+    registerDataExportRoute(app, baseDir, TOKEN);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await rm(baseDir, { recursive: true, force: true });
+  });
+
+  it('rejects a missing token with 401', async () => {
+    const res = await app.inject({ url: '/api/export/bus-traces' });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects a wrong token with 401', async () => {
+    const res = await app.inject({
+      url: '/api/export/bus-traces/2026-08-20',
+      headers: { authorization: 'Bearer wrong' },
+    });
+
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('lists only well-formed day files for a dataset', async () => {
+    const res = await app.inject({ url: '/api/export/bus-traces', headers: AUTH });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(['2026-08-20']);
+  });
+
+  it('returns an empty list for a dataset with no directory yet', async () => {
+    const res = await app.inject({ url: '/api/export/tube-status', headers: AUTH });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([]);
+  });
+
+  it('rejects an unknown dataset with 400', async () => {
+    const res = await app.inject({ url: '/api/export/learned-routes', headers: AUTH });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('rejects a malformed day (path traversal shape) with 400', async () => {
+    const res = await app.inject({
+      url: '/api/export/bus-traces/..%2F..%2Fsecrets',
+      headers: AUTH,
+    });
+
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('returns 404 for a day with no file', async () => {
+    const res = await app.inject({ url: '/api/export/bus-traces/2026-08-19', headers: AUTH });
+
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('streams the day file back verbatim', async () => {
+    const res = await app.inject({ url: '/api/export/bus-traces/2026-08-20', headers: AUTH });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toContain('application/x-ndjson');
+    expect(res.body).toContain('"k":"TFLO:88:outbound"');
+  });
+});

--- a/backend/src/routes/data-export.ts
+++ b/backend/src/routes/data-export.ts
@@ -1,0 +1,87 @@
+// One-off bulk export of runtime-collected datasets for local analysis.
+//
+//   GET /api/export/:dataset        → ["2026-08-16", …] available UTC days
+//   GET /api/export/:dataset/:day   → that day's file, streamed
+//
+// Datasets are a fixed whitelist of the day-partitioned archives under the
+// persist base dir. Everything is guarded by ADMIN_EXPORT_TOKEN (Bearer): the
+// raw traces contain vehicle IDs, which are fine to analyse privately but are
+// never published — so this must never be an open endpoint. When the token is
+// unset the routes are not registered at all. Streaming keeps memory flat even
+// for multi-hundred-MB trace days; egress is a deliberate one-off cost.
+
+import { createReadStream } from 'node:fs';
+import { readdir, stat } from 'node:fs/promises';
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { join } from 'node:path';
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+const DAY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+interface DatasetSpec {
+  readonly dir: string;
+  readonly ext: '.jsonl' | '.json';
+  readonly contentType: string;
+}
+
+const DATASETS: Readonly<Record<string, DatasetSpec>> = {
+  'bus-traces': { dir: 'bus-traces', ext: '.jsonl', contentType: 'application/x-ndjson' },
+  'bus-rollups': { dir: 'bus-rollups', ext: '.json', contentType: 'application/json' },
+  'tube-status': { dir: 'tube-status', ext: '.jsonl', contentType: 'application/x-ndjson' },
+};
+
+/** Constant-time bearer-token check; hashing first equalises lengths. */
+function isAuthorized(header: string | undefined, token: string): boolean {
+  if (!header?.startsWith('Bearer ')) return false;
+  const presented = createHash('sha256').update(header.slice('Bearer '.length)).digest();
+  const expected = createHash('sha256').update(token).digest();
+  return timingSafeEqual(presented, expected);
+}
+
+export function registerDataExportRoute(
+  app: FastifyInstance,
+  baseDir: string,
+  token: string,
+): void {
+  const guard = (req: FastifyRequest, reply: FastifyReply): boolean => {
+    if (isAuthorized(req.headers.authorization, token)) return true;
+    void reply.code(401).send({ error: 'missing or invalid token' });
+    return false;
+  };
+
+  app.get<{ Params: { dataset: string } }>('/api/export/:dataset', async (req, reply) => {
+    if (!guard(req, reply)) return reply;
+    const spec = DATASETS[req.params.dataset];
+    if (!spec) return reply.code(400).send({ error: 'unknown dataset' });
+    try {
+      const names = await readdir(join(baseDir, spec.dir));
+      const days = names
+        .filter((n) => n.endsWith(spec.ext) && DAY_RE.test(n.slice(0, -spec.ext.length)))
+        .map((n) => n.slice(0, -spec.ext.length))
+        .sort();
+      return await reply.send(days);
+    } catch {
+      return reply.send([]); // dataset directory not created yet — nothing recorded
+    }
+  });
+
+  app.get<{ Params: { dataset: string; day: string } }>(
+    '/api/export/:dataset/:day',
+    async (req, reply) => {
+      if (!guard(req, reply)) return reply;
+      const spec = DATASETS[req.params.dataset];
+      if (!spec) return reply.code(400).send({ error: 'unknown dataset' });
+      if (!DAY_RE.test(req.params.day)) {
+        return reply.code(400).send({ error: 'day must be YYYY-MM-DD' });
+      }
+      const filePath = join(baseDir, spec.dir, `${req.params.day}${spec.ext}`);
+      try {
+        const info = await stat(filePath);
+        if (!info.isFile()) return await reply.code(404).send({ error: 'no such day' });
+      } catch {
+        return reply.code(404).send({ error: 'no such day' });
+      }
+      return reply.header('content-type', spec.contentType).send(createReadStream(filePath));
+    },
+  );
+}

--- a/backend/src/tfl-client.ts
+++ b/backend/src/tfl-client.ts
@@ -44,6 +44,15 @@ export async function fetchLineStatus(
   return fetchTfl(`/Line/${lineIds.join(',')}/Status`, appKey, timeoutMs);
 }
 
+/** Service status for every line of the given modes (e.g. all tube lines). */
+export async function fetchLineStatusByModes(
+  modes: readonly string[],
+  appKey: string,
+  timeoutMs: number = UPSTREAM_TIMEOUT_MS,
+): Promise<TflResponse> {
+  return fetchTfl(`/Line/Mode/${modes.join(',')}/Status`, appKey, timeoutMs);
+}
+
 /** Full stop point detail (zones, facilities, lines) — a large object. */
 export async function fetchStopDetail(
   naptanId: string,

--- a/backend/src/tube-status-recorder.test.ts
+++ b/backend/src/tube-status-recorder.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { compactStatus, shouldWrite } from './tube-status-recorder';
+
+const GOOD_SERVICE = {
+  id: 'victoria',
+  lineStatuses: [{ statusSeverity: 10, statusSeverityDescription: 'Good Service' }],
+};
+
+const PART_SUSPENDED = {
+  id: 'district',
+  lineStatuses: [
+    {
+      statusSeverity: 4,
+      statusSeverityDescription: 'Part Suspended',
+      reason: 'DISTRICT LINE: No service between Tower Hill and Barking due to a signal failure.',
+    },
+    { statusSeverity: 9, statusSeverityDescription: 'Minor Delays' },
+  ],
+};
+
+describe('compactStatus', () => {
+  it('keeps every concurrent status and its reason for a disrupted line', () => {
+    const lines = compactStatus([PART_SUSPENDED]);
+
+    expect(lines).toHaveLength(1);
+    expect(lines?.[0]?.id).toBe('district');
+    expect(lines?.[0]?.st).toHaveLength(2);
+    expect(lines?.[0]?.st[0]?.s).toBe(4);
+    expect(lines?.[0]?.st[0]?.r).toContain('signal failure');
+    expect(lines?.[0]?.st[1]?.s).toBe(9);
+    expect(lines?.[0]?.st[1]?.r).toBeUndefined();
+  });
+
+  it('sorts lines by id so serialized snapshots compare stably', () => {
+    const lines = compactStatus([PART_SUSPENDED, GOOD_SERVICE]);
+
+    expect(lines?.map((l) => l.id)).toEqual(['district', 'victoria']);
+  });
+
+  it('returns null for non-array payloads (error objects, HTML gateways)', () => {
+    expect(compactStatus({ httpStatusCode: 429, message: 'rate limited' })).toBeNull();
+    expect(compactStatus('<html>Bad Gateway</html>')).toBeNull();
+    expect(compactStatus(null)).toBeNull();
+  });
+
+  it('drops malformed entries but keeps valid ones', () => {
+    const lines = compactStatus([
+      GOOD_SERVICE,
+      { lineStatuses: [{ statusSeverity: 10 }] }, // no id
+      { id: 'bakerloo' }, // no statuses
+      { id: 'central', lineStatuses: [{ statusSeverityDescription: 'no code' }] },
+      null,
+    ]);
+
+    expect(lines?.map((l) => l.id)).toEqual(['victoria']);
+  });
+
+  it('returns null when nothing valid remains', () => {
+    expect(compactStatus([{ id: 'x' }, null])).toBeNull();
+    expect(compactStatus([])).toBeNull();
+  });
+});
+
+describe('shouldWrite', () => {
+  const T0 = 1_755_900_000_000;
+
+  it('always writes the first snapshot of a file', () => {
+    expect(shouldWrite(null, '[]', null, T0)).toBe(true);
+  });
+
+  it('writes when the status changed', () => {
+    expect(shouldWrite('[a]', '[b]', T0, T0 + 120_000)).toBe(true);
+  });
+
+  it('skips an unchanged status inside the heartbeat window', () => {
+    expect(shouldWrite('[a]', '[a]', T0, T0 + 120_000)).toBe(false);
+  });
+
+  it('writes an unchanged status once the heartbeat interval elapses', () => {
+    expect(shouldWrite('[a]', '[a]', T0, T0 + 30 * 60_000)).toBe(true);
+  });
+});

--- a/backend/src/tube-status-recorder.ts
+++ b/backend/src/tube-status-recorder.ts
@@ -1,0 +1,158 @@
+// Permanent archive of TfL line status. TfL's Unified API only serves the
+// present moment — there is no historical endpoint — so any analysis of how
+// disruptions start, spread, and recover needs its own recording, started as
+// early as possible. Snapshots are appended to <base>/tube-status/YYYY-MM-DD.jsonl
+// (UTC days), deduplicated against the previous snapshot so a quiet network
+// costs a handful of lines per day. Nothing here is ever pruned: a full year
+// of status history is a few MB.
+
+import { appendFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fetchLineStatusByModes } from './tfl-client';
+
+const POLL_INTERVAL_MS = 2 * 60_000;
+/** Unchanged status is still written this often, so gaps mean "recorder down". */
+const HEARTBEAT_INTERVAL_MS = 30 * 60_000;
+const STARTUP_DELAY_MS = 10_000;
+const STATUS_MODES = ['tube', 'overground', 'dlr', 'elizabeth-line', 'tram'] as const;
+const SUBDIR = 'tube-status';
+
+/** One concurrent status on a line (a line can carry several at once). */
+interface LineStatusEntry {
+  /** TfL statusSeverity code — 10 is Good Service, lower is worse. */
+  s: number;
+  /** Human description, e.g. "Minor Delays". */
+  d: string;
+  /** Free-text reason; only present when TfL provides one. */
+  r?: string;
+}
+
+export interface LineSnapshot {
+  id: string;
+  st: LineStatusEntry[];
+}
+
+interface TflLineStatus {
+  statusSeverity?: number;
+  statusSeverityDescription?: string;
+  reason?: string;
+}
+
+interface TflLine {
+  id?: string;
+  lineStatuses?: TflLineStatus[];
+}
+
+/**
+ * Reduces a TfL /Line/Mode/.../Status body to the compact archived form.
+ * Returns null when the body is not the expected array (error payloads,
+ * HTML gateways, etc.) — never trust upstream data.
+ */
+export function compactStatus(body: unknown): LineSnapshot[] | null {
+  if (!Array.isArray(body)) return null;
+  const lines: LineSnapshot[] = [];
+  for (const raw of body as TflLine[]) {
+    if (typeof raw?.id !== 'string' || raw.id === '') continue;
+    const statuses: LineStatusEntry[] = [];
+    for (const status of raw.lineStatuses ?? []) {
+      if (typeof status?.statusSeverity !== 'number') continue;
+      const entry: LineStatusEntry = {
+        s: status.statusSeverity,
+        d: typeof status.statusSeverityDescription === 'string' ? status.statusSeverityDescription : '',
+      };
+      const reason = typeof status.reason === 'string' ? status.reason.trim() : '';
+      if (reason !== '') entry.r = reason;
+      statuses.push(entry);
+    }
+    if (statuses.length === 0) continue;
+    lines.push({ id: raw.id, st: statuses });
+  }
+  if (lines.length === 0) return null;
+  lines.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  return lines;
+}
+
+/**
+ * A snapshot is written when the status changed, when the heartbeat interval
+ * elapsed, or when nothing has been written yet (fresh start / new day file).
+ */
+export function shouldWrite(
+  prevSerialized: string | null,
+  nextSerialized: string,
+  lastWriteMs: number | null,
+  nowMs: number,
+): boolean {
+  if (prevSerialized === null || lastWriteMs === null) return true;
+  if (nextSerialized !== prevSerialized) return true;
+  return nowMs - lastWriteMs >= HEARTBEAT_INTERVAL_MS;
+}
+
+export class TubeStatusRecorder {
+  private readonly dir: string;
+  private readonly appKey: string;
+  private readonly log: (msg: string) => void;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private startTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+  /** Serialized `lines` of the last written snapshot, per current day file. */
+  private lastSerialized: string | null = null;
+  private lastWriteMs: number | null = null;
+  private lastDay: string | null = null;
+
+  constructor(baseDir: string, appKey: string, log: (msg: string) => void) {
+    this.dir = join(baseDir, SUBDIR);
+    this.appKey = appKey;
+    this.log = log;
+  }
+
+  start(): void {
+    this.startTimer = setTimeout(() => {
+      void this.poll();
+      this.timer = setInterval(() => void this.poll(), POLL_INTERVAL_MS);
+      this.timer.unref();
+    }, STARTUP_DELAY_MS);
+    this.startTimer.unref();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    if (this.startTimer) clearTimeout(this.startTimer);
+    if (this.timer) clearInterval(this.timer);
+  }
+
+  private async poll(): Promise<void> {
+    if (this.stopped) return;
+    try {
+      const response = await fetchLineStatusByModes(STATUS_MODES, this.appKey);
+      if (response.status !== 200) {
+        this.log(`tube-status: TfL returned ${response.status}, skipping snapshot`);
+        return;
+      }
+      const lines = compactStatus(response.body);
+      if (lines === null) {
+        this.log('tube-status: unrecognised TfL payload, skipping snapshot');
+        return;
+      }
+      await this.record(lines, Date.now());
+    } catch (err) {
+      this.log(`tube-status: poll failed: ${String(err)}`);
+    }
+  }
+
+  private async record(lines: LineSnapshot[], nowMs: number): Promise<void> {
+    const day = new Date(nowMs).toISOString().slice(0, 10);
+    if (day !== this.lastDay) {
+      // Each day file opens with an unconditional snapshot so it reads standalone.
+      this.lastDay = day;
+      this.lastSerialized = null;
+      this.lastWriteMs = null;
+    }
+    const serialized = JSON.stringify(lines);
+    if (!shouldWrite(this.lastSerialized, serialized, this.lastWriteMs, nowMs)) return;
+    await mkdir(this.dir, { recursive: true });
+    const line = `{"t":${Math.floor(nowMs / 1000)},"lines":${serialized}}\n`;
+    await appendFile(join(this.dir, `${day}.jsonl`), line, 'utf8');
+    this.lastSerialized = serialized;
+    this.lastWriteMs = nowMs;
+  }
+}


### PR DESCRIPTION
## Why

The diversion-detection and disruption analyses run **locally** over the archives that live on the Railway volume. This adds the one-off export path so 7 days of traces (~2 GB, a few tens of pence of egress) can be pulled down with curl instead of building any server-side analysis infrastructure.

## What

- `GET /api/export/:dataset` → list of available UTC days (`["2026-08-16", …]`)
- `GET /api/export/:dataset/:day` → that day's file, streamed (flat memory even for multi-hundred-MB trace days)
- Datasets are a fixed whitelist: `bus-traces` (.jsonl), `bus-rollups` (.json), `tube-status` (.jsonl, arrives with #14)
- **Auth**: `Authorization: Bearer $ADMIN_EXPORT_TOKEN`, compared constant-time (sha256 + timingSafeEqual). When the env var is unset the routes are **not registered at all** — nothing changes for current deployments until you opt in. Raw traces contain vehicle IDs (private analysis only, never published), hence the hard gate.
- Day param format-validated (`YYYY-MM-DD`) — no path traversal; unknown dataset → 400; missing day → 404.

## Usage after merge

```bash
# Railway → service → Variables: add ADMIN_EXPORT_TOKEN=<long random string>
TOKEN=... BASE=https://london.pengrubin.com
curl -H "Authorization: Bearer $TOKEN" $BASE/api/export/bus-traces
for d in $(curl -s -H "Authorization: Bearer $TOKEN" $BASE/api/export/bus-traces | jq -r '.[]'); do
  curl -H "Authorization: Bearer $TOKEN" -o "traces-$d.jsonl" $BASE/api/export/bus-traces/$d
done
```

## Tests

8 new tests: 401 (missing/wrong token), 400 (unknown dataset, traversal-shaped day), 404 (absent day), verbatim streaming, day listing filters malformed filenames, empty list for not-yet-created dataset dirs.

`npx vitest run`: 39/39 passed · `npm run typecheck`: clean