### PR TITLE
feat: mobile UI tweaks — drop zoom buttons, heading beam, bus-filter input fixes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -61,9 +61,29 @@
         to { opacity: 1; transform: translate(-50%, 0); }
       }
 
+      /* ── device-heading beam on the geolocate dot ──
+         Rotated from JS (main.ts setupHeadingBeam); drawn pointing up so
+         rotate(heading - bearing) is the whole transform. Centred on the 15px
+         dot so rotation pivots on the dot centre; the radial mask cuts a hole
+         over the dot and fades the wedge tip. Hidden until a valid compass
+         heading arrives (JS sets opacity). */
+      .user-heading-beam {
+        position: absolute; left: 50%; top: 50%;
+        width: 52px; height: 52px; margin: -26px 0 0 -26px;
+        pointer-events: none; opacity: 0; transition: opacity .3s;
+        /* ~45° fan straight up, in maplibre's dot blue (#1da1f2) */
+        background: conic-gradient(from -22.5deg,
+          rgba(29, 161, 242, 0.4) 0deg 45deg, transparent 45deg);
+        -webkit-mask: radial-gradient(circle,
+          transparent 8px, rgba(0, 0, 0, 0.9) 9px, transparent 26px);
+        mask: radial-gradient(circle,
+          transparent 8px, rgba(0, 0, 0, 0.9) 9px, transparent 26px);
+      }
+
       /* ── legend panel ──
-         top offset clears the top-right MapLibre control stack (zoom + compass
-         + geolocate) so the panel never covers the geolocate button */
+         top offset keeps clear of the top-right MapLibre stack (now just the
+         geolocate button; headroom kept from when zoom + compass lived there
+         so the layout did not shift) */
       .legend {
         position: absolute; right: 10px; top: 150px; z-index: 5;
         background: rgba(16, 18, 22, 0.92); border: 1px solid #333; border-radius: 6px;
@@ -111,7 +131,7 @@
 
       /* ── merged control panel (one panel, docks top-left) ──
          Board / Filter / Lines tabs live here; top-right stays free for the
-         MapLibre zoom + geolocate controls. */
+         MapLibre geolocate control. */
       .control-panel {
         left: 10px; right: auto; top: 10px; width: 224px;
         max-height: calc(100vh - 40px);
@@ -144,6 +164,11 @@
       /* ── bus line filter (Filter tab) ── */
       .bf-body { padding: 8px 10px 10px; display: flex; flex-direction: column; gap: 7px; }
       .bf-hint { color: #888; font-size: 10px; line-height: 1.4; }
+      .bf-row { display: flex; gap: 6px; }
+      /* min-width:auto would stop the input shrinking below its placeholder;
+         stretch overrides .bf-clear's flex-start for the row's Add button. */
+      .bf-row .bf-input { min-width: 0; }
+      .bf-row .bf-clear { align-self: stretch; }
       .bf-input {
         width: 100%; box-sizing: border-box; background: #101216; color: #ddd;
         border: 1px solid #333; border-radius: 4px; padding: 5px 7px;

--- a/frontend/src/layers/buses.ts
+++ b/frontend/src/layers/buses.ts
@@ -143,13 +143,22 @@ const parkedCase = (
 const dotsColorNormal = (): ExpressionSpecification => parkedCase(PARKED_FILL, TFL_BUS_RED);
 const iconImageNormal = (): ExpressionSpecification => parkedCase('bus-icon-parked', 'bus-bullet');
 
+/**
+ * Case-insensitive line membership test. BODS `line` values are mixed-case in
+ * the wild ("Go2", "x80") while filterLines is stored uppercased (see
+ * setBusLineFilter) — upcase the feature side so both agree, otherwise a user
+ * typing "GO2" would never match the live "Go2" buses.
+ */
+const lineMatch = (lines: readonly string[]): ExpressionSpecification =>
+  ['in', ['upcase', ['get', 'line']], ['literal', lines]] as ExpressionSpecification;
+
 /** Filtered dots: parked stays black, on-line stays red, everything else greys. */
 const dotsColorFiltered = (lines: readonly string[]): ExpressionSpecification =>
   [
     'case',
     ['==', ['get', 'parked'], 1],
     PARKED_FILL,
-    ['in', ['get', 'line'], ['literal', lines]],
+    lineMatch(lines),
     TFL_BUS_RED,
     BUS_DIM_FILL,
   ] as ExpressionSpecification;
@@ -157,7 +166,7 @@ const dotsColorFiltered = (lines: readonly string[]): ExpressionSpecification =>
 const dotsOpacityFiltered = (lines: readonly string[]): ExpressionSpecification =>
   [
     'case',
-    ['in', ['get', 'line'], ['literal', lines]],
+    lineMatch(lines),
     DOTS_OPACITY_MATCH,
     DOTS_OPACITY_DIM,
   ] as ExpressionSpecification;
@@ -167,7 +176,7 @@ const iconImageFiltered = (lines: readonly string[]): ExpressionSpecification =>
     'case',
     ['==', ['get', 'parked'], 1],
     'bus-icon-parked',
-    ['in', ['get', 'line'], ['literal', lines]],
+    lineMatch(lines),
     'bus-bullet',
     'bus-bullet-dim',
   ] as ExpressionSpecification;
@@ -323,9 +332,7 @@ function applyBusDisplay(map: MaplibreMap): void {
   // In every other case there's no setFilter, so non-matching buses stay on the
   // map and clickable.
   const layerFilter: FilterSpecification | null =
-    !busesOverlayOn && filterActive
-      ? (['in', ['get', 'line'], ['literal', filterLines]] as FilterSpecification)
-      : null;
+    !busesOverlayOn && filterActive ? (lineMatch(filterLines) as FilterSpecification) : null;
 
   for (const id of [BUSES_DOTS_LAYER_ID, BUSES_ICONS_LAYER_ID]) {
     if (!map.getLayer(id)) continue;
@@ -360,7 +367,9 @@ function applyBusDisplay(map: MaplibreMap): void {
  * applyBusDisplay. Passing null or an empty set clears the filter.
  */
 export function setBusLineFilter(map: MaplibreMap, lines: ReadonlySet<string> | null): void {
-  filterLines = lines ? [...lines] : [];
+  // Stored uppercased: lineMatch upcases the feature side, so together the
+  // whole comparison is case-insensitive regardless of how callers cased it.
+  filterLines = lines ? [...lines].map((line) => line.toUpperCase()) : [];
   applyBusDisplay(map);
 }
 
@@ -380,12 +389,16 @@ export function listActiveBusLines(): string[] {
   return [...seen].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
 }
 
-/** How many live buses are currently running one of `lines` — light UI feedback. */
+/** How many live buses are currently running one of `lines` — light UI
+ * feedback. Case-insensitive: tracker lines keep BODS casing ("Go2", "x80"),
+ * callers may not. */
 export function countActiveBusesOnLines(lines: ReadonlySet<string>): number {
   if (!activeTrackers || lines.size === 0) return 0;
+  const upper = new Set<string>();
+  for (const line of lines) upper.add(line.toUpperCase());
   let n = 0;
   for (const tr of activeTrackers.values()) {
-    if (lines.has(tr.line)) n += 1;
+    if (upper.has(tr.line.toUpperCase())) n += 1;
   }
   return n;
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -71,6 +71,101 @@ function readInitialViewFromUrl(
 }
 
 /**
+ * Google-Maps-style heading wedge on the geolocate dot. maplibre-gl 6.0 has no
+ * `showUserHeading`, so it is hand-rolled: a CSS wedge (styled in index.html as
+ * .user-heading-beam) appended inside maplibre's dot element and rotated from
+ * device-orientation events. Stays invisible until a trustworthy compass
+ * reading arrives, so desktop browsers never show a broken beam.
+ */
+function setupHeadingBeam(map: maplibregl.Map, geolocate: maplibregl.GeolocateControl): void {
+  let compassHeading: number | null = null; // degrees clockwise from true north
+  let beam: HTMLDivElement | null = null;
+  let rafPending = false;
+
+  // Orientation events and map `rotate` both fire in bursts; coalesce to one
+  // style write per frame by storing the latest heading and scheduling one rAF.
+  const scheduleRender = (): void => {
+    if (rafPending) return;
+    rafPending = true;
+    requestAnimationFrame(() => {
+      rafPending = false;
+      if (beam === null || compassHeading === null) return;
+      // The wedge is drawn pointing screen-up; subtract the map bearing so it
+      // stays true when the map has been rotated by touch gestures.
+      beam.style.transform = `rotate(${compassHeading - map.getBearing()}deg)`;
+      beam.style.opacity = '1';
+    });
+  };
+
+  const onOrientation = (event: DeviceOrientationEvent): void => {
+    // iOS ships a ready-made compass heading (already clockwise-from-north);
+    // elsewhere alpha is only trustworthy when the browser marks it absolute.
+    // Anything else is ignored — no beam beats a wrong beam.
+    const webkitHeading = (event as any).webkitCompassHeading;
+    if (typeof webkitHeading === 'number' && Number.isFinite(webkitHeading)) {
+      compassHeading = webkitHeading;
+    } else if (event.absolute && event.alpha != null) {
+      // alpha is measured in the DEVICE frame, but the wedge is drawn in
+      // screen space — in landscape they differ by the screen rotation, so
+      // add it back. (webkitCompassHeading is already screen-corrected.)
+      const screenAngle = window.screen.orientation?.angle ?? 0;
+      compassHeading = (360 - event.alpha + screenAngle) % 360;
+    } else {
+      return;
+    }
+    scheduleRender();
+  };
+
+  let listening = false;
+  const startListening = (): void => {
+    if (listening) return;
+    listening = true;
+    // Prefer the absolute-referenced event (Android Chrome); fall back to the
+    // plain one where it does not exist (iOS, which compensates via
+    // webkitCompassHeading instead).
+    const type = 'ondeviceorientationabsolute' in window ? 'deviceorientationabsolute' : 'deviceorientation';
+    window.addEventListener(type, onOrientation as EventListener);
+  };
+
+  // iOS only grants orientation events when requestPermission() runs inside a
+  // user gesture, so piggyback on the geolocate button click (the element
+  // exists: the control's onAdd ran in addControl above). Denial silently
+  // means no beam.
+  const button = map.getContainer().querySelector<HTMLButtonElement>('.maplibregl-ctrl-geolocate');
+  button?.addEventListener('click', () => {
+    const request = typeof DeviceOrientationEvent !== 'undefined' ? (DeviceOrientationEvent as any).requestPermission : undefined;
+    if (typeof request === 'function') {
+      void Promise.resolve(request.call(DeviceOrientationEvent))
+        .then((state: unknown) => {
+          if (state === 'granted') startListening();
+        })
+        .catch((err: unknown) => {
+          // Denial resolves as 'denied' above; only genuine API errors land
+          // here — keep them visible in devtools without surfacing UI.
+          console.debug('[heading] orientation permission request failed', err);
+        });
+    } else {
+      startListening();
+    }
+  });
+
+  geolocate.on('geolocate', () => {
+    // The dot only exists after a successful fix. A child div is safe from the
+    // dot's pulse animation, which lives on its ::before/::after.
+    const dot = map.getContainer().querySelector('.maplibregl-user-location-dot');
+    if (dot === null) return;
+    if (beam === null) {
+      beam = document.createElement('div');
+      beam.className = 'user-heading-beam';
+    }
+    // Re-append if maplibre ever rebuilt the marker between fixes.
+    if (beam.parentElement !== dot) dot.append(beam);
+    scheduleRender();
+  });
+  map.on('rotate', scheduleRender);
+}
+
+/**
  * Builds the map from whatever the backend says this deployment is and has.
  *
  * The camera cannot be created before /api/capabilities answers — centre, zoom,
@@ -143,12 +238,13 @@ async function bootstrap(): Promise<void> {
   });
   toastHost = map.getContainer();
 
-  map.addControl(new maplibregl.NavigationControl(), 'top-right');
+  // No NavigationControl: the zoom +/- buttons and compass go unused (pinch /
+  // scroll zoom covers it, and the map is never deliberately rotated), so the
+  // top-right stack holds only the geolocate button.
 
   // User-initiated "locate me" control. Privacy-safe: the browser permission
   // prompt only fires on click, never on load, and the coordinates stay on the
-  // client (maplibre never transmits them). Sits directly under the zoom +/-
-  // buttons in the top-right stack.
+  // client (maplibre never transmits them).
   const geolocate = new maplibregl.GeolocateControl({
     positionOptions: { enableHighAccuracy: true },
     trackUserLocation: false,
@@ -159,6 +255,7 @@ async function bootstrap(): Promise<void> {
     fitBoundsOptions: { maxZoom: 14 },
   });
   map.addControl(geolocate, 'top-right');
+  setupHeadingBeam(map, geolocate);
 
   const isOutsideRegion = (lon: number, lat: number): boolean => {
     const [[west, south], [east, north]] = bounds;
@@ -345,7 +442,7 @@ async function addTransitOverlays(target: maplibregl.Map): Promise<void> {
     .map((layer) => layer.overlay);
 
   // One merged panel (top-left): Board / Filter / Lines tabs. Leaving the
-  // top-right corner free for MapLibre's zoom + geolocate controls.
+  // top-right corner free for MapLibre's geolocate control.
   const handle = trains ?? NO_TRAINS;
   addControlPanel(target, manifestLines, overlays, handle.colorByLine, {
     findTrain: handle.findVehicle,

--- a/frontend/src/ui/bus-filter.test.ts
+++ b/frontend/src/ui/bus-filter.test.ts
@@ -1,0 +1,113 @@
+// Unit tests for the pure bus-filter helpers (suggestion capping + resolution).
+// bus-filter.ts value-imports the buses layer, which value-imports maplibre-gl
+// (Popup), so we stub that module to keep the test in the fast node
+// environment — same pattern as emergency-classify.test.ts.
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('maplibre-gl', () => ({ Popup: class {} }));
+
+const { MAX_SUGGESTIONS, resolveLine, suggestLines } = await import('./bus-filter');
+
+describe('suggestLines', () => {
+  test('returns prefix matches before substring matches', () => {
+    // Arrange
+    const lines = ['124', '24', '241', '624', '99'];
+
+    // Act
+    const result = suggestLines(lines, '24');
+
+    // Assert — '24' and '241' start with the query; '124'/'624' only contain it
+    expect(result).toEqual(['24', '241', '124', '624']);
+  });
+
+  test('caps results at MAX_SUGGESTIONS', () => {
+    // Arrange — 30 routes all sharing the '1' prefix
+    const lines = Array.from({ length: 30 }, (_, i) => `1${i}`);
+
+    // Act
+    const result = suggestLines(lines, '1');
+
+    // Assert
+    expect(MAX_SUGGESTIONS).toBe(12);
+    expect(result).toHaveLength(MAX_SUGGESTIONS);
+    expect(result.every((line) => line.startsWith('1'))).toBe(true);
+  });
+
+  test('substring matches only fill slots left over after prefix matches', () => {
+    // Arrange — 12 prefix hits already saturate the cap; '624' must not appear
+    const prefixHits = Array.from({ length: 12 }, (_, i) => `24${i}`);
+    const lines = ['624', ...prefixHits];
+
+    // Act
+    const result = suggestLines(lines, '24');
+
+    // Assert
+    expect(result).toHaveLength(MAX_SUGGESTIONS);
+    expect(result).not.toContain('624');
+  });
+
+  test('matches case-insensitively and keeps canonical casing in results', () => {
+    // Arrange — real mixed-case BODS line names
+    const lines = ['Go2', 'x80', 'N25', 'W7'];
+
+    // Act / Assert
+    expect(suggestLines(lines, 'go')).toEqual(['Go2']);
+    expect(suggestLines(lines, 'X8')).toEqual(['x80']);
+    expect(suggestLines(lines, 'n25')).toEqual(['N25']);
+  });
+
+  test('returns no suggestions for empty or whitespace-only input', () => {
+    // Arrange
+    const lines = ['24', 'N25', 'Go2'];
+
+    // Act / Assert
+    expect(suggestLines(lines, '')).toEqual([]);
+    expect(suggestLines(lines, '   ')).toEqual([]);
+  });
+
+  test('respects a custom cap', () => {
+    // Arrange
+    const lines = ['10', '11', '12', '13'];
+
+    // Act
+    const result = suggestLines(lines, '1', 2);
+
+    // Assert
+    expect(result).toEqual(['10', '11']);
+  });
+});
+
+describe('resolveLine', () => {
+  test('returns the canonical casing of a live line', () => {
+    // Arrange
+    const lines = ['Go2', 'x80', 'N25'];
+
+    // Act / Assert
+    expect(resolveLine('GO2', lines)).toBe('Go2');
+    expect(resolveLine('X80', lines)).toBe('x80');
+    expect(resolveLine('n25', lines)).toBe('N25');
+  });
+
+  test('passes an unknown line through uppercased', () => {
+    // Arrange — 'w7' is not live right now
+    const lines = ['24', 'Go2'];
+
+    // Act / Assert
+    expect(resolveLine('w7', lines)).toBe('W7');
+  });
+
+  test('trims surrounding whitespace before resolving', () => {
+    // Arrange
+    const lines = ['Go2'];
+
+    // Act / Assert
+    expect(resolveLine('  go2  ', lines)).toBe('Go2');
+    expect(resolveLine('  24 ', [])).toBe('24');
+  });
+
+  test('resolves empty or whitespace-only input to the empty string', () => {
+    // Act / Assert
+    expect(resolveLine('', ['24'])).toBe('');
+    expect(resolveLine('   ', ['24'])).toBe('');
+  });
+});

--- a/frontend/src/ui/bus-filter.ts
+++ b/frontend/src/ui/bus-filter.ts
@@ -11,8 +11,16 @@ import {
   setBusLineFilter,
 } from '../layers/buses';
 
-/** How often the autocomplete list is refreshed to reflect currently-live routes. */
-const SUGGEST_REFRESH_MS = 20_000;
+/** Live-line cache TTL — the bus feed itself only refreshes every ~15 s. */
+const LINES_TTL_MS = 20_000;
+/** Retry sooner while the list is empty (first bus poll not landed yet). */
+const EMPTY_RETRY_MS = 2_000;
+/**
+ * Datalist cap. The old design kept ALL ~600-700 live routes in the datalist
+ * and rebuilt them on a timer — mobile browsers choke matching/rendering a
+ * list that size on every keystroke, and the rebuild could land mid-typing.
+ */
+export const MAX_SUGGESTIONS = 12;
 const DATALIST_ID = 'bus-filter-lines';
 
 /** Normalize typed input to the tracker's `line` form (BODS lines are unpadded). */
@@ -20,10 +28,68 @@ function normalizeLine(raw: string): string {
   return raw.trim().toUpperCase();
 }
 
+/**
+ * Up to `cap` autocomplete suggestions for `typed`, case-insensitively:
+ * prefix matches rank first, substring matches fill any remaining slots.
+ * Empty input suggests nothing — that is what keeps the datalist tiny.
+ */
+export function suggestLines(
+  lines: readonly string[],
+  typed: string,
+  cap: number = MAX_SUGGESTIONS,
+): string[] {
+  const q = normalizeLine(typed);
+  if (q === '') return [];
+  const prefix: string[] = [];
+  const substring: string[] = [];
+  for (const line of lines) {
+    const upper = line.toUpperCase();
+    if (upper.startsWith(q)) {
+      prefix.push(line);
+      if (prefix.length >= cap) break; // cap reached — substrings can't outrank
+    } else if (substring.length < cap && upper.includes(q)) {
+      substring.push(line);
+    }
+  }
+  return [...prefix, ...substring].slice(0, cap);
+}
+
+/**
+ * Resolve typed input against the live lines, case-insensitively. A live match
+ * returns that line's CANONICAL casing (BODS names are mixed-case in the wild:
+ * "Go2", "x80"); an unknown line passes through uppercased so it can still be
+ * selected before its first bus of the day appears — the buses layer matches
+ * case-insensitively either way.
+ */
+export function resolveLine(typed: string, lines: readonly string[]): string {
+  const norm = normalizeLine(typed);
+  if (norm === '') return '';
+  const canonical = lines.find((line) => line.toUpperCase() === norm);
+  return canonical ?? norm;
+}
+
 /** Build the bus filter view into `container` (a control-panel section). */
 export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
   // The chosen lines; the single source of truth driving setBusLineFilter().
   const selected = new Set<string>();
+
+  // Live-line list, cached with a short TTL and refreshed lazily on
+  // focus/input. This replaces a 20 s setInterval datalist rebuild whose
+  // replaceChildren could land mid-typing and stall mobile keyboards. An empty
+  // result usually means the first /api/buses poll hasn't landed yet, so it is
+  // retried on a much shorter TTL — but still a TTL, so a genuinely bus-less
+  // night can't trigger a full fleet rescan on every keystroke.
+  let cachedLines: string[] = [];
+  let cachedAt = 0;
+  function liveLines(): string[] {
+    const now = Date.now();
+    const ttl = cachedLines.length === 0 ? EMPTY_RETRY_MS : LINES_TTL_MS;
+    if (cachedAt === 0 || now - cachedAt >= ttl) {
+      cachedLines = listActiveBusLines();
+      cachedAt = now;
+    }
+    return cachedLines;
+  }
 
   const wrap = document.createElement('div');
   wrap.className = 'legend-body bf-body';
@@ -32,15 +98,34 @@ export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
   hint.className = 'bf-hint';
   hint.textContent = 'Type a route number to spotlight it — every other bus greys out.';
 
+  // Input + Add button on one row (.bf-row in index.html).
+  const inputRow = document.createElement('div');
+  inputRow.className = 'bf-row';
+
   const input = document.createElement('input');
-  input.type = 'text';
+  // `search` (with NO inputmode override) keeps the full mobile keyboard,
+  // return key included — the old inputmode=numeric pad could not type
+  // lettered routes (N25, X68, W7, Go2) and iOS's numeric pad has no
+  // confirm key at all.
+  input.type = 'search';
   input.className = 'bf-input';
   input.placeholder = 'e.g. 24';
-  input.setAttribute('inputmode', 'numeric');
   input.setAttribute('list', DATALIST_ID);
   input.setAttribute('aria-label', 'Bus line number');
+  input.setAttribute('enterkeyhint', 'go');
+  input.setAttribute('autocapitalize', 'characters'); // route letters are caps
+  input.setAttribute('autocomplete', 'off'); // the datalist IS the autocomplete
+  input.spellcheck = false;
 
-  // Native autocomplete, refreshed on an interval so it tracks live routes.
+  // Visible confirm button so ANY keyboard can submit (some mobile keyboards
+  // surface no usable return key). Same path as Enter/datalist-pick.
+  const add = document.createElement('button');
+  add.type = 'button';
+  add.className = 'bf-clear'; // reuses the quiet-button look
+  add.textContent = 'Add';
+  add.setAttribute('aria-label', 'Add route to filter');
+
+  // Native autocomplete list, filled per keystroke with capped matches only.
   const datalist = document.createElement('datalist');
   datalist.id = DATALIST_ID;
 
@@ -55,7 +140,8 @@ export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
   clear.className = 'bf-clear';
   clear.textContent = 'Clear';
 
-  wrap.append(hint, input, datalist, chips, feedback, clear);
+  inputRow.append(input, add);
+  wrap.append(hint, inputRow, datalist, chips, feedback, clear);
   container.append(wrap);
 
   /** Push the current selection down to the map and refresh chips + feedback. */
@@ -99,10 +185,28 @@ export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
     clear.disabled = false;
   }
 
+  function renderSuggestions(): void {
+    const matches = suggestLines(liveLines(), input.value);
+    datalist.replaceChildren(
+      ...matches.map((line) => {
+        const opt = document.createElement('option');
+        opt.value = line;
+        return opt;
+      }),
+    );
+  }
+
   function addFromInput(): void {
-    const line = normalizeLine(input.value);
+    const line = resolveLine(input.value, liveLines());
     input.value = '';
-    if (line === '' || selected.has(line)) return;
+    renderSuggestions(); // input is empty now → clears the datalist
+    if (line === '') return;
+    // Case-insensitive dedupe: a canonical "Go2" chip and typed "GO2" are the
+    // same route — never show both.
+    const upper = line.toUpperCase();
+    for (const existing of selected) {
+      if (existing.toUpperCase() === upper) return;
+    }
     selected.add(line);
     apply();
   }
@@ -115,6 +219,17 @@ export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
   });
   // Picking a datalist suggestion fires `change` (not always `keydown`).
   input.addEventListener('change', addFromInput);
+  add.addEventListener('click', addFromInput);
+
+  // Focus/input replace the old refresh interval for suggestions. The "N buses
+  // live" count only refreshes on focus and on apply — NOT per keystroke:
+  // counting is a full fleet scan (~8-9k trackers), and counts only drift as
+  // the 15 s bus polls land anyway.
+  input.addEventListener('focus', () => {
+    renderSuggestions();
+    if (selected.size > 0) renderFeedback();
+  });
+  input.addEventListener('input', renderSuggestions);
 
   clear.addEventListener('click', () => {
     if (selected.size === 0) return;
@@ -122,20 +237,5 @@ export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
     apply();
   });
 
-  function refreshSuggestions(): void {
-    const lines = listActiveBusLines();
-    datalist.replaceChildren(
-      ...lines.map((line) => {
-        const opt = document.createElement('option');
-        opt.value = line;
-        return opt;
-      }),
-    );
-    // Live counts shift the numbers under an active filter — keep them fresh.
-    if (selected.size > 0) renderFeedback();
-  }
-
-  refreshSuggestions();
-  window.setInterval(refreshSuggestions, SUGGEST_REFRESH_MS);
   apply();
 }

--- a/frontend/src/ui/control-panel.ts
+++ b/frontend/src/ui/control-panel.ts
@@ -6,7 +6,7 @@
 //   ℹ️ Info   — data sources, licences, acknowledgements (about.ts)
 // Merging the former two separate panels (leaderboard top-left + legend
 // top-right) into one frees screen space on phones and leaves the top-right
-// corner clear for MapLibre's zoom + geolocate controls.
+// corner clear for MapLibre's geolocate control.
 
 import type { Map as MaplibreMap } from 'maplibre-gl';
 import { addAbout } from './about';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig(({ command }) => ({
   publicDir: command === 'build' ? false : dataDir,
   server: {
     port: 5173,
+    // Phone testing needs HTTPS (iOS gates geolocation + compass on a secure
+    // context); a cloudflared quick tunnel provides it, but vite's host check
+    // would 403 the tunnel's random hostname without this.
+    allowedHosts: ['.trycloudflare.com'],
     // Forward API calls to the Fastify backend so frontend code can use
     // relative /api URLs in dev and prod alike.
     proxy: {


### PR DESCRIPTION
## Summary

Four phone-first UX fixes, all client-side (zero egress impact):

- **Zoom control removed** (`main.ts`): the +/- and compass buttons are gone; pinch/scroll/double-tap zoom untouched. Top-right now holds only the geolocate button.
- **Heading beam** (`main.ts` + `index.html`): after a successful locate, the blue dot grows a Google-Maps-style wedge showing which way the phone faces. maplibre 6.0 has no `showUserHeading`, so it's hand-rolled from `deviceorientation(absolute)` events — iOS permission is requested inside the geolocate button click (a required user gesture), Android landscape is compensated via `screen.orientation.angle`, and the beam stays hidden until a trustworthy compass reading arrives (desktop never shows one).
- **Bus filter freeze fixed** (`bus-filter.ts`): the old design kept ALL ~700 live routes in a `<datalist>` and rebuilt them on a 20 s `setInterval` — mobile browsers choked on every keystroke. Suggestions are now computed per keystroke from a TTL-cached line list, capped at 12, and the interval is gone.
- **Mobile keyboard fixed** (`bus-filter.ts`): `inputmode=numeric` blocked lettered routes (N25, X68, Go2) and iOS's numeric pad has no confirm key. Now `type=search` + `enterkeyhint=go` + a visible **Add** button.
- **Case-insensitive matching** (`buses.ts`): typed `GO2` now matches BODS `Go2` across all four maplibre filter expressions, chip dedupe, and the live-bus counter — closes a deferred bug.
- Dev-only: vite `allowedHosts` for `.trycloudflare.com` so phone testing over an HTTPS quick tunnel works (iOS gates geolocation + compass on secure contexts).

## Review

Two independent review passes (TypeScript-focused + general): both APPROVE, zero CRITICAL/HIGH. All MEDIUM/LOW findings fixed in this branch: Android landscape heading compensation, no per-keystroke fleet scan for the live counter, empty-cache TTL bypass, stale comments, inline styles moved to CSS.

## Test plan

- [x] `tsc --noEmit` clean; `vite build` succeeds
- [x] `vitest run`: 89/89 (10 new tests: suggestion capping/ranking, case-insensitive resolution)
- [x] Headless smoke test (390×844 viewport): zoom/compass buttons absent, geolocate present, input attrs correct, suggestions cap at 12, Add-button → chip + live count, no JS errors
- [x] Real-device check (user, via HTTPS tunnel): typing smooth, full keyboard with confirm key, lettered routes typable, beam works