### PR TITLE
fix: stop iOS Safari page-zoom on double-tapping UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,15 @@
       html, body { height: 100%; margin: 0; background: #0a0a0a; }
       #app { position: fixed; inset: 0; }
 
+      /* iOS Safari zooms the whole PAGE on a quick double-tap — easy to
+         trigger on the geolocate button, whose second tap often changes
+         nothing visibly (already located). Safari ignores user-scalable=no,
+         so opting every element out of double-tap zoom (pinch/pan stay
+         allowed) is the supported fix. touch-action does not inherit, hence
+         the universal selector; maplibre's own canvas gesture rules are class
+         selectors and outrank it, so map handling is untouched. */
+      * { touch-action: manipulation; }
+
       /* ── dark popup theme (vehicle + station boards) ──
          double selector outranks maplibre-gl.css, which is injected later */
       .maplibregl-popup .maplibregl-popup-content {


### PR DESCRIPTION
## Summary

On phones, a quick second tap on the geolocate button (natural, since the first tap often changes nothing visibly — the map is already centred on you) triggers **Safari's double-tap page zoom**: the entire interface blows up, buttons and text included, and everything feels broken afterwards.

Safari has ignored `user-scalable=no` since iOS 10, so the supported fix is `touch-action: manipulation` on UI elements — double-tap zoom is disabled while pinch and pan stay available. `touch-action` doesn't inherit, hence one universal rule; maplibre's own canvas gesture rules are class selectors and outrank it, so map gestures are untouched.

One CSS rule in `frontend/index.html`.

## Test plan

- [x] `tsc --noEmit` clean, `vite build` succeeds
- [x] Headless computed-style check: geolocate button + panel header → `manipulation`; maplibre canvas + canvas container → `none` (unchanged)
- [ ] Real device after deploy: double-tap the geolocate button / panel — page must not zoom; pinch-zoom on the map still works