### PR TITLE
chore: rename the Coverage overlay to Bus Flow

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -455,7 +455,10 @@ async function addTransitOverlays(target: maplibregl.Map): Promise<void> {
       row: 10,
       start: () => startBusCoverage(target),
       overlay: {
-        label: 'Coverage',
+        // "Bus Flow", not "Coverage": coverage reads as telecom/insurance
+        // jargon, while the layer answers "how much bus service flows down
+        // this road" — the label should say so.
+        label: 'Bus Flow',
         layerIds: [BUS_COVERAGE_LAYER_ID],
         startOff: true,
         // Custom handler because the first toggle-on also triggers the lazy


### PR DESCRIPTION
One-line UX rename: the Lines-tab overlay toggle **Coverage** → **Bus Flow**. 'Coverage' reads as telecom/insurance jargon; the layer shows how much bus service flows down each road, so the label now says that. No behavior change; 89/89 frontend tests green.

Internal identifiers (`busCoverage` capability, `/api/coverage`, layer ids) are unchanged — they're API surface, not user-facing.