### PR TITLE
feat: tidy attribution — owner first, uniform separators, terse Info tab

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -246,6 +246,19 @@ async function bootstrap(): Promise<void> {
   });
   toastHost = map.getContainer();
 
+  // On phone widths MapLibre's compact attribution starts EXPANDED — a fat
+  // white bar over the map until the user happens to tap elsewhere. Collapse
+  // it up front: credits stay one tap away behind the ⓘ (the OSMF-accepted
+  // minimum for small screens; ODbL requires OSM attribution on or one
+  // interaction from the map, so the control itself cannot be dropped).
+  // Desktop keeps the always-visible line — space is not contested there.
+  map.once('load', () => {
+    map
+      .getContainer()
+      .querySelector('.maplibregl-ctrl-attrib.maplibregl-compact')
+      ?.classList.remove('maplibregl-compact-show');
+  });
+
   // No NavigationControl: the zoom +/- buttons and compass go unused (pinch /
   // scroll zoom covers it, and the map is never deliberately rotated), so the
   // top-right stack holds only the geolocate button.

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -196,16 +196,24 @@ async function bootstrap(): Promise<void> {
   // a deployment only names the licensors whose data it actually draws (TfL's
   // terms require a visible "Powered by TfL Open Data"; Dubai must not show
   // one). Kept short: the full licence wording lives in the panel's About tab
-  // and the README. OSM is already credited via the basemap source attribution.
+  // and the README. Joined into ONE string — MapLibre length-sorts separate
+  // attribution entries, which scrambled the order — so the owner credit stays
+  // first and the separator stays uniform. The basemap credit lives here too
+  // (not on the source) for the same reason.
   const dataCredits = [
+    '<a href="https://github.com/pengrubin/london-live-2d" target="_blank" rel="noopener"><b>© PENG</b></a>',
     hasLayer('trainPositions') || hasLayer('stopArrivals')
       ? '<a href="https://tfl.gov.uk/info-for/open-data-users/" target="_blank" rel="noopener">Powered by TfL Open Data</a>'
       : null,
     hasLayer('buses')
       ? '<a href="https://www.bus-data.dft.gov.uk/" target="_blank" rel="noopener">DfT BODS</a>'
       : null,
-    '<a href="https://github.com/pengrubin/london-live-2d" target="_blank" rel="noopener"><b>© PENG</b></a>',
-  ].filter((credit): credit is string => credit !== null);
+    // Corner keeps only the legally required OSM notice; the Protomaps tile
+    // credit lives in the Info tab and README (self-hosted pmtiles).
+    '<a href="https://openstreetmap.org/copyright" target="_blank" rel="noopener">© OpenStreetMap</a>',
+  ]
+    .filter((credit): credit is string => credit !== null)
+    .join(' | ');
 
   const map = new maplibregl.Map({
     container: 'app',
@@ -217,8 +225,8 @@ async function bootstrap(): Promise<void> {
         protomaps: {
           type: 'vector',
           url: `pmtiles://${basemapUrl}`,
-          attribution:
-            '<a href="https://protomaps.com">Protomaps</a> © <a href="https://openstreetmap.org">OpenStreetMap</a>',
+          // No `attribution` here: the Protomaps/OSM credit is part of
+          // dataCredits above so the credit line renders in a fixed order.
         },
       },
       layers: layers('protomaps', namedFlavor('dark'), { lang: 'en' }),

--- a/frontend/src/ui/about.ts
+++ b/frontend/src/ui/about.ts
@@ -1,11 +1,12 @@
-// About / data-credits view for the control panel: what this map is, where
-// every layer's data comes from, and the licences that data arrives under.
+// About / data-credits view for the control panel: what this map is and where
+// every layer's data comes from, one terse line per source.
 //
 // Sources are derived from the capabilities layer set (hasLayer) — the same
 // signal that decides whether a layer exists — so a deployment only credits
 // the feeds it actually draws: Dubai never claims TfL, London never hides it.
-// The map-corner attribution line stays short; this view carries the full
-// licence wording (TfL's required text, OGL, ODbL) and the acknowledgements.
+// Panel space is premium: only the legally required notices stay here (TfL's
+// prescribed wording, OSM/ODbL); everything long-form — full licence text,
+// acknowledgements (Zone One) — lives in the README.
 
 import { hasLayer } from '../region';
 
@@ -31,6 +32,8 @@ function buildCredits(): CreditEntry[] {
     hasLayer('bikePoints');
   return [
     {
+      // TfL's licence prescribes this attribution and the OS/Geomni notice —
+      // the one entry that cannot be shortened further.
       when: usesTfl,
       html:
         `${link('https://tfl.gov.uk/info-for/open-data-users/', 'Powered by TfL Open Data')}. ` +
@@ -39,28 +42,26 @@ function buildCredits(): CreditEntry[] {
     },
     {
       when: hasLayer('buses'),
-      html:
-        `Bus positions: ${link('https://www.bus-data.dft.gov.uk/', 'DfT Bus Open Data Service')} ` +
-        `(${link('https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/', 'OGL v3')}).`,
+      html: `Buses: ${link('https://www.bus-data.dft.gov.uk/', 'DfT BODS')} (OGL v3).`,
     },
     {
       when: hasLayer('nationalRail'),
-      html: 'National Rail departures: Darwin, © Rail Delivery Group.',
+      html: 'National Rail: Darwin © Rail Delivery Group.',
     },
     {
       when: true,
       html:
-        `Network geometry &amp; basemap: © ${link('https://www.openstreetmap.org/copyright', 'OpenStreetMap')} contributors ` +
+        `Map &amp; routes: © ${link('https://www.openstreetmap.org/copyright', 'OpenStreetMap')} ` +
         `(${link('https://opendatacommons.org/licenses/odbl/', 'ODbL')}), ` +
-        `tiles by ${link('https://protomaps.com', 'Protomaps')}.`,
+        `${link('https://protomaps.com', 'Protomaps')} tiles.`,
     },
     {
       when: hasLayer('tideGauges'),
-      html: `Tide gauges: ${link('https://environment.data.gov.uk/', 'Environment Agency')} (OGL v3).`,
+      html: `Tides: ${link('https://environment.data.gov.uk/', 'Environment Agency')} (OGL v3).`,
     },
     {
       when: hasLayer('vessels'),
-      html: `Ship positions: ${link('https://aisstream.io', 'aisstream.io')}.`,
+      html: `Ships: ${link('https://aisstream.io', 'aisstream.io')}.`,
     },
     {
       when: hasLayer('aircraft'),
@@ -84,8 +85,8 @@ export function addAbout(container: HTMLElement): void {
   const intro = document.createElement('div');
   intro.className = 'about-note';
   intro.innerHTML =
-    'A real-time 2D transport map, estimated in your browser from open data. ' +
-    `Source on ${link(REPO_URL, 'GitHub')} — code MIT, baked network geometry ODbL.`;
+    'Real-time transport map from open data. ' +
+    `${link(REPO_URL, 'Source on GitHub')} — full licences &amp; credits there.`;
 
   const sourcesHeader = document.createElement('div');
   sourcesHeader.className = 'legend-group';
@@ -99,18 +100,4 @@ export function addAbout(container: HTMLElement): void {
     .join('');
 
   container.append(intro, sourcesHeader, sources);
-
-  // The countdown→position primitive behind the train layer is Zone One's idea;
-  // this project's contribution is the per-mode hardening on top of it.
-  if (hasLayer('trainPositions')) {
-    const ackHeader = document.createElement('div');
-    ackHeader.className = 'legend-group';
-    ackHeader.textContent = 'Acknowledgements';
-    const ack = document.createElement('div');
-    ack.className = 'about-note';
-    ack.innerHTML =
-      'Train positions are inferred from arrival countdowns — an approach ' +
-      `pioneered by ${link('https://london.jamespotter.dev', 'Zone One')}.`;
-    container.append(ackHeader, ack);
-  }
 }


### PR DESCRIPTION
## Summary

Two complaints from real-phone use: the corner credit line rendered in a jumbled order with mixed styling, and the Info tab was too wordy for premium panel space.

**Corner line** — MapLibre length-sorts separate attribution entries, which is what scrambled the order. All credits (basemap included) are now joined into one `customAttribution` string rendering exactly:

`© PENG | Powered by TfL Open Data | DfT BODS | © OpenStreetMap`

Owner credit first, uniform `|` separators. Protomaps is out of the corner (pmtiles are self-hosted; credit stays in the Info tab + README). "Powered by TfL Open Data" and "© OpenStreetMap" are licence-prescribed and can't shrink further.

**Info tab** — one terse line per data source ("Buses: DfT BODS (OGL v3)." etc.); the Zone One acknowledgements section is removed from the panel — README line 9 already credits it. Only the TfL-prescribed OS/Geomni notice keeps its full wording.

Per-region gating unchanged: Dubai still only credits the sources it draws.

## Test plan

- [x] `tsc --noEmit` clean, `vite build` succeeds
- [x] Headless render check — corner reads exactly `© PENG | Powered by TfL Open Data | DfT BODS | © OpenStreetMap`; Info tab shows the terse lines, no acknowledgements block
- [ ] Real device after deploy: corner line order + Info tab length