### PR TITLE
fix: label the info tab 'ℹ️ Info' instead of a bare icon

### DIFF
--- a/frontend/src/ui/control-panel.ts
+++ b/frontend/src/ui/control-panel.ts
@@ -3,7 +3,7 @@
 //   🏆 Board  — the leaderboard (leaderboard.ts)
 //   🚌 Filter — the bus line filter (bus-filter.ts)
 //   🗺 Lines  — the lines legend + overlays (legend.ts)
-//   ℹ️ About  — data sources, licences, acknowledgements (about.ts)
+//   ℹ️ Info   — data sources, licences, acknowledgements (about.ts)
 // Merging the former two separate panels (leaderboard top-left + legend
 // top-right) into one frees screen space on phones and leaves the top-right
 // corner clear for MapLibre's zoom + geolocate controls.
@@ -24,7 +24,7 @@ const ALL_TABS: { key: TabKey; label: string }[] = [
   { key: 'board', label: '🏆 Board' },
   { key: 'filter', label: '🚌 Filter' },
   { key: 'lines', label: '🗺 Lines' },
-  { key: 'about', label: 'ℹ️' },
+  { key: 'about', label: 'ℹ️ Info' },
 ];
 
 export function addControlPanel(


### PR DESCRIPTION
The about tab's label was just `ℹ️`, and the panel header doubles as the collapse toggle showing the active tab's label — so with the info view active, both the tab and the header displayed a lone icon with no word (screenshot feedback). Now matches the other tabs' emoji + word style: **ℹ️ Info**.

One-line change in `control-panel.ts`; frontend typecheck clean, 79/79 tests pass.