### PR TITLE
feat: bus coverage flow-map layer — per-road total journeys/day

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,11 +19,17 @@ data/*.pmtiles
 data/**/bus-traces/
 data/**/osm-cache/
 data/**/bus-routes/
+data/**/bus-rollups/
+data/**/tube-status/
+data/**/coverage/
 data/**/leaderboard.json
 data/**/leaderboard.json.tmp
 data/bus-traces/
 data/osm-cache/
 data/bus-routes/
+data/bus-rollups/
+data/tube-status/
+data/coverage/
 data/leaderboard.json
 data/leaderboard.json.tmp
 # Scratch space (review agents and one-off experiments write here).

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -11,6 +11,7 @@ import { BodsClient } from './bods-client';
 import { GbfsClient } from './gbfs-client';
 import { TtlCache } from './cache';
 import { type AppConfig, resolveBusDataDir } from './config';
+import { startCoverageWriter } from './coverage-writer';
 import { ARRIVALS_CACHE_TTL_MS, TFL_BUDGET_LIMIT, TFL_BUDGET_WINDOW_MS } from './constants';
 import {
   LeaderboardTracker,
@@ -46,6 +47,7 @@ import {
 } from './routes/external';
 import { registerAircraftPhotoRoute } from './routes/aircraft-photo';
 import { registerBusRoutesRoute } from './routes/bus-routes';
+import { registerCoverageRoute } from './routes/coverage';
 import { registerDataExportRoute } from './routes/data-export';
 import { registerShipPhotoRoute } from './routes/ship-photo';
 
@@ -158,6 +160,14 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
   }
   registerBusRoutesRoute(app, join(busDataDir, 'bus-routes', 'learned'));
 
+  // Coverage flow-map artifact — derived offline from learned routes +
+  // rollups already on disk, so unlike the writers above it needs no BODS key:
+  // a deployment that lost its credential keeps serving (and re-windowing)
+  // the coverage it already earned. Skips itself until inputs exist.
+  const coverage = startCoverageWriter(busDataDir, (msg) => app.log.info(msg));
+  app.addHook('onClose', () => coverage.stop());
+  registerCoverageRoute(app, join(busDataDir, 'coverage'));
+
   // Permanent line-status archive — TfL publishes no history, so we keep our
   // own from the day this ships. A few MB per year; never pruned.
   if (config.tflAppKey) {
@@ -202,7 +212,7 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
   const tflBudget = new RateBudget(TFL_BUDGET_LIMIT, TFL_BUDGET_WINDOW_MS);
 
   registerHealthRoute(app);
-  registerCapabilitiesRoute(app, config, DATA_DIR);
+  registerCapabilitiesRoute(app, config, DATA_DIR, busDataDir);
   registerArrivalsRoute(app, { config, cache: arrivalsCache, budget: tflBudget });
   registerStopArrivalsRoute(app, { config, cache: stopArrivalsCache, budget: tflBudget });
   registerVehicleArrivalsRoute(app, { config, cache: vehicleArrivalsCache, budget: tflBudget });

--- a/backend/src/coverage-writer.test.ts
+++ b/backend/src/coverage-writer.test.ts
@@ -1,0 +1,416 @@
+import { describe, expect, test } from 'vitest';
+import {
+  assignBucket,
+  buildCoverageArtifact,
+  computeRollingMeans,
+  quantizePolyline,
+  selectWindowDays,
+  simplifyPolyline,
+  type LonLat,
+} from './coverage-writer';
+
+// ~11.13 m per 0.0001° of latitude — offsets with a known metric size.
+const LAT_51_5 = 51.5;
+// Same projection constants as the corridor pass (fixed London latitude).
+const M_PER_DEG_LAT = 111_320;
+const M_PER_DEG_LON = M_PER_DEG_LAT * Math.cos((51.5 * Math.PI) / 180);
+
+/** North-south line through metric offsets — bearings 0°/180°, so match
+ * distances between routes are pure longitude offsets in metres. */
+const latAt = (metres: number): number => LAT_51_5 + metres / M_PER_DEG_LAT;
+const lonAt = (metres: number): number => -0.1 + metres / M_PER_DEG_LON;
+const nsLine = (fromM: number, toM: number, lonOffsetM = 0): LonLat[] => [
+  [lonAt(lonOffsetM), latAt(fromM)],
+  [lonAt(lonOffsetM), latAt(toM)],
+];
+
+describe('simplifyPolyline', () => {
+  test('always preserves the endpoints', () => {
+    const poly: LonLat[] = [
+      [-0.1, LAT_51_5],
+      [-0.1005, LAT_51_5],
+      [-0.101, LAT_51_5],
+    ];
+
+    const out = simplifyPolyline(poly, 5);
+
+    expect(out[0]).toEqual([-0.1, LAT_51_5]);
+    expect(out[out.length - 1]).toEqual([-0.101, LAT_51_5]);
+  });
+
+  test('drops a collinear interior point', () => {
+    const out = simplifyPolyline(
+      [
+        [-0.1, LAT_51_5],
+        [-0.1005, LAT_51_5],
+        [-0.101, LAT_51_5],
+      ],
+      5,
+    );
+
+    expect(out).toEqual([
+      [-0.1, LAT_51_5],
+      [-0.101, LAT_51_5],
+    ]);
+  });
+
+  test('keeps an interior point deviating more than the tolerance', () => {
+    // 0.0001° of latitude ≈ 11.1 m off the chord — above a 5 m tolerance
+    const out = simplifyPolyline(
+      [
+        [-0.1, LAT_51_5],
+        [-0.1005, LAT_51_5 + 0.0001],
+        [-0.101, LAT_51_5],
+      ],
+      5,
+    );
+
+    expect(out).toHaveLength(3);
+  });
+
+  test('drops an interior point deviating less than the tolerance', () => {
+    // 0.00002° of latitude ≈ 2.2 m off the chord — below a 5 m tolerance
+    const out = simplifyPolyline(
+      [
+        [-0.1, LAT_51_5],
+        [-0.1005, LAT_51_5 + 0.00002],
+        [-0.101, LAT_51_5],
+      ],
+      5,
+    );
+
+    expect(out).toEqual([
+      [-0.1, LAT_51_5],
+      [-0.101, LAT_51_5],
+    ]);
+  });
+
+  test('returns a two-point polyline unchanged', () => {
+    const poly: LonLat[] = [
+      [-0.1, LAT_51_5],
+      [-0.2, 51.6],
+    ];
+
+    expect(simplifyPolyline(poly, 5)).toEqual(poly);
+  });
+});
+
+describe('quantizePolyline', () => {
+  test('rounds coordinates to 4 decimals', () => {
+    const out = quantizePolyline([
+      [-0.123456789, 51.987654321],
+      [-0.100049, 51.100051],
+    ]);
+
+    expect(out).toEqual([
+      [-0.1235, 51.9877],
+      [-0.1, 51.1001],
+    ]);
+  });
+});
+
+describe('assignBucket', () => {
+  test('assigns the largest absolute lower bound met, edges inclusive', () => {
+    // exact edge values land IN the bucket they open
+    expect(assignBucket(0)).toBe(0);
+    expect(assignBucket(10)).toBe(1);
+    expect(assignBucket(30)).toBe(2);
+    expect(assignBucket(75)).toBe(3);
+    expect(assignBucket(150)).toBe(4);
+    expect(assignBucket(300)).toBe(5);
+  });
+
+  test('values just under an edge stay in the bucket below', () => {
+    expect(assignBucket(9.99)).toBe(0);
+    expect(assignBucket(29.9)).toBe(1);
+    expect(assignBucket(74.5)).toBe(2);
+    expect(assignBucket(149.9)).toBe(3);
+    expect(assignBucket(299.9)).toBe(4);
+  });
+
+  test('is unbounded above and clamps below', () => {
+    expect(assignBucket(10_000)).toBe(5);
+    expect(assignBucket(0.4)).toBe(0);
+  });
+});
+
+describe('selectWindowDays', () => {
+  const NOW = Date.UTC(2026, 7, 28, 12); // 2026-08-28T12:00Z
+
+  test('takes the newest 7 completed days, skipping the current UTC day', () => {
+    const files = [
+      '2026-08-28.json', // today — still growing, must be excluded
+      '2026-08-27.json',
+      '2026-08-26.json',
+      '2026-08-25.json',
+      '2026-08-24.json',
+      '2026-08-23.json',
+      '2026-08-22.json',
+      '2026-08-21.json',
+      '2026-08-20.json', // 8th completed day — outside the window
+    ];
+
+    const days = selectWindowDays(files, NOW);
+
+    expect(days).toEqual([
+      '2026-08-21',
+      '2026-08-22',
+      '2026-08-23',
+      '2026-08-24',
+      '2026-08-25',
+      '2026-08-26',
+      '2026-08-27',
+    ]);
+  });
+
+  test('ignores non-day filenames and tmp leftovers', () => {
+    const days = selectWindowDays(
+      ['not-a-day.json', '2026-08-20.json.tmp', '2026-08-20.json'],
+      NOW,
+    );
+
+    expect(days).toEqual(['2026-08-20']);
+  });
+
+  test('returns fewer days when fewer completed rollups exist', () => {
+    const days = selectWindowDays(['2026-08-26.json', '2026-08-27.json'], NOW);
+
+    expect(days).toEqual(['2026-08-26', '2026-08-27']);
+  });
+});
+
+describe('computeRollingMeans', () => {
+  test('divides by the full window so absent days count as zero', () => {
+    const means = computeRollingMeans([
+      new Map([
+        ['TFLO_88_outbound', 10],
+        ['GOAH_x80_inbound', 4],
+      ]),
+      new Map([['TFLO_88_outbound', 20]]),
+    ]);
+
+    expect(means.get('TFLO_88_outbound')).toBe(15);
+    expect(means.get('GOAH_x80_inbound')).toBe(2); // 4 over 2 days, not 4 over 1
+  });
+});
+
+describe('buildCoverageArtifact (corridor merge)', () => {
+  test('carries day and windowDays as foreign members', async () => {
+    const artifact = await buildCoverageArtifact(
+      new Map([['R0', nsLine(0, 200)]]),
+      new Map([['R0', 20]]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.type).toBe('FeatureCollection');
+    expect(artifact.day).toBe('2026-08-27');
+    expect(artifact.windowDays).toBe(7);
+  });
+
+  test('merges two identical polylines into one corridor with summed j', async () => {
+    const artifact = await buildCoverageArtifact(
+      new Map([
+        ['A', nsLine(0, 200)],
+        ['B', nsLine(0, 200)],
+      ]),
+      new Map([
+        ['A', 30],
+        ['B', 20],
+      ]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(1);
+    const feature = artifact.features[0];
+    expect(feature?.geometry.type).toBe('LineString');
+    expect(feature?.properties).toEqual({ j: 50, b: 2 }); // 50 >= 30 → bucket 2
+    // a straight 200 m corridor simplifies down to its two endpoints
+    expect(feature?.geometry.coordinates).toHaveLength(2);
+  });
+
+  test('merges an antiparallel (reversed) polyline instead of duplicating it', async () => {
+    const artifact = await buildCoverageArtifact(
+      new Map([
+        ['A_outbound', nsLine(0, 200)],
+        ['A_inbound', nsLine(200, 0)], // same road, walked the other way
+      ]),
+      new Map([
+        ['A_outbound', 30],
+        ['A_inbound', 20],
+      ]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(1);
+    expect(artifact.features[0]?.properties).toEqual({ j: 50, b: 2 });
+  });
+
+  test('a route cannot add twice to one piece (out-and-back polyline)', async () => {
+    // A → B → A: the return leg revisits every corridor piece the outbound
+    // leg emitted; the guard must keep the total at one contribution.
+    const lon = lonAt(0);
+    const outAndBack: LonLat[] = [
+      [lon, latAt(0)],
+      [lon, latAt(210)],
+      [lon, latAt(0)],
+    ];
+
+    const artifact = await buildCoverageArtifact(
+      new Map([['loop', outAndBack]]),
+      new Map([['loop', 20]]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(1);
+    expect(artifact.features[0]?.properties).toEqual({ j: 20, b: 1 }); // not 40
+  });
+
+  test('drops routes whose rolling mean is 0 or missing', async () => {
+    const artifact = await buildCoverageArtifact(
+      new Map([
+        ['zeroed', nsLine(0, 200, 0)],
+        ['no_rollup_entry', nsLine(0, 200, 200)],
+        ['alive', nsLine(0, 200, 400)],
+      ]),
+      new Map([
+        ['zeroed', 0],
+        ['alive', 5],
+      ]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(1);
+    expect(artifact.features[0]?.properties).toEqual({ j: 5, b: 0 });
+  });
+
+  test('splits an owner run where the corridor total changes bucket', async () => {
+    // trunk covers 0..400 m at mean 20; branch overlaps only 200..400 m,
+    // lifting that half to 35 — across the 30 journeys/day bucket edge.
+    const artifact = await buildCoverageArtifact(
+      new Map([
+        ['trunk', nsLine(0, 400)],
+        ['branch', nsLine(200, 400)],
+      ]),
+      new Map([
+        ['trunk', 20],
+        ['branch', 15],
+      ]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(2);
+    expect(artifact.features.map((f) => f.properties)).toEqual([
+      { j: 20, b: 1 }, // 0..200 m: trunk alone
+      { j: 35, b: 2 }, // 200..400 m: trunk + branch
+    ]);
+    // the split point sits at the 200 m mark on both features
+    const splitLat = Number(latAt(200).toFixed(4));
+    const first = artifact.features[0]?.geometry.coordinates;
+    const second = artifact.features[1]?.geometry.coordinates;
+    expect(first?.[first.length - 1]?.[1]).toBe(splitLat);
+    expect(second?.[0]?.[1]).toBe(splitLat);
+  });
+
+  test('parallel lines 30 m apart stay separate corridors', async () => {
+    const artifact = await buildCoverageArtifact(
+      new Map([
+        ['east', nsLine(0, 200, 0)],
+        ['west', nsLine(0, 200, 30)], // 30 m > the 18 m match radius
+      ]),
+      new Map([
+        ['east', 20],
+        ['west', 20],
+      ]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(2);
+    for (const feature of artifact.features) {
+      expect(feature.properties).toEqual({ j: 20, b: 1 });
+    }
+  });
+
+  test('parallel lines 17 m apart merge into one corridor', async () => {
+    // complement of the 30 m case: inside the 18 m radius, across whatever
+    // grid cells the absolute coordinates land in (3×3 neighbourhood scan)
+    const artifact = await buildCoverageArtifact(
+      new Map([
+        ['east', nsLine(0, 200, 0)],
+        ['west', nsLine(0, 200, 17)],
+      ]),
+      new Map([
+        ['east', 30],
+        ['west', 20],
+      ]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(1);
+    expect(artifact.features[0]?.properties).toEqual({ j: 50, b: 2 });
+  });
+
+  test('a phase-shifted quieter route still adds to EVERY corridor piece', async () => {
+    // Regression for the per-piece guard scope: B walks the same road as A
+    // but resampled half a step out of phase, so each B piece sees BOTH the
+    // corridor piece its previous B piece just touched (12.5 m behind, inside
+    // the 18 m radius) and the untouched next one (12.5 m ahead). The guard
+    // must only block the touched piece — suppressing the whole neighbourhood
+    // would skip every other add and undercount the corridor (~j 41 not 60).
+    const artifact = await buildCoverageArtifact(
+      new Map([
+        ['A', nsLine(0, 400)],
+        ['B', nsLine(-12.5, 387.5)],
+      ]),
+      new Map([
+        ['A', 40],
+        ['B', 20],
+      ]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(1);
+    expect(artifact.features[0]?.properties).toEqual({ j: 60, b: 2 });
+  });
+
+  test('drops a corridor whose geometry collapses under 4-decimal rounding', async () => {
+    // A 3 m stub rounds both endpoints onto the same 0.0001° grid point; a
+    // one-position LineString is invalid GeoJSON and must not be emitted.
+    const artifact = await buildCoverageArtifact(
+      new Map([['stub', nsLine(0, 3)]]),
+      new Map([['stub', 20]]),
+      '2026-08-27',
+      7,
+    );
+
+    expect(artifact.features).toHaveLength(0);
+  });
+
+  test('quantizes artifact coordinates to 4 decimals', async () => {
+    const wobbly = new Map<string, LonLat[]>([
+      [
+        'R0',
+        [
+          [-0.123456789, 51.512345678],
+          [-0.2, 51.6],
+        ],
+      ],
+    ]);
+
+    const artifact = await buildCoverageArtifact(wobbly, new Map([['R0', 1]]), '2026-08-27', 1);
+
+    const coords = artifact.features.flatMap((f) => f.geometry.coordinates).flat();
+    expect(coords.length).toBeGreaterThan(0);
+    for (const value of coords) {
+      expect(value).toBe(Number(value.toFixed(4)));
+    }
+  });
+});

--- a/backend/src/coverage-writer.ts
+++ b/backend/src/coverage-writer.ts
@@ -1,0 +1,643 @@
+// Bus-coverage flow-map artifact — road-segment corridors carrying the TOTAL
+// journeys/day of every route traversing them, prebuilt so the frontend
+// fetches ONE cacheable GeoJSON instead of ~1800 learned-route files.
+//
+// Everything here is derived from data already on disk (learned polylines +
+// daily rollups), so regeneration is seconds of pure local CPU with zero
+// network egress. That is why the schedule needs no staleness dance: build on
+// boot only when the artifact is missing, then every 6 h unconditionally — the
+// rolling window simply advances as new rollup days complete.
+//
+// Weights are a ROLLING mean: per-route journeys/day averaged over the newest
+// up to 7 COMPLETED rollup days (the current UTC day is skipped — its trace is
+// still growing). Days where a route is absent count as 0 (sum is divided by
+// the full window length), which smooths weekday/weekend swings instead of
+// hiding them.
+//
+// Assembly is a corridor merge (prototype-validated at STEP=25 m, MATCH=18 m):
+// routes are walked busiest-first, each polyline resampled to 25 m pieces; a
+// piece landing within 18 m of an already-emitted piece with a compatible
+// bearing (same road, either direction) ADDS its route's mean to that piece
+// instead of drawing a second line. Same-owner consecutive pieces then merge
+// into LineString runs, split where the summed total crosses a bucket edge.
+// Buckets are ABSOLUTE journeys/day lower bounds — a corridor's colour means
+// the same service level on every rebuild, unlike quantile edges which would
+// recolour untouched corridors whenever unrelated routes shift.
+
+import { mkdir, readdir, readFile, rename, stat, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/** Simplification tolerance chosen by the prototype: run weights are fixed
+ * before simplification, so 5 m only shaves bytes, never changes j/b. */
+export const COVERAGE_TOLERANCE_M = 5;
+export const COVERAGE_WINDOW_DAYS = 7;
+/** Absolute bucket lower bounds in journeys/day (b = index 0..5). */
+export const COVERAGE_BUCKET_EDGES = [0, 10, 30, 75, 150, 300] as const;
+const COORD_DECIMALS = 4;
+const REGEN_INTERVAL_MS = 6 * 60 * 60_000;
+const ROLLUP_FILE_RE = /^\d{4}-\d{2}-\d{2}\.json$/;
+/** Metres per degree of latitude (equirectangular; fine at route scale). */
+const M_PER_DEG = 111_320;
+// Corridor matching runs in ONE shared equirectangular projection so pieces
+// from different routes land in the same metric plane. Its reference latitude
+// is derived from the data itself (see buildCoverageArtifact), not hardcoded:
+// a fixed 51.5° would distort east-west distances ~45% for a ~25°N deployment
+// like Dubai and silently corrupt the 18 m matching there.
+
+// Corridor-merge parameters, fixed by the measured prototype (report-25-18):
+// 25 m pieces + 18 m match keep p99 match distance under the carriageway
+// width while a 30 m grid bounds each query to a 3×3 neighbourhood.
+const STEP_M = 25;
+const MATCH_DIST_M = 18;
+const BEARING_TOL_DEG = 25; // <=25° same direction, >=155° antiparallel
+const CELL_M = 30;
+
+/** Matches the learner's key→filename mapping (learn-bus-routes.mjs), so
+ * rollup keys (raw `TFLO:88:outbound`) join learned filenames. */
+const sanitizeKey = (key: string): string => key.replace(/[^A-Za-z0-9_.-]/g, '_');
+
+export type LonLat = readonly [number, number];
+
+interface CoverageFeature {
+  type: 'Feature';
+  /** j: rounded total journeys/day on the corridor; b: bucket index 0..5.
+   * The frontend interpolates on `b`, so it MUST stay numeric. */
+  properties: { j: number; b: number };
+  geometry: { type: 'LineString'; coordinates: Array<[number, number]> };
+}
+
+export interface CoverageArtifact {
+  type: 'FeatureCollection';
+  /** Foreign members: newest completed rollup day + how many days averaged. */
+  day: string;
+  windowDays: number;
+  features: CoverageFeature[];
+}
+
+/** Distance from p to the SEGMENT a→b (not the infinite line), in the same
+ * planar units as the inputs. */
+function segmentDistance(
+  px: number,
+  py: number,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+): number {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const len2 = dx * dx + dy * dy;
+  if (len2 === 0) return Math.hypot(px - ax, py - ay);
+  const t = Math.max(0, Math.min(1, ((px - ax) * dx + (py - ay) * dy) / len2));
+  return Math.hypot(px - (ax + t * dx), py - (ay + t * dy));
+}
+
+/** Douglas-Peucker with a metric tolerance. Endpoints are always preserved.
+ * Iterative (explicit stack) so pathological inputs cannot blow the call
+ * stack; projection is local equirectangular, accurate at route scale. */
+export function simplifyPolyline(poly: readonly LonLat[], toleranceM: number): LonLat[] {
+  if (poly.length <= 2) return poly.map(([lon, lat]) => [lon, lat]);
+  const meanLatRad =
+    (poly.reduce((sum, p) => sum + p[1], 0) / poly.length) * (Math.PI / 180);
+  const lonScale = Math.cos(meanLatRad) * M_PER_DEG;
+  const px = poly.map((p) => p[0] * lonScale);
+  const py = poly.map((p) => p[1] * M_PER_DEG);
+
+  const keep = new Array<boolean>(poly.length).fill(false);
+  keep[0] = true;
+  keep[poly.length - 1] = true;
+  const stack: Array<readonly [number, number]> = [[0, poly.length - 1]];
+  while (stack.length > 0) {
+    const span = stack.pop();
+    if (span === undefined) break;
+    const [a, b] = span;
+    let maxDist = 0;
+    let maxIdx = -1;
+    for (let i = a + 1; i < b; i += 1) {
+      const d = segmentDistance(
+        px[i] ?? 0,
+        py[i] ?? 0,
+        px[a] ?? 0,
+        py[a] ?? 0,
+        px[b] ?? 0,
+        py[b] ?? 0,
+      );
+      if (d > maxDist) {
+        maxDist = d;
+        maxIdx = i;
+      }
+    }
+    if (maxIdx !== -1 && maxDist > toleranceM) {
+      keep[maxIdx] = true;
+      stack.push([a, maxIdx], [maxIdx, b]);
+    }
+  }
+  return poly.filter((_, i) => keep[i]).map(([lon, lat]) => [lon, lat]);
+}
+
+/** 4-decimal quantization: a 0.0001° grid is ≤ ~5.6 m of latitude error —
+ * on par with the 5 m simplification tolerance and required to keep the
+ * corridor artifact inside its ~1.6 MB brotli budget (5 decimals put the
+ * prototype at 3.1 MB). */
+export function quantizePolyline(poly: readonly LonLat[]): Array<[number, number]> {
+  const factor = 10 ** COORD_DECIMALS;
+  return poly.map(([lon, lat]) => [
+    Math.round(lon * factor) / factor,
+    Math.round(lat * factor) / factor,
+  ]);
+}
+
+/** Largest bucket whose absolute lower bound the corridor total meets. */
+export function assignBucket(total: number): number {
+  for (let b = COVERAGE_BUCKET_EDGES.length - 1; b > 0; b -= 1) {
+    if (total >= (COVERAGE_BUCKET_EDGES[b] ?? Infinity)) return b;
+  }
+  return 0;
+}
+
+/** Newest up to 7 COMPLETED rollup days, ascending. Today's stamp is excluded
+ * defensively — the rollup writer never emits it, but a clock skew must not
+ * let a half-day drag the mean down. */
+export function selectWindowDays(fileNames: readonly string[], nowMs: number): string[] {
+  const today = new Date(nowMs).toISOString().slice(0, 10);
+  return fileNames
+    .filter((name) => ROLLUP_FILE_RE.test(name))
+    .map((name) => name.slice(0, 10))
+    .filter((day) => day < today)
+    .sort()
+    .slice(-COVERAGE_WINDOW_DAYS);
+}
+
+/** Rolling mean journeys/day per (sanitized) route key. Absent days count as
+ * 0: the sum is divided by the FULL window length, not the days seen. */
+export function computeRollingMeans(
+  perDayJourneys: ReadonlyArray<ReadonlyMap<string, number>>,
+): Map<string, number> {
+  const sums = new Map<string, number>();
+  for (const day of perDayJourneys) {
+    for (const [key, journeys] of day) {
+      sums.set(key, (sums.get(key) ?? 0) + journeys);
+    }
+  }
+  const means = new Map<string, number>();
+  for (const [key, sum] of sums) {
+    means.set(key, sum / perDayJourneys.length);
+  }
+  return means;
+}
+
+// --- corridor piece store -------------------------------------------------
+//
+// Parallel typed arrays instead of an array of objects, and a single
+// last-contributor slot instead of a per-piece Set of route indices: the
+// prototype's ~440k Sets cost ~800 MB RSS, while routes are processed one at
+// a time, so "the last route to touch this piece" is exactly equivalent to
+// full membership for the only question asked ("did THIS route already add
+// to THIS piece?").
+//
+// The guard is deliberately PER PIECE, not per neighbourhood. Consecutive
+// 25 m route pieces walking a shared road routinely see the previous piece's
+// matched corridor piece still inside the 18 m radius (phase offset < 18 m of
+// the 25 m step) alongside the NEXT corridor piece — suppressing the add
+// whenever any nearby piece was already touched would therefore skip roughly
+// every other piece on shared roads, systematically undercounting exactly the
+// corridors this artifact exists to measure. The cost of per-piece scope: a
+// route whose own polyline revisits a junction (terminus loops, gyratories)
+// can add to a second distinct piece there — which matches the product
+// semantics anyway, because those buses really do pass that road twice per
+// journey. Peak RSS stays well under 200 MB.
+
+interface PieceStore {
+  count: number;
+  mx: Float64Array; // piece midpoint, metres (fixed London projection)
+  my: Float64Array;
+  bearingDeg: Float64Array;
+  total: Float64Array; // summed journeys/day of all matched routes
+  p0lon: Float64Array; // piece endpoints, degrees
+  p0lat: Float64Array;
+  p1lon: Float64Array;
+  p1lat: Float64Array;
+  seq: Int32Array; // walk position within the owner route (run-gap detection)
+  lastRoute: Int32Array; // last contributing route index (double-add guard)
+}
+
+function makePieceStore(): PieceStore {
+  const capacity = 1 << 16;
+  return {
+    count: 0,
+    mx: new Float64Array(capacity),
+    my: new Float64Array(capacity),
+    bearingDeg: new Float64Array(capacity),
+    total: new Float64Array(capacity),
+    p0lon: new Float64Array(capacity),
+    p0lat: new Float64Array(capacity),
+    p1lon: new Float64Array(capacity),
+    p1lat: new Float64Array(capacity),
+    seq: new Int32Array(capacity),
+    lastRoute: new Int32Array(capacity),
+  };
+}
+
+/** Double every array in place (field reassignment) once count hits
+ * capacity. Mutation is deliberate here: the store is function-local to one
+ * build and copying ~440k-piece arrays per push would be quadratic. */
+function growPieceStore(store: PieceStore): void {
+  const capacity = store.mx.length * 2;
+  const growF = (old: Float64Array): Float64Array => {
+    const next = new Float64Array(capacity);
+    next.set(old);
+    return next;
+  };
+  const growI = (old: Int32Array): Int32Array => {
+    const next = new Int32Array(capacity);
+    next.set(old);
+    return next;
+  };
+  store.mx = growF(store.mx);
+  store.my = growF(store.my);
+  store.bearingDeg = growF(store.bearingDeg);
+  store.total = growF(store.total);
+  store.p0lon = growF(store.p0lon);
+  store.p0lat = growF(store.p0lat);
+  store.p1lon = growF(store.p1lon);
+  store.p1lat = growF(store.p1lat);
+  store.seq = growI(store.seq);
+  store.lastRoute = growI(store.lastRoute);
+}
+
+/** Same road iff bearings agree within tolerance in EITHER direction —
+ * inbound/outbound pairs of one street must merge, not double-draw. */
+function bearingOk(b1: number, b2: number): boolean {
+  let d = Math.abs(b1 - b2) % 360;
+  if (d > 180) d = 360 - d;
+  return d <= BEARING_TOL_DEG || d >= 180 - BEARING_TOL_DEG;
+}
+
+/** Numeric grid key: the walk queries 9 cells per piece (~10M lookups per
+ * build), and string keys would allocate a temp string for every one of
+ * them. The +65536 bias keeps both axes positive out to ±1966 km — far
+ * beyond any learned route. */
+const cellKey = (gx: number, gy: number): number => (gx + 65_536) * 131_072 + (gy + 65_536);
+
+/** Resample a projected polyline to ~STEP_M point spacing, keeping the true
+ * endpoint so the tail piece is never dropped. */
+function resampleMetres(xs: Float64Array, ys: Float64Array): { rx: number[]; ry: number[] } {
+  const rx: number[] = [xs[0] ?? 0];
+  const ry: number[] = [ys[0] ?? 0];
+  let carry = 0;
+  for (let i = 1; i < xs.length; i += 1) {
+    const x0 = xs[i - 1] ?? 0;
+    const y0 = ys[i - 1] ?? 0;
+    const dx = (xs[i] ?? 0) - x0;
+    const dy = (ys[i] ?? 0) - y0;
+    const segLen = Math.hypot(dx, dy);
+    if (segLen === 0) continue;
+    let along = STEP_M - carry;
+    while (along < segLen) {
+      const t = along / segLen;
+      rx.push(x0 + dx * t);
+      ry.push(y0 + dy * t);
+      along += STEP_M;
+    }
+    carry = segLen - (along - STEP_M);
+  }
+  const endX = xs[xs.length - 1] ?? 0;
+  const endY = ys[ys.length - 1] ?? 0;
+  if (Math.hypot(endX - (rx[rx.length - 1] ?? 0), endY - (ry[ry.length - 1] ?? 0)) > 1) {
+    rx.push(endX);
+    ry.push(endY);
+  }
+  return { rx, ry };
+}
+
+/** Walk one route's resampled pieces against the corridor store: match →
+ * add the route mean once, no match → emit a new owned piece. Returns the
+ * emitted piece indices (walk-ordered) for the run-merge phase. */
+function walkRoute(
+  store: PieceStore,
+  grid: Map<number, number[]>,
+  routeIdx: number,
+  poly: readonly LonLat[],
+  mean: number,
+  mPerDegLon: number,
+): number[] {
+  const xs = new Float64Array(poly.length);
+  const ys = new Float64Array(poly.length);
+  for (let i = 0; i < poly.length; i += 1) {
+    xs[i] = (poly[i]?.[0] ?? 0) * mPerDegLon;
+    ys[i] = (poly[i]?.[1] ?? 0) * M_PER_DEG;
+  }
+  const { rx, ry } = resampleMetres(xs, ys);
+  const owned: number[] = [];
+
+  for (let i = 1, seq = 0; i < rx.length; i += 1, seq += 1) {
+    const x0 = rx[i - 1] ?? 0;
+    const y0 = ry[i - 1] ?? 0;
+    const x1 = rx[i] ?? 0;
+    const y1 = ry[i] ?? 0;
+    const dx = x1 - x0;
+    const dy = y1 - y0;
+    if (Math.hypot(dx, dy) === 0) continue;
+    const mx = (x0 + x1) / 2;
+    const my = (y0 + y1) / 2;
+    const bearing = (Math.atan2(dx, dy) * 180) / Math.PI;
+
+    // nearest matchable piece in the 3×3 cell neighbourhood
+    const cx = Math.floor(mx / CELL_M);
+    const cy = Math.floor(my / CELL_M);
+    let best = -1;
+    let bestD = Infinity;
+    let alreadyCounted = false; // this route contributed to a corridor here
+    for (let gx = cx - 1; gx <= cx + 1; gx += 1) {
+      for (let gy = cy - 1; gy <= cy + 1; gy += 1) {
+        const cell = grid.get(cellKey(gx, gy));
+        if (cell === undefined) continue;
+        for (const pi of cell) {
+          const d = Math.hypot((store.mx[pi] ?? 0) - mx, (store.my[pi] ?? 0) - my);
+          if (d > MATCH_DIST_M) continue;
+          if (!bearingOk(store.bearingDeg[pi] ?? 0, bearing)) continue;
+          if (store.lastRoute[pi] === routeIdx) {
+            alreadyCounted = true; // guard: a route must never add twice
+          } else if (d < bestD) {
+            bestD = d;
+            best = pi;
+          }
+        }
+      }
+    }
+
+    if (best >= 0) {
+      store.total[best] = (store.total[best] ?? 0) + mean;
+      store.lastRoute[best] = routeIdx;
+    } else if (!alreadyCounted) {
+      // emit a new corridor piece owned by this route
+      if (store.count === store.mx.length) growPieceStore(store);
+      const pi = store.count;
+      store.count += 1;
+      store.mx[pi] = mx;
+      store.my[pi] = my;
+      store.bearingDeg[pi] = bearing;
+      store.total[pi] = mean;
+      store.p0lon[pi] = x0 / mPerDegLon;
+      store.p0lat[pi] = y0 / M_PER_DEG;
+      store.p1lon[pi] = x1 / mPerDegLon;
+      store.p1lat[pi] = y1 / M_PER_DEG;
+      store.seq[pi] = seq;
+      store.lastRoute[pi] = routeIdx;
+      const ck = cellKey(cx, cy);
+      const cell = grid.get(ck);
+      if (cell === undefined) grid.set(ck, [pi]);
+      else cell.push(pi);
+      owned.push(pi);
+    }
+    // else: the corridor already counted this route on this stretch —
+    // emitting a duplicate line or adding again would both be wrong.
+  }
+  return owned;
+}
+
+/** Emit one run of same-owner consecutive same-bucket pieces as a feature.
+ * j/b are fixed BEFORE geometry post-processing, so simplify + quantize can
+ * only shave bytes, never change what the feature claims. */
+function emitRun(store: PieceStore, run: readonly number[], out: CoverageFeature[]): void {
+  const first = run[0];
+  if (first === undefined) return;
+  let totalSum = 0;
+  const coords: LonLat[] = [[store.p0lon[first] ?? 0, store.p0lat[first] ?? 0]];
+  for (const pi of run) {
+    totalSum += store.total[pi] ?? 0;
+    coords.push([store.p1lon[pi] ?? 0, store.p1lat[pi] ?? 0]);
+  }
+  const quantized = quantizePolyline(simplifyPolyline(coords, COVERAGE_TOLERANCE_M));
+  // 4-decimal rounding can collapse a short tail piece onto its neighbour;
+  // GeoJSON LineStrings must not carry repeated positions, so drop them.
+  const line = quantized.filter(
+    (p, i) => i === 0 || p[0] !== quantized[i - 1]?.[0] || p[1] !== quantized[i - 1]?.[1],
+  );
+  if (line.length < 2) return;
+  out.push({
+    type: 'Feature',
+    properties: {
+      // j is the run MEAN — pieces in one run share a bucket, so the true
+      // per-point total varies at most within that bucket's bounds. Any
+      // future tap-to-inspect UI should present it as "~j/day", not exact.
+      j: Math.round(totalSum / run.length),
+      b: assignBucket(store.total[first] ?? 0),
+    },
+    geometry: { type: 'LineString', coordinates: line },
+  });
+}
+
+/** Split one owner route's emitted pieces into runs: break on a walk gap
+ * (matched pieces in between) or a bucket change, then emit each run. */
+function emitOwnerRuns(store: PieceStore, owned: readonly number[], out: CoverageFeature[]): void {
+  let runStart = 0;
+  for (let i = 1; i <= owned.length; i += 1) {
+    const prev = owned[i - 1];
+    const cur = owned[i];
+    const breaks =
+      cur === undefined ||
+      prev === undefined ||
+      (store.seq[cur] ?? 0) !== (store.seq[prev] ?? 0) + 1 ||
+      assignBucket(store.total[cur] ?? 0) !== assignBucket(store.total[prev] ?? 0);
+    if (breaks) {
+      emitRun(store, owned.slice(runStart, i), out);
+      runStart = i;
+    }
+  }
+}
+
+/** How many routes to process between event-loop yields. The corridor walk
+ * is heavier per route than the old per-route Douglas-Peucker, so the stride
+ * is smaller — chunks stay tens of milliseconds. */
+const YIELD_EVERY_ROUTES = 50;
+
+/** Assemble the corridor artifact. Routes with a zero rolling mean carry no
+ * journeys in the window and are DROPPED (drawing them would claim service
+ * that does not exist). The rest are walked busiest-first so each corridor's
+ * canonical geometry comes from the busiest route through it. Async because
+ * the full walk over ~1800 routes would stall the event loop this process
+ * also serves live traffic from — it yields every YIELD_EVERY_ROUTES. */
+export async function buildCoverageArtifact(
+  polylines: ReadonlyMap<string, readonly LonLat[]>,
+  means: ReadonlyMap<string, number>,
+  day: string,
+  windowDays: number,
+): Promise<CoverageArtifact> {
+  const routes: Array<{ key: string; poly: readonly LonLat[]; mean: number }> = [];
+  for (const [key, poly] of polylines) {
+    const mean = means.get(key) ?? 0;
+    if (mean > 0 && poly.length >= 2) routes.push({ key, poly, mean });
+  }
+  // Busiest first; key tiebreak → byte-identical artifacts for equal inputs.
+  routes.sort((a, b) => b.mean - a.mean || a.key.localeCompare(b.key));
+
+  // Projection reference latitude from the data itself (mean of route first
+  // vertices) — see the note by BEARING_TOL_DEG: a hardcoded latitude would
+  // silently corrupt matching for regions far from London.
+  const latSum = routes.reduce((sum, r) => sum + (r.poly[0]?.[1] ?? 0), 0);
+  const meanLat = routes.length > 0 ? latSum / routes.length : 0;
+  const mPerDegLon = M_PER_DEG * Math.cos((meanLat * Math.PI) / 180);
+
+  const store = makePieceStore();
+  const grid = new Map<number, number[]>();
+  const ownedByRoute: number[][] = [];
+  for (let ri = 0; ri < routes.length; ri += 1) {
+    const route = routes[ri];
+    ownedByRoute.push(
+      route === undefined ? [] : walkRoute(store, grid, ri, route.poly, route.mean, mPerDegLon),
+    );
+    if (ri % YIELD_EVERY_ROUTES === YIELD_EVERY_ROUTES - 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+
+  const features: CoverageFeature[] = [];
+  for (let ri = 0; ri < ownedByRoute.length; ri += 1) {
+    emitOwnerRuns(store, ownedByRoute[ri] ?? [], features);
+    if (ri % YIELD_EVERY_ROUTES === YIELD_EVERY_ROUTES - 1) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+
+  return { type: 'FeatureCollection', day, windowDays, features };
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** learned/<sanitized key>.json → polyline, best-effort per file. */
+async function loadLearnedPolylines(learnedDir: string): Promise<Map<string, LonLat[]>> {
+  const out = new Map<string, LonLat[]>();
+  let names: string[];
+  try {
+    names = (await readdir(learnedDir)).filter((n) => !n.startsWith('.') && n.endsWith('.json'));
+  } catch {
+    return out; // learner hasn't produced anything yet
+  }
+  for (const name of names) {
+    try {
+      const parsed = JSON.parse(await readFile(join(learnedDir, name), 'utf8')) as {
+        poly?: unknown;
+      };
+      const poly = parsed.poly;
+      const isValid =
+        Array.isArray(poly) &&
+        poly.length >= 2 &&
+        poly.every(
+          (p) => Array.isArray(p) && typeof p[0] === 'number' && typeof p[1] === 'number',
+        );
+      if (isValid) out.set(name.slice(0, -'.json'.length), poly as LonLat[]);
+    } catch {
+      // one unreadable learned file must not sink the artifact
+    }
+  }
+  return out;
+}
+
+/** One Map<sanitizedKey, journeys> per window day. Distinct raw keys that
+ * sanitize identically (the go2/Go2 case split) are summed, not clobbered. */
+async function loadWindowJourneys(
+  rollupsDir: string,
+  days: readonly string[],
+  log: (msg: string) => void = () => {},
+): Promise<Array<Map<string, number>>> {
+  const perDay: Array<Map<string, number>> = [];
+  for (const day of days) {
+    const journeys = new Map<string, number>();
+    try {
+      const parsed = JSON.parse(await readFile(join(rollupsDir, `${day}.json`), 'utf8')) as {
+        routes?: Record<string, { journeys?: unknown }>;
+      };
+      for (const [rawKey, stats] of Object.entries(parsed.routes ?? {})) {
+        // Optional-chain: a null/malformed ENTRY must only lose itself, never
+        // throw and void every valid route in the same day file.
+        const value = (stats as { journeys?: unknown } | null)?.journeys;
+        if (typeof value !== 'number' || !Number.isFinite(value)) continue;
+        const key = sanitizeKey(rawKey);
+        journeys.set(key, (journeys.get(key) ?? 0) + value);
+      }
+    } catch {
+      log(`coverage: rollup day ${day} unreadable — counted as zeros`);
+      // the window still averages over it so one bad file cannot inflate
+      // every route's mean
+    }
+    perDay.push(journeys);
+  }
+  return perDay;
+}
+
+/** Full disk-to-disk rebuild. Skips (with a log line) until both inputs
+ * exist; writes tmp + rename so a crash mid-write never truncates the
+ * artifact readers are serving. */
+export async function generateCoverage(
+  baseDir: string,
+  log: (msg: string) => void,
+): Promise<void> {
+  const rollupsDir = join(baseDir, 'bus-rollups');
+  const learnedDir = join(baseDir, 'bus-routes', 'learned');
+  let rollupNames: string[];
+  try {
+    rollupNames = await readdir(rollupsDir);
+  } catch {
+    rollupNames = [];
+  }
+  const days = selectWindowDays(rollupNames, Date.now());
+  if (days.length === 0) {
+    log('coverage: no completed rollup days yet — skipped');
+    return;
+  }
+  const polylines = await loadLearnedPolylines(learnedDir);
+  if (polylines.size === 0) {
+    log('coverage: no learned routes yet — skipped');
+    return;
+  }
+  const means = computeRollingMeans(await loadWindowJourneys(rollupsDir, days, log));
+  const newestDay = days[days.length - 1] ?? '';
+  const artifact = await buildCoverageArtifact(polylines, means, newestDay, days.length);
+
+  const coverageDir = join(baseDir, 'coverage');
+  await mkdir(coverageDir, { recursive: true });
+  const outPath = join(coverageDir, 'latest.json');
+  const tmpPath = `${outPath}.tmp`;
+  await writeFile(tmpPath, JSON.stringify(artifact), 'utf8');
+  await rename(tmpPath, outPath);
+  log(
+    `coverage: wrote day=${newestDay} window=${days.length}d — ` +
+      `${polylines.size} routes into ${artifact.features.length} corridor features`,
+  );
+}
+
+/** Boot build only when the artifact is missing, then every 6 h regardless —
+ * the recompute is pure local-disk work, so unconditional beats tracking
+ * which rollup day it last saw. `baseDir` is the resolved bus data dir. */
+export function startCoverageWriter(
+  baseDir: string,
+  log: (msg: string) => void,
+): { stop: () => void } {
+  let running = false;
+  const run = async (): Promise<void> => {
+    if (running) return; // re-entrancy guard, mirrors RollupWriter.catchUp
+    running = true;
+    try {
+      await generateCoverage(baseDir, log);
+    } catch (err) {
+      // leave the previous artifact serving; the 6 h cycle retries
+      log(`coverage: generation failed (will retry): ${String(err)}`);
+    } finally {
+      running = false;
+    }
+  };
+  void (async () => {
+    if (!(await fileExists(join(baseDir, 'coverage', 'latest.json')))) await run();
+  })();
+  const timer = setInterval(() => void run(), REGEN_INTERVAL_MS);
+  timer.unref();
+  return { stop: () => clearInterval(timer) };
+}

--- a/backend/src/routes/capabilities.test.ts
+++ b/backend/src/routes/capabilities.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { registerCapabilitiesRoute } from './capabilities';
+import type { AppConfig } from '../config';
+
+// Only the fields buildCapabilities reads; everything credential-ish is unset
+// so the busCoverage flag is the sole moving part under test.
+const CONFIG = {
+  region: {
+    name: 'Testville',
+    centerLon: -0.1,
+    centerLat: 51.5,
+    zoom: 11,
+    viewBounds: { minLon: -0.65, minLat: 51.2, maxLon: 0.45, maxLat: 51.77 },
+    tideGauges: false,
+    pmtilesUrl: undefined,
+  },
+} as unknown as AppConfig;
+
+describe('capabilities busCoverage flag', () => {
+  let app: FastifyInstance;
+  let busDataDir: string;
+
+  const layers = async (): Promise<Record<string, boolean>> => {
+    const res = await app.inject({ method: 'GET', url: '/api/capabilities' });
+    return (res.json() as { layers: Record<string, boolean> }).layers;
+  };
+
+  beforeEach(async () => {
+    busDataDir = await mkdtemp(join(tmpdir(), 'caps-test-'));
+    app = Fastify();
+    registerCapabilitiesRoute(app, CONFIG, join(busDataDir, 'no-baked-data'), busDataDir);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await rm(busDataDir, { recursive: true, force: true });
+  });
+
+  it('is false while no coverage artifact exists', async () => {
+    expect((await layers()).busCoverage).toBe(false);
+  });
+
+  it('stays false when only the writer INPUTS exist — the toggle must never dead-click', async () => {
+    // Inputs (learned routes + rollups) can precede the first artifact build
+    // by hours; a flag keyed on inputs would render a toggle whose fetch 404s.
+    await mkdir(join(busDataDir, 'bus-routes', 'learned'), { recursive: true });
+    await writeFile(join(busDataDir, 'bus-routes', 'learned', 'TFLO_88_outbound.json'), '{}');
+    await mkdir(join(busDataDir, 'bus-rollups'), { recursive: true });
+    await writeFile(join(busDataDir, 'bus-rollups', '2026-08-27.json'), '{}');
+
+    expect((await layers()).busCoverage).toBe(false);
+  });
+
+  it('flips true WITHOUT a restart once the coverage artifact lands', async () => {
+    // The coverage writer produces its first artifact mid-process on a fresh
+    // volume; a boot-frozen flag would hide the feature until a redeploy.
+    expect((await layers()).busCoverage).toBe(false);
+
+    await mkdir(join(busDataDir, 'coverage'), { recursive: true });
+    await writeFile(join(busDataDir, 'coverage', 'latest.json'), '{"type":"FeatureCollection"}');
+
+    expect((await layers()).busCoverage).toBe(true);
+  });
+});

--- a/backend/src/routes/capabilities.ts
+++ b/backend/src/routes/capabilities.ts
@@ -10,9 +10,17 @@
 // touching this file.
 
 import { existsSync } from 'node:fs';
+import { stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import type { AppConfig } from '../config';
+
+/** The coverage flag means "GET /api/coverage will answer 200 right now", so
+ * it watches the ARTIFACT file, not the writer's inputs — anything else opens
+ * a window where the toggle renders but the fetch 404s. */
+function coverageArtifactPath(busDataDir: string): string {
+  return join(busDataDir, 'coverage', 'latest.json');
+}
 
 export interface Capabilities {
   readonly region: {
@@ -28,9 +36,19 @@ export interface Capabilities {
   readonly layers: Readonly<Record<string, boolean>>;
 }
 
-export function buildCapabilities(config: AppConfig, bakedDataDir: string): Capabilities {
+export function buildCapabilities(
+  config: AppConfig,
+  bakedDataDir: string,
+  busDataDir: string,
+): Capabilities {
   const { region } = config;
   const hasTfl = config.tflAppKey !== undefined;
+
+  // The coverage flow-map is derived offline from learned route polylines and
+  // daily rollups. No credential is involved: a deployment that lost its BODS
+  // key can still draw the map it already earned. True only once the writer
+  // has actually produced a servable artifact.
+  const hasBusCoverage = existsSync(coverageArtifactPath(busDataDir));
 
   // Line geometry and station points come from baked data on disk, NOT from a
   // credential — a region can have a drawn network with no operator API at all
@@ -67,6 +85,7 @@ export function buildCapabilities(config: AppConfig, bakedDataDir: string): Capa
       bikePoints: hasTfl,
       // Independent feeds, each gated by its own credential or flag.
       buses: config.bodsApiKey !== undefined,
+      busCoverage: hasBusCoverage,
       nationalRail: config.darwinToken !== undefined,
       bikeStations: config.gbfsUrl !== undefined,
       vessels: config.aisApiKey !== undefined,
@@ -83,7 +102,26 @@ export function registerCapabilitiesRoute(
   app: FastifyInstance,
   config: AppConfig,
   bakedDataDir: string,
+  busDataDir: string,
 ): void {
-  const payload = buildCapabilities(config, bakedDataDir);
-  app.get('/api/capabilities', () => payload);
+  let payload = buildCapabilities(config, bakedDataDir, busDataDir);
+  app.get('/api/capabilities', async () => {
+    // busCoverage is the one flag derived from a runtime-WRITTEN file rather
+    // than config or baked data: on a fresh volume it is false at boot and
+    // flips days later within this same process, when the coverage writer's
+    // first artifact lands. Re-check per request until it flips (the artifact
+    // is never deleted), then stop paying the stat. Async so the pre-flip
+    // window never blocks the event loop — every other flag stays a boot-time
+    // constant.
+    if (!payload.layers.busCoverage) {
+      const servable = await stat(coverageArtifactPath(busDataDir)).then(
+        (s) => s.isFile(),
+        () => false,
+      );
+      if (servable) {
+        payload = { ...payload, layers: { ...payload.layers, busCoverage: true } };
+      }
+    }
+    return payload;
+  });
 }

--- a/backend/src/routes/coverage.test.ts
+++ b/backend/src/routes/coverage.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { registerCoverageRoute } from './coverage';
+
+describe('coverage route', () => {
+  let app: FastifyInstance;
+  let coverageDir: string;
+
+  beforeEach(async () => {
+    coverageDir = await mkdtemp(join(tmpdir(), 'coverage-test-'));
+    app = Fastify();
+    registerCoverageRoute(app, coverageDir);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    await rm(coverageDir, { recursive: true, force: true });
+  });
+
+  it('serves the artifact with the 6h cache header', async () => {
+    const artifact = '{"type":"FeatureCollection","day":"2026-08-27","features":[]}';
+    await writeFile(join(coverageDir, 'latest.json'), artifact);
+
+    const res = await app.inject({ method: 'GET', url: '/api/coverage' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toMatch(/^application\/json\b/);
+    expect(res.headers['cache-control']).toBe('public, max-age=21600');
+    expect(res.body).toBe(artifact);
+  });
+
+  it('returns an uncacheable 404 before the first build', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/coverage' });
+
+    expect(res.statusCode).toBe(404);
+    // no-store: an edge-cached 404 would outlive the artifact landing
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.json()).toEqual({ error: 'coverage artifact not generated yet' });
+  });
+
+  it('reports a non-ENOENT read failure as a 500, not a benign 404', async () => {
+    // a directory at the artifact path makes readFile fail with EISDIR
+    await mkdir(join(coverageDir, 'latest.json'));
+
+    const res = await app.inject({ method: 'GET', url: '/api/coverage' });
+
+    expect(res.statusCode).toBe(500);
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.json()).toEqual({ error: 'coverage read failed' });
+  });
+});

--- a/backend/src/routes/coverage.ts
+++ b/backend/src/routes/coverage.ts
@@ -1,0 +1,45 @@
+// Bus-coverage flow-map endpoint.
+//
+//   GET /api/coverage → the prebuilt six-bucket GeoJSON, 404 until first build
+//
+// The artifact is written by coverage-writer.ts under <busDataDir>/coverage/.
+// A 6 h HTTP max-age matches the writer's regeneration cadence (rain-radar
+// style): the payload only changes when the rolling window advances, so
+// letting the CDN hold it for a full cycle costs no freshness and saves the
+// origin→CDN egress this deployment is billed by.
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { FastifyInstance } from 'fastify';
+
+const COVERAGE_MAX_AGE_S = 21_600;
+
+export function registerCoverageRoute(app: FastifyInstance, coverageDir: string): void {
+  app.get('/api/coverage', async (_req, reply) => {
+    try {
+      // read-then-send (not a stream) so a concurrent tmp+rename rebuild can
+      // never interleave with an in-flight response
+      const body = await readFile(join(coverageDir, 'latest.json'), 'utf8');
+      return await reply
+        .header('content-type', 'application/json')
+        .header('cache-control', `public, max-age=${COVERAGE_MAX_AGE_S}`)
+        .send(body);
+    } catch (err) {
+      // no-store on both error paths: an edge-cached 404 would keep answering
+      // "not yet" for its whole TTL after the artifact actually lands.
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+        return reply
+          .code(404)
+          .header('cache-control', 'no-store')
+          .send({ error: 'coverage artifact not generated yet' });
+      }
+      // Anything else (permissions, disk I/O) is a real server fault — do not
+      // disguise it as the benign pre-first-build state.
+      app.log.error({ err }, 'coverage: artifact read failed');
+      return reply
+        .code(500)
+        .header('cache-control', 'no-store')
+        .send({ error: 'coverage read failed' });
+    }
+  });
+}

--- a/frontend/src/layers/coverage.ts
+++ b/frontend/src/layers/coverage.ts
@@ -1,0 +1,109 @@
+// Bus-coverage flow map. Each feature is a deduplicated ROAD CORRIDOR (built
+// server-side by merging all learned route polylines that traverse it), with
+// properties j = total journeys/day across every route and direction on that
+// road, and b = absolute bucket 0..5 (edges ~10/30/75/150/300 journeys/day).
+// Every road is drawn exactly once, so brightness IS the total service level —
+// three 1/day routes sharing a street show 3, one 30/day route shows 30. j is
+// carried for a future tap-to-inspect; styling reads only b.
+//
+// Lazy by design: the artifact is ~1 MB compressed, so nothing is fetched
+// until the user first toggles the overlay on. The layer itself must still
+// exist from start() (empty source, hidden) or the legend would drop the
+// toggle for a layer it cannot find.
+
+import type { Map as MaplibreMap, GeoJSONSource } from 'maplibre-gl';
+
+export const BUS_COVERAGE_LAYER_ID = 'bus-coverage';
+const SOURCE_ID = 'bus-coverage';
+const COVERAGE_URL = '/api/coverage';
+/** Beneath the transit line casings, same anchor as the rain radar — anything
+ * that drives or floats is added above the static network, so this guarantees
+ * the glow sits under bus dots without depending on bus start timing. */
+const INSERT_BEFORE_LAYER_ID = 'transit-lines-casing';
+
+const EMPTY: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
+
+/** 'idle' allows a fetch; 'pending' blocks re-entry while one is in flight;
+ * 'loaded' means the source holds real data and toggles are pure visibility
+ * flips. A failed fetch returns to 'idle' so the next toggle-on retries. */
+let fetchState: 'idle' | 'pending' | 'loaded' = 'idle';
+
+/**
+ * Adds the (empty, hidden) source + layer. No network traffic here — data
+ * arrives on the first toggle-on via setBusCoverageVisible.
+ */
+export function startBusCoverage(map: MaplibreMap): Promise<void> {
+  map.addSource(SOURCE_ID, { type: 'geojson', data: EMPTY });
+  map.addLayer(
+    {
+      id: BUS_COVERAGE_LAYER_ID,
+      type: 'line',
+      source: SOURCE_ID,
+      layout: {
+        'line-cap': 'round',
+        'line-join': 'round',
+        visibility: 'none', // off by default; toggled via the legend
+      },
+      paint: {
+        // Deep teal → ice-white ("ice", user-picked over warm/neon/mono
+        // ramps): cool glow against the dark basemap that the crimson bus
+        // dots sit on as a complementary color. Quiet roads (low b) stay
+        // near-invisible; only busy corridors turn properly bright.
+        'line-color': [
+          'interpolate',
+          ['linear'],
+          ['get', 'b'],
+          0,
+          '#0c2733',
+          3,
+          '#0891b2',
+          5,
+          '#a5f3fc',
+        ],
+        'line-width': ['interpolate', ['linear'], ['get', 'b'], 0, 0.5, 3, 1.6, 5, 3.8],
+        'line-opacity': ['interpolate', ['linear'], ['get', 'b'], 0, 0.22, 3, 0.55, 5, 0.9],
+        // Blur grows with width so heavy corridors get a soft halo rather
+        // than a hard stroke.
+        'line-blur': ['interpolate', ['linear'], ['get', 'b'], 0, 0.3, 5, 1.4],
+      },
+    },
+    // Regions without a drawn transit network lack the anchor layer, and
+    // passing a missing id makes addLayer throw. Undefined means "top of the
+    // stack as of now" — still beneath every vehicle layer added after.
+    map.getLayer(INSERT_BEFORE_LAYER_ID) ? INSERT_BEFORE_LAYER_ID : undefined,
+  );
+  return Promise.resolve();
+}
+
+/** Legend toggle handler: visibility flip, plus the one-time lazy fetch. */
+export function setBusCoverageVisible(map: MaplibreMap, visible: boolean): void {
+  if (!map.getLayer(BUS_COVERAGE_LAYER_ID)) return;
+  map.setLayoutProperty(BUS_COVERAGE_LAYER_ID, 'visibility', visible ? 'visible' : 'none');
+  if (visible && fetchState === 'idle') void loadCoverage(map);
+}
+
+async function loadCoverage(map: MaplibreMap): Promise<void> {
+  fetchState = 'pending';
+  try {
+    const res = await fetch(COVERAGE_URL);
+    // 404 is the contract's "no artifact yet" — same recovery as any failure:
+    // the toggle shows nothing now and a later re-toggle retries.
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as GeoJSON.FeatureCollection;
+    // Minimal shape guard: a 200 from an intermediary (error page, captive
+    // portal) must fail into the retryable path, not reach setData.
+    if (data?.type !== 'FeatureCollection' || !Array.isArray(data.features)) {
+      throw new Error('unexpected coverage payload shape');
+    }
+    const src = map.getSource(SOURCE_ID);
+    if (src && 'setData' in src) {
+      (src as GeoJSONSource).setData(data);
+      fetchState = 'loaded';
+      return;
+    }
+    throw new Error('coverage source missing');
+  } catch (error) {
+    console.warn('[coverage]', error);
+    fetchState = 'idle';
+  }
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -31,6 +31,7 @@ import { startTideGauges, TIDE_GAUGES_LAYER_IDS } from './layers/tide-gauges';
 import { startRainRadar, RAIN_RADAR_LAYER_ID } from './layers/rain-radar';
 import { startBikeStations, BIKE_STATIONS_LAYER_ID } from './layers/bike-stations';
 import { startSimulatedTrains, SIMULATED_TRAINS_LAYER_ID } from './layers/simulated-trains';
+import { startBusCoverage, setBusCoverageVisible, BUS_COVERAGE_LAYER_ID } from './layers/coverage';
 import { hasLayer, loadCapabilities } from './region';
 
 const TOAST_DISMISS_MS = 4000;
@@ -205,7 +206,9 @@ async function bootstrap(): Promise<void> {
     hasLayer('trainPositions') || hasLayer('stopArrivals')
       ? '<a href="https://tfl.gov.uk/info-for/open-data-users/" target="_blank" rel="noopener">Powered by TfL Open Data</a>'
       : null,
-    hasLayer('buses')
+    // busCoverage is BODS-derived too — the corner credit must survive a
+    // deployment losing its live key while still drawing earned coverage.
+    hasLayer('buses') || hasLayer('busCoverage')
       ? '<a href="https://www.bus-data.dft.gov.uk/" target="_blank" rel="noopener">DfT BODS</a>'
       : null,
     // Corner keeps only the legally required OSM notice; the Protomaps tile
@@ -446,6 +449,19 @@ async function addTransitOverlays(target: maplibregl.Map): Promise<void> {
       row: 9,
       start: () => startRainRadar(target),
       overlay: { label: 'Rain radar', layerIds: [RAIN_RADAR_LAYER_ID], startOff: true },
+    },
+    {
+      name: 'busCoverage',
+      row: 10,
+      start: () => startBusCoverage(target),
+      overlay: {
+        label: 'Coverage',
+        layerIds: [BUS_COVERAGE_LAYER_ID],
+        startOff: true,
+        // Custom handler because the first toggle-on also triggers the lazy
+        // one-time artifact fetch; afterwards it is a plain visibility flip.
+        onToggle: (visible: boolean) => setBusCoverageVisible(target, visible),
+      },
     },
   ];
 

--- a/frontend/src/region.ts
+++ b/frontend/src/region.ts
@@ -51,6 +51,7 @@ const LONDON_FALLBACK: Capabilities = {
     roadDisruptions: true,
     bikePoints: true,
     buses: true,
+    busCoverage: true,
     nationalRail: true,
     bikeStations: true,
     vessels: true,

--- a/frontend/src/ui/about.ts
+++ b/frontend/src/ui/about.ts
@@ -41,7 +41,9 @@ function buildCredits(): CreditEntry[] {
         'and Geomni UK Map data © and database rights 2019.',
     },
     {
-      when: hasLayer('buses'),
+      // busCoverage is BODS-derived too (learned from SIRI-VM traces): the
+      // credit must survive losing the live key while coverage still renders.
+      when: hasLayer('buses') || hasLayer('busCoverage'),
       html: `Buses: ${link('https://www.bus-data.dft.gov.uk/', 'DfT BODS')} (OGL v3).`,
     },
     {


### PR DESCRIPTION
## Summary

A new default-off **Coverage** overlay (Lines tab): every bus-served road drawn once, ice-blue, brightness = **total journeys/day across all routes and directions on that road** (absolute buckets <10 / 10-30 / 30-75 / 75-150 / 150-300 / 300+). Product goal: let users judge which streets have the most bus service.

**Backend** — `coverage-writer.ts` corridor-merge aggregation: 1,800 learned polylines walked busiest-first, 25 m resample, 18 m / ±25° grid-hash matching (antiparallel = same road) so overlapping routes SUM onto one corridor instead of overdrawing; per-piece guard prevents resampling double-adds without undercounting shared roads (regression-tested with a phase-shifted route). Rolling ≤7-day mean weights, 6 h unconditional regen (pure local disk, zero egress), atomic writes, data-derived projection latitude (Dubai-safe). Artifact: ~48.5k features {j, b}, **0.87 MB brotli**.

**Serving** — `GET /api/coverage`, `Cache-Control: public, max-age=21600` matching the regen cadence; ENOENT → no-store 404, other errors → no-store 500. `busCoverage` capability watches the **artifact file** (async stat until flip): the toggle can never appear before the fetch would succeed, and fresh deployments pick it up without restart.

**Frontend** — lazy layer: zero fetch until first toggle-on, one fetch per session, then pure visibility flips; payload shape-guarded; inserted beneath transit casings. BODS credit now gated on `buses || busCoverage`.

**Egress**: default off + one ~0.87 MB fetch per opted-in session + 6 h cacheable. Regeneration is local-disk only.

## Review

Workflow-orchestrated: prototype (validated on the local raw-data archive: dedup ×2.6, mis-merge spot-checks clean, Elephant & Castle 41-route sum verified exact) → implementation → two independent review passes. All HIGH/MEDIUM findings fixed: artifact-based capability (kills both the sync-readdir-per-request and the dead-toggle window), per-piece guard scope documented + regression-pinned, data-derived projection latitude, degenerate-vertex drop, frontend payload guard, .gitignore for runtime dirs.

## Test plan

- [x] backend `tsc` + **78/78** vitest (24 corridor-math tests: identical/antiparallel merge, out-and-back no-double-add, phase-shift no-skip, 17 m merge vs 30 m separate, bucket-edge split, degenerate drop, 4-dp quantize)
- [x] frontend `tsc` + 89/89 + `vite build`
- [x] Full-artifact generation from real data via the final TS code: 48,554 features, 1.2 s build, 869 KB brotli, all 6 buckets
- [x] Rendered locally with all layers; visuals user-approved (ice palette)
- [x] User-verified on real phone via HTTPS tunnel