### PR TITLE
feat: real-time bus diversion detection + map event layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ data/**/bus-routes/
 data/**/bus-rollups/
 data/**/tube-status/
 data/**/road-disruptions/
+data/**/diversions/
 data/**/coverage/
 data/**/leaderboard.json
 data/**/leaderboard.json.tmp
@@ -31,6 +32,7 @@ data/bus-routes/
 data/bus-rollups/
 data/tube-status/
 data/road-disruptions/
+data/diversions/
 data/coverage/
 data/leaderboard.json
 data/leaderboard.json.tmp

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -12,6 +12,7 @@ import { GbfsClient } from './gbfs-client';
 import { TtlCache } from './cache';
 import { type AppConfig, resolveBusDataDir } from './config';
 import { startCoverageWriter } from './coverage-writer';
+import { startDiversionDetector, type DiversionDetector } from './diversion-detector';
 import { ARRIVALS_CACHE_TTL_MS, TFL_BUDGET_LIMIT, TFL_BUDGET_WINDOW_MS } from './constants';
 import {
   LeaderboardTracker,
@@ -49,6 +50,7 @@ import { registerAircraftPhotoRoute } from './routes/aircraft-photo';
 import { registerBusRoutesRoute } from './routes/bus-routes';
 import { registerCoverageRoute } from './routes/coverage';
 import { registerDataExportRoute } from './routes/data-export';
+import { registerDiversionsRoute } from './routes/diversions';
 import { registerShipPhotoRoute } from './routes/ship-photo';
 
 /** Repo layout anchors — data/ and scripts/ sit beside backend/. */
@@ -72,6 +74,11 @@ function resolveBakedDataDir(): string {
   return isAbsolute(configured) ? configured : join(REPO_ROOT, configured);
 }
 const DATA_DIR = resolveBakedDataDir();
+
+/** Fresh-volume retry cadence for the diversion detector: the learner needs
+ * days of traces before the learned dir exists, so a boot-only check would
+ * disable the feature until a redeploy. 30 min is modest — one existsSync. */
+const DIVERSIONS_RETRY_INTERVAL_MS = 30 * 60_000;
 
 /** Builds the Fastify app with all plugins and routes; exported for tests (inject()). */
 export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
@@ -131,15 +138,38 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
 
   // All-London live buses (optional feature — needs a BODS key in .env)
   let bodsClient: BodsClient | null = null;
+  let diversions: DiversionDetector | null = null;
   if (config.bodsApiKey) {
     // Trace log + self-scheduled route learner ride along with the poller.
     const traces = new TraceWriter(join(busDataDir, 'bus-traces'), (msg) => app.log.info(msg));
     traces.start();
+    // Diversion detection also rides the poll, but only once the learner has
+    // produced polylines to project against. On a fresh volume that happens
+    // DAYS after boot, so a missing dir starts a modest retry instead of
+    // disabling the feature until redeploy (same bug class the capabilities
+    // busCoverage flag already fixed): re-check every 30 min, start the
+    // detector once, then stop retrying. The poll callback reads the mutable
+    // `diversions` binding, so a late start is picked up on the next poll.
+    const learnedDir = join(busDataDir, 'bus-routes', 'learned');
+    if (existsSync(learnedDir)) {
+      diversions = startDiversionDetector(busDataDir, (msg) => app.log.info(msg));
+    } else {
+      const retryTimer = setInterval(() => {
+        if (!existsSync(learnedDir)) return;
+        clearInterval(retryTimer);
+        diversions = startDiversionDetector(busDataDir, (msg) => app.log.info(msg));
+      }, DIVERSIONS_RETRY_INTERVAL_MS);
+      retryTimer.unref();
+      app.addHook('onClose', () => clearInterval(retryTimer));
+    }
     const bods = new BodsClient(
       config.bodsApiKey,
       config.region.bbox,
       (msg) => app.log.info(msg),
-      (buses, now) => traces.record(buses, now),
+      (buses, now) => {
+        traces.record(buses, now);
+        diversions?.record(buses, now);
+      },
     );
     bods.start();
     const learner = new LearnerScheduler(SCRIPTS_DIR, busDataDir, (msg) => app.log.info(msg));
@@ -152,6 +182,7 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
       traces.stop();
       learner.stop();
       rollups.stop();
+      diversions?.stop();
     });
     app.get('/api/buses', () => bods.list());
     bodsClient = bods;
@@ -159,6 +190,9 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
     app.get('/api/buses', () => []);
   }
   registerBusRoutesRoute(app, join(busDataDir, 'bus-routes', 'learned'));
+  // A getter, not the instance: the detector may start long after boot (fresh
+  // volume + retry timer above), and the route must see it when it does.
+  registerDiversionsRoute(app, () => diversions);
 
   // Coverage flow-map artifact — derived offline from learned routes +
   // rollups already on disk, so unlike the writers above it needs no BODS key:

--- a/backend/src/diversion-detector.test.ts
+++ b/backend/src/diversion-detector.test.ts
@@ -666,3 +666,23 @@ describe('severity and route labels', () => {
     expect(two.events[0]?.routes).toEqual(['45 → Ealing', '45 → Uxbridge']);
   });
 });
+
+describe('credible-offset guard', () => {
+  test('a kilometres-scale offset is LOW confidence even when moving', () => {
+    const ctx = makeCtx();
+    const fixes = warmupFixes();
+    let t = AFTER_WARMUP_T;
+    // moving the whole time, but 2 km off the route — shape/service mismatch
+    for (let i = 0; i < 6; i++) {
+      t += STEP_S;
+      fixes.push(fixAt(t, 1200 + i * 120, 2000));
+    }
+    fixes.push(fixAt(t + STEP_S, 1920));
+    fixes.push(fixAt(t + 2 * STEP_S, 2040));
+
+    const { completed } = drive(fixes, ctx);
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0]?.confidence).toBe('low');
+  });
+});

--- a/backend/src/diversion-detector.test.ts
+++ b/backend/src/diversion-detector.test.ts
@@ -1,0 +1,668 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { Bus } from './bods-client';
+import {
+  createGuardCounters,
+  createVehicleState,
+  isDiversionDetectorRunning,
+  oppositeKey,
+  startDiversionDetector,
+  stepVehicle,
+  type FixInput,
+  type StepContext,
+} from './diversion-detector';
+import {
+  addExcursion,
+  buildApiEvents,
+  createEventStore,
+  matchTfl,
+  noteOnRouteFix,
+  parseDisruptionSnapshotLine,
+  tickLifecycle,
+  type CompletedExcursion,
+} from './diversion-events';
+import { buildRouteIndex, type LonLat } from './route-projection';
+
+// ---------------------------------------------------------------------------
+// synthetic geometry: a straight 10 km north-south route
+// ---------------------------------------------------------------------------
+
+const LAT0 = 51.5;
+const LON0 = -0.1;
+const M_PER_DEG_LAT = 110_540;
+const M_PER_DEG_LON = 111_320 * Math.cos((51.545 * Math.PI) / 180); // route mean lat
+
+const latAt = (metres: number): number => LAT0 + metres / M_PER_DEG_LAT;
+const lonAt = (offsetM: number): number => LON0 + offsetM / M_PER_DEG_LON;
+
+const ROUTE_KEY = 'OP:45:outbound';
+const ROUTE_POLY: LonLat[] = [
+  [LON0, latAt(0)],
+  [LON0, latAt(10_000)],
+];
+const ROUTE_INDEX = buildRouteIndex(ROUTE_POLY);
+const THR_M = 75; // the no-rollup default: max(50, 5 × 15)
+
+const T0 = 1_000_000;
+const STEP_S = 15;
+
+function makeCtx(overrides: Partial<StepContext> = {}): StepContext {
+  return {
+    key: ROUTE_KEY,
+    veh: 'OP:V1',
+    dest: '',
+    thrM: THR_M,
+    index: ROUTE_INDEX,
+    oppIndex: null,
+    counters: createGuardCounters(),
+    ...overrides,
+  };
+}
+
+/** Fix at along-route position sM with a lateral offset (east = positive). */
+const fixAt = (t: number, sM: number, offsetM = 0): FixInput => ({
+  t,
+  lon: lonAt(offsetM),
+  lat: latAt(sM),
+});
+
+/** Drive one vehicle through a fix sequence, collecting everything emitted. */
+function drive(
+  fixes: readonly FixInput[],
+  ctx: StepContext,
+): { completed: CompletedExcursion[]; onRouteCount: number } {
+  const state = createVehicleState();
+  const completed: CompletedExcursion[] = [];
+  let onRouteCount = 0;
+  for (const fix of fixes) {
+    const result = stepVehicle(state, fix, ctx);
+    completed.push(...result.completed);
+    if (result.onRouteS !== null) onRouteCount += 1;
+  }
+  return { completed, onRouteCount };
+}
+
+/** On-route warm-up from s=0: clears the 500 m clip and banks the ≥2 on-route
+ * fixes the before-bracket needs. Ends at s=1080, t = T0 + 9×15. */
+function warmupFixes(): FixInput[] {
+  const fixes: FixInput[] = [];
+  for (let i = 0; i <= 9; i++) fixes.push(fixAt(T0 + i * STEP_S, i * 120));
+  return fixes;
+}
+const AFTER_WARMUP_T = T0 + 9 * STEP_S;
+
+/** The canonical detour: 150 m parallel offset for 6 fixes, then rejoin. */
+function detourFixes(): FixInput[] {
+  const fixes = warmupFixes();
+  let t = AFTER_WARMUP_T;
+  for (let i = 0; i < 6; i++) {
+    t += STEP_S;
+    fixes.push(fixAt(t, 1200 + i * 120, 150));
+  }
+  fixes.push(fixAt(t + STEP_S, 1920));
+  fixes.push(fixAt(t + 2 * STEP_S, 2040));
+  return fixes;
+}
+
+// ---------------------------------------------------------------------------
+// per-vehicle state machine
+// ---------------------------------------------------------------------------
+
+describe('stepVehicle', () => {
+  test('on-route → parallel offset → rejoin yields one HIGH-confidence excursion', () => {
+    const ctx = makeCtx();
+
+    const { completed } = drive(detourFixes(), ctx);
+
+    expect(completed).toHaveLength(1);
+    const exc = completed[0];
+    expect(exc?.confidence).toBe('high');
+    expect(exc?.key).toBe(ROUTE_KEY);
+    expect(exc?.maxD).toBeGreaterThan(140);
+    expect(exc?.maxD).toBeLessThan(160);
+    // exit at the last on-route fix, rejoin at the first one after
+    expect(Math.abs((exc?.sExit ?? 0) - 1080)).toBeLessThan(2);
+    expect(Math.abs((exc?.sRejoin ?? 0) - 1920)).toBeLessThan(2);
+    expect(exc?.nFix).toBe(6);
+    expect(ctx.counters.completedHigh).toBe(1);
+  });
+
+  test('the first 500 m of a journey never count as evidence', () => {
+    const ctx = makeCtx();
+    // Straight off-route from the depot: offset fixes from the journey start.
+    const fixes: FixInput[] = [];
+    for (let i = 0; i < 8; i++) fixes.push(fixAt(T0 + i * STEP_S, i * 120, 150));
+
+    const { completed, onRouteCount } = drive(fixes.slice(0, 4), ctx);
+
+    expect(completed).toHaveLength(0);
+    expect(onRouteCount).toBe(0); // clipped fixes are not on-route evidence either
+  });
+
+  test('garage pull-in (off-route at journey end, no rejoin) yields nothing', () => {
+    const ctx = makeCtx();
+    const fixes = warmupFixes();
+    let t = AFTER_WARMUP_T;
+    for (let i = 0; i < 8; i++) {
+      t += STEP_S;
+      fixes.push(fixAt(t, 1200 + i * 120, 200)); // veers off toward the garage
+    }
+    fixes.push(fixAt(t + 700, 5_000)); // next journey, 700 s later
+
+    const { completed } = drive(fixes, ctx);
+
+    expect(completed).toHaveLength(0);
+    expect(ctx.counters.completedHigh + ctx.counters.completedLow).toBe(0);
+  });
+
+  test('dwell-only excursion (moving fraction < 30%) is LOW confidence', () => {
+    const ctx = makeCtx();
+    const fixes = warmupFixes();
+    let t = AFTER_WARMUP_T;
+    // two fast off-route hops (real movement ≥ 300 m)…
+    for (const s of [1200, 1400, 1600]) {
+      t += STEP_S;
+      fixes.push(fixAt(t, s, 150));
+    }
+    // …then 20 fixes parked at the same spot
+    for (let i = 0; i < 20; i++) {
+      t += STEP_S;
+      fixes.push(fixAt(t, 1600, 150));
+    }
+    fixes.push(fixAt(t + STEP_S, 1720));
+    fixes.push(fixAt(t + 2 * STEP_S, 1840));
+
+    const { completed } = drive(fixes, ctx);
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0]?.confidence).toBe('low');
+    expect(ctx.counters.completedLow).toBe(1);
+  });
+
+  test('a >180 s gap inside an excursion resets its accumulation', () => {
+    const ctx = makeCtx();
+    const fixes = warmupFixes();
+    let t = AFTER_WARMUP_T;
+    for (const s of [1200, 1320, 1440]) {
+      t += STEP_S;
+      fixes.push(fixAt(t, s, 150));
+    }
+    t += 200; // hole > EXCURSION_GAP_RESET_S, < the 600 s journey split
+    for (const s of [1560, 1680, 1800]) {
+      fixes.push(fixAt(t, s, 150));
+      t += STEP_S;
+    }
+    fixes.push(fixAt(t, 1920));
+    fixes.push(fixAt(t + STEP_S, 2040));
+
+    const { completed } = drive(fixes, ctx);
+
+    // post-reset run is only 3 fixes — below the 5-fix bar, so no excursion
+    expect(completed).toHaveLength(0);
+    expect(ctx.counters.gapResets).toBe(1);
+    expect(ctx.counters.minorRun).toBe(1);
+  });
+
+  test('beyond-terminus wandering is rejected by the endpoint-clamp guard', () => {
+    const ctx = makeCtx();
+    const fixes: FixInput[] = [];
+    let t = T0;
+    for (let i = 0; i <= 10; i++) {
+      fixes.push(fixAt(t, 8000 + i * 120)); // on-route toward the terminus
+      t += STEP_S;
+    }
+    for (let i = 1; i <= 5; i++) {
+      fixes.push(fixAt(t, 10_000 + i * 120)); // straight past the end: s clamps
+      t += STEP_S;
+    }
+    fixes.push(fixAt(t, 9920)); // comes back onto the route
+    fixes.push(fixAt(t + STEP_S, 9800));
+
+    const { completed } = drive(fixes, ctx);
+
+    expect(completed).toHaveLength(0);
+    expect(ctx.counters.clampInvalid).toBe(1);
+  });
+
+  test('direction mislabel: the excursion lies ON the opposite polyline → discarded', () => {
+    const oppositePoly: LonLat[] = [
+      [lonAt(150), latAt(10_000)],
+      [lonAt(150), latAt(0)],
+    ];
+    const ctx = makeCtx({ oppIndex: buildRouteIndex(oppositePoly) });
+
+    const { completed } = drive(detourFixes(), ctx);
+
+    expect(completed).toHaveLength(0);
+    expect(ctx.counters.mislabelDropped).toBe(1);
+  });
+
+  test('wanderer guard: huge ground for a tiny skipped interval → rejected', () => {
+    const ctx = makeCtx();
+    const fixes = warmupFixes();
+    let t = AFTER_WARMUP_T;
+    // 30 fast fixes sweeping 3.5 km east and back while skipping ~600 m of route
+    for (let i = 0; i < 15; i++) {
+      t += STEP_S;
+      fixes.push(fixAt(t, 1200 + i * 20, 150 + i * 230));
+    }
+    for (let i = 14; i >= 0; i--) {
+      t += STEP_S;
+      fixes.push(fixAt(t, 1500 + (14 - i) * 20, 150 + i * 230));
+    }
+    fixes.push(fixAt(t + STEP_S, 1920));
+    fixes.push(fixAt(t + 2 * STEP_S, 2040));
+
+    const { completed } = drive(fixes, ctx);
+
+    expect(completed).toHaveLength(0);
+    expect(ctx.counters.wandererDropped).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// site-keyed clustering + lifecycle
+// ---------------------------------------------------------------------------
+
+function mkExc(overrides: Partial<CompletedExcursion>): CompletedExcursion {
+  return {
+    key: ROUTE_KEY,
+    veh: 'OP:V1',
+    dest: '',
+    t0: T0,
+    t1: T0 + 300,
+    sExit: 1080,
+    sRejoin: 1920,
+    sA: 1080,
+    sB: 1920,
+    maxD: 150,
+    nFix: 6,
+    groundM: 600,
+    midLon: lonAt(150),
+    midLat: latAt(1500),
+    confidence: 'high',
+    ...overrides,
+  };
+}
+
+describe('event clustering', () => {
+  test('two HIGH vehicles at one site within 45 min → one display-worthy event', () => {
+    const store = createEventStore();
+
+    const first = addExcursion(store, mkExc({ veh: 'OP:V1' }), T0 + 300);
+    const second = addExcursion(
+      store,
+      mkExc({ veh: 'OP:V2', t0: T0 + 600, t1: T0 + 900, midLat: latAt(1700) }),
+      T0 + 900,
+    );
+
+    expect(first.map((r) => r.transition)).toEqual(['created']);
+    expect(second.map((r) => r.transition)).toEqual(['displayed']);
+    expect(store.events).toHaveLength(1);
+    expect(store.events[0]?.id).toMatch(/^div-\d{4}-\d{2}-\d{2}-1$/);
+    expect(store.events[0]?.vehicles.size).toBe(2);
+  });
+
+  test('cross-route excursions merge by SITE, not route family', () => {
+    const store = createEventStore();
+
+    addExcursion(store, mkExc({ veh: 'OP:V1' }), T0 + 300);
+    addExcursion(
+      store,
+      mkExc({ key: 'OP:133:inbound', veh: 'OP:V9', midLat: latAt(1600) }),
+      T0 + 300,
+    );
+
+    expect(store.events).toHaveLength(1);
+    expect(store.events[0]?.brackets.size).toBe(2);
+  });
+
+  test('a site 2 km away opens a separate event', () => {
+    const store = createEventStore();
+
+    addExcursion(store, mkExc({}), T0 + 300);
+    addExcursion(store, mkExc({ veh: 'OP:V2', midLat: latAt(3500) }), T0 + 300);
+
+    expect(store.events).toHaveLength(2);
+  });
+
+  test('one vehicle alone is never display-worthy — even excursing twice', () => {
+    const store = createEventStore();
+
+    addExcursion(store, mkExc({}), T0 + 300);
+    addExcursion(store, mkExc({ t0: T0 + 400, t1: T0 + 700 }), T0 + 700);
+
+    expect(store.events[0]?.displayWorthy).toBe(false);
+  });
+
+  test('two LOW-confidence vehicles reach the day log but never the display bar', () => {
+    const store = createEventStore();
+
+    const first = addExcursion(store, mkExc({ confidence: 'low' }), T0 + 300);
+    addExcursion(store, mkExc({ veh: 'OP:V2', confidence: 'low' }), T0 + 400);
+
+    expect(first.map((r) => r.transition)).toEqual(['created']); // logged
+    expect(store.events[0]?.displayWorthy).toBe(false);
+  });
+});
+
+describe('lifecycle', () => {
+  function displayWorthyStore(): ReturnType<typeof createEventStore> {
+    const store = createEventStore();
+    addExcursion(store, mkExc({ veh: 'OP:V1' }), T0 + 300);
+    addExcursion(store, mkExc({ veh: 'OP:V2', t0: T0 + 600, t1: T0 + 900 }), T0 + 900);
+    return store;
+  }
+
+  test('recovery passages by two vehicles flip the event to recovering, then drop it', () => {
+    const store = displayWorthyStore();
+    const transitions: string[] = [];
+    for (const veh of ['OP:R1', 'OP:R2']) {
+      for (let s = 1000; s <= 2000; s += 100) {
+        transitions.push(
+          ...noteOnRouteFix(store, ROUTE_KEY, veh, s, T0 + 2000).map((r) => r.transition),
+        );
+      }
+    }
+
+    expect(transitions).toEqual(['recovering']);
+    expect(store.events[0]?.status).toBe('recovering');
+
+    // 10 min later the recovered event leaves the API entirely
+    const dropped = tickLifecycle(store, T0 + 2000 + 601);
+    expect(dropped.map((r) => r.transition)).toEqual(['dropped']);
+    expect(store.events).toHaveLength(0);
+  });
+
+  test('one recovery vehicle is not enough', () => {
+    const store = displayWorthyStore();
+    for (let s = 1000; s <= 2000; s += 100) {
+      noteOnRouteFix(store, ROUTE_KEY, 'OP:R1', s, T0 + 2000);
+    }
+
+    expect(store.events[0]?.status).toBe('active');
+  });
+
+  test('fresh evidence reactivates a recovering event and resets its passages', () => {
+    const store = displayWorthyStore();
+    for (const veh of ['OP:R1', 'OP:R2']) {
+      for (let s = 1000; s <= 2000; s += 100) noteOnRouteFix(store, ROUTE_KEY, veh, s, T0 + 2000);
+    }
+    expect(store.events[0]?.status).toBe('recovering');
+
+    const transitions = addExcursion(
+      store,
+      mkExc({ veh: 'OP:V3', t0: T0 + 2100, t1: T0 + 2400 }),
+      T0 + 2400,
+    );
+
+    expect(transitions.map((r) => r.transition)).toContain('reactivated');
+    expect(store.events[0]?.status).toBe('active');
+    expect(store.events[0]?.passedVehicles.size).toBe(0);
+  });
+
+  test('active → stale at 90 min without evidence, dropped 6 h after that', () => {
+    const store = displayWorthyStore();
+    const lastEvidence = T0 + 900;
+
+    const toStale = tickLifecycle(store, lastEvidence + 90 * 60);
+    expect(toStale.map((r) => r.transition)).toEqual(['stale']);
+    expect(store.events[0]?.status).toBe('stale'); // still served while stale
+
+    const toDropped = tickLifecycle(store, lastEvidence + 90 * 60 + 6 * 3600);
+    expect(toDropped.map((r) => r.transition)).toEqual(['dropped']);
+    expect(store.events).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API payload + enrichment
+// ---------------------------------------------------------------------------
+
+describe('buildApiEvents', () => {
+  test('serves exactly the contract for a display-worthy event', () => {
+    const store = createEventStore();
+    addExcursion(store, mkExc({ veh: 'OP:V1' }), T0 + 300);
+    addExcursion(store, mkExc({ veh: 'OP:V2', key: 'OP:133:inbound' }), T0 + 900);
+
+    const payload = buildApiEvents(
+      store,
+      T0 + 1000,
+      (key) => (key === ROUTE_KEY ? ROUTE_POLY : null),
+      () => null,
+    );
+
+    expect(payload.generatedAt).toBe(T0 + 1000);
+    expect(payload.events).toHaveLength(1);
+    const ev = payload.events[0];
+    expect(ev?.id).toMatch(/^div-\d{4}-\d{2}-\d{2}-\d+$/);
+    expect(ev?.status).toBe('active');
+    expect(ev?.routes).toEqual(['45', '133']); // human line names, sorted
+    expect(ev?.vehicles).toBe(2);
+    expect(ev?.longRunning).toBe(false);
+    // one segment: the 133 has no learned polyline in this fixture
+    expect(ev?.segments).toHaveLength(1);
+    const segment = ev?.segments[0] ?? [];
+    expect(segment.length).toBeGreaterThanOrEqual(2);
+    // the slice spans the bypassed bracket [1080, 1920]
+    const sOf = (p: readonly [number, number]): number => (p[1] - LAT0) * M_PER_DEG_LAT;
+    expect(Math.abs(sOf(segment[0] ?? [0, 0]) - 1080)).toBeLessThan(15);
+    expect(Math.abs(sOf(segment[segment.length - 1] ?? [0, 0]) - 1920)).toBeLessThan(15);
+    expect(ev?.tfl).toBeNull();
+  });
+
+  test('non-display-worthy events are never returned', () => {
+    const store = createEventStore();
+    addExcursion(store, mkExc({}), T0 + 300);
+
+    const payload = buildApiEvents(store, T0 + 400, () => ROUTE_POLY, () => null);
+
+    expect(payload.events).toHaveLength(0);
+  });
+
+  test('a route contributing only LOW-confidence excursions gets no name and no line (hitchhiker)', () => {
+    const store = createEventStore();
+    // route 45: two HIGH vehicles → the event is display-worthy
+    addExcursion(store, mkExc({ veh: 'OP:V1' }), T0 + 300);
+    addExcursion(store, mkExc({ veh: 'OP:V2', t0: T0 + 600, t1: T0 + 900 }), T0 + 900);
+    // route 133: a LOW-confidence hitchhiker at the same site
+    addExcursion(
+      store,
+      mkExc({ key: 'OP:133:inbound', veh: 'OP:V3', confidence: 'low', midLat: latAt(1600) }),
+      T0 + 900,
+    );
+
+    // getPoly answers for EVERY key: were the 133's bracket wrongly kept, a
+    // second segment would appear.
+    const payload = buildApiEvents(store, T0 + 1000, () => ROUTE_POLY, () => null);
+
+    expect(payload.events).toHaveLength(1);
+    expect(payload.events[0]?.routes).toEqual(['45']); // no 133 in the popup
+    expect(payload.events[0]?.segments).toHaveLength(1); // no red line for 133
+  });
+
+  test('longRunning flips once the evidence span exceeds 24 h', () => {
+    const store = createEventStore();
+    addExcursion(store, mkExc({ veh: 'OP:V1' }), T0 + 300);
+    addExcursion(store, mkExc({ veh: 'OP:V2' }), T0 + 600);
+    const ev = store.events[0];
+    if (ev !== undefined) ev.lastEvidenceAt = T0 + 25 * 3600;
+
+    const payload = buildApiEvents(store, T0 + 25 * 3600, () => ROUTE_POLY, () => null);
+
+    expect(payload.events[0]?.longRunning).toBe(true);
+  });
+});
+
+describe('TfL enrichment', () => {
+  test('parses the recorder snapshot line and matches within 250 m', () => {
+    const line = JSON.stringify({
+      t: T0,
+      disruptions: [
+        { id: 'A', loc: 'HIGH ROAD closed', pt: `[${lonAt(100)},${latAt(1500)}]` },
+        { id: 'B', loc: 'far away', pt: `[${lonAt(100)},${latAt(9000)}]` },
+        { id: 'C', loc: 'no point' },
+      ],
+    });
+
+    const points = parseDisruptionSnapshotLine(line);
+    expect(points).toHaveLength(2);
+
+    const hit = matchTfl(points, lonAt(150), latAt(1500));
+    expect(hit?.loc).toBe('HIGH ROAD closed');
+    expect(hit?.dist).toBeLessThan(100);
+
+    expect(matchTfl(points, lonAt(150), latAt(5000))).toBeNull();
+  });
+
+  test('malformed snapshot lines yield no candidates instead of throwing', () => {
+    expect(parseDisruptionSnapshotLine('not json')).toEqual([]);
+    expect(parseDisruptionSnapshotLine('{"t":1}')).toEqual([]);
+    expect(
+      parseDisruptionSnapshotLine('{"disruptions":[{"pt":"broken["}]}'),
+    ).toEqual([]);
+  });
+});
+
+describe('oppositeKey', () => {
+  test('pairs inbound and outbound, leaves other directions alone', () => {
+    expect(oppositeKey('OP:45:outbound')).toBe('OP:45:inbound');
+    expect(oppositeKey('OP:45:inbound')).toBe('OP:45:outbound');
+    expect(oppositeKey('OP:45:unknown')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// full detector wiring (learned dir → record() → API events + day log)
+// ---------------------------------------------------------------------------
+
+describe('startDiversionDetector wiring', () => {
+  let tmp = '';
+
+  afterEach(async () => {
+    if (tmp !== '') await rm(tmp, { recursive: true, force: true });
+  });
+
+  const toBus = (veh: string, fix: FixInput): Bus => ({
+    id: veh,
+    line: '45',
+    operator: 'OP',
+    direction: 'outbound',
+    dest: 'Test Terminus',
+    lat: fix.lat,
+    lon: fix.lon,
+    bearing: null,
+    recordedAt: fix.t * 1000,
+  });
+
+  /** detourFixes() with the parallel offset widened to 500 m, time-shifted. */
+  function detour500(tOffsetS: number): FixInput[] {
+    const fixes: FixInput[] = [];
+    for (let i = 0; i <= 9; i++) fixes.push(fixAt(T0 + tOffsetS + i * STEP_S, i * 120));
+    let t = T0 + tOffsetS + 9 * STEP_S;
+    for (let i = 0; i < 6; i++) {
+      t += STEP_S;
+      fixes.push(fixAt(t, 1200 + i * 120, 500));
+    }
+    fixes.push(fixAt(t + STEP_S, 1920));
+    fixes.push(fixAt(t + 2 * STEP_S, 2040));
+    return fixes;
+  }
+
+  test('two detouring vehicles produce one display-worthy event and a logged transition', async () => {
+    tmp = await mkdtemp(join(tmpdir(), 'diversions-wiring-'));
+    await mkdir(join(tmp, 'bus-routes', 'learned'), { recursive: true });
+    await writeFile(
+      join(tmp, 'bus-routes', 'learned', 'OP_45_outbound.json'),
+      JSON.stringify({ key: ROUTE_KEY, poly: ROUTE_POLY }),
+    );
+    await mkdir(join(tmp, 'bus-rollups'), { recursive: true });
+    await writeFile(
+      join(tmp, 'bus-rollups', '2026-08-27.json'),
+      JSON.stringify({ routes: { [ROUTE_KEY]: { meanResidualM: 12 } } }),
+    );
+
+    const logs: string[] = [];
+    const detector = startDiversionDetector(tmp, (msg) => logs.push(msg));
+    try {
+      expect(isDiversionDetectorRunning()).toBe(true);
+      // The index build is async; record() drops fixes until it completes.
+      await vi.waitFor(() => {
+        expect(logs.some((m) => m.includes('route indexes built'))).toBe(true);
+      });
+
+      // Two vehicles, same on-route → 500 m parallel → rejoin sequence, 60 s
+      // apart — timestamps carried by recordedAt, so no fake timers needed.
+      const v1 = detour500(0);
+      const v2 = detour500(60);
+      for (let i = 0; i < v1.length; i++) {
+        const f1 = v1[i];
+        const f2 = v2[i];
+        if (f1 === undefined || f2 === undefined) continue;
+        detector.record([toBus('OP:V1', f1), toBus('OP:V2', f2)], f2.t * 1000);
+      }
+
+      const payload = await detector.snapshot();
+      expect(payload.events).toHaveLength(1);
+      expect(payload.events[0]?.status).toBe('active');
+      expect(payload.events[0]?.routes).toEqual(['45 → Test Terminus']);
+      expect(payload.events[0]?.vehicles).toBe(2);
+      expect(payload.events[0]?.segments.length).toBeGreaterThanOrEqual(1);
+
+      // Transition appends are a serialized async chain — wait for the file.
+      const day = new Date(T0 * 1000).toISOString().slice(0, 10);
+      const dayFile = join(tmp, 'diversions', `${day}.jsonl`);
+      await vi.waitFor(async () => {
+        const body = await readFile(dayFile, 'utf8');
+        expect(body).toContain('"transition":"created"');
+        expect(body).toContain('"transition":"displayed"');
+      });
+    } finally {
+      detector.stop();
+    }
+    expect(isDiversionDetectorRunning()).toBe(false);
+  });
+});
+
+describe('updateShapeGate', () => {
+  test('stays open for healthy routes and suspends broken shapes, then recovers', async () => {
+    const { createShapeGate, updateShapeGate } = await import('./diversion-detector');
+    const gate = createShapeGate();
+    // healthy: median |d| ~8 m, threshold 50 — never suspends
+    for (let i = 0; i < 200; i += 1) updateShapeGate(gate, 8, 50);
+    expect(gate.suspended).toBe(false);
+
+    // broken shape: median jumps far beyond the threshold — suspends
+    let flipped = false;
+    for (let i = 0; i < 300; i += 1) flipped = updateShapeGate(gate, 400, 50) || flipped;
+    expect(gate.suspended).toBe(true);
+    expect(flipped).toBe(true);
+
+    // re-learned shape: |d| back to noise — the gate re-opens
+    for (let i = 0; i < 300; i += 1) updateShapeGate(gate, 6, 50);
+    expect(gate.suspended).toBe(false);
+  });
+});
+
+describe('severity and route labels', () => {
+  test('one direction of one route is partial; a second direction makes it road', () => {
+    const store = createEventStore();
+    const t = [
+      ...addExcursion(store, mkExc({ veh: 'OP:V1', dest: 'Uxbridge' }), T0 + 400),
+      ...addExcursion(store, mkExc({ veh: 'OP:V2', dest: 'Uxbridge', t0: T0 + 60 }), T0 + 460),
+    ];
+    expect(t.length).toBeGreaterThan(0);
+    const one = buildApiEvents(store, T0 + 500, () => ROUTE_POLY, () => null);
+    expect(one.events[0]?.severity).toBe('partial');
+    expect(one.events[0]?.routes).toEqual(['45 → Uxbridge']);
+
+    // the opposite direction joins at the same site → the road itself is hit
+    addExcursion(store, mkExc({ key: 'OP:45:inbound', veh: 'OP:V3', dest: 'Ealing' }), T0 + 520);
+    addExcursion(store, mkExc({ key: 'OP:45:inbound', veh: 'OP:V4', dest: 'Ealing', t0: T0 + 60 }), T0 + 540);
+    const two = buildApiEvents(store, T0 + 600, () => ROUTE_POLY, () => null);
+    expect(two.events[0]?.severity).toBe('road');
+    expect(two.events[0]?.routes).toEqual(['45 → Ealing', '45 → Uxbridge']);
+  });
+});

--- a/backend/src/diversion-detector.ts
+++ b/backend/src/diversion-detector.ts
@@ -1,0 +1,777 @@
+// Real-time bus diversion detection — the online port of the validated batch
+// prototype (scan-diversions.cjs; audit gate 8/10 confirmed, 0 garage
+// artifacts) plus the four production guards from the final audit.
+//
+// Pipeline, riding the existing BODS poll exactly like TraceWriter:
+//   1. per (route key, vehicle): project each fix → (s, d) against the learned
+//      polyline; journeys split at 600 s gaps; the first 500 m of ground track
+//      is excluded from evidence (depot pull-outs). The batch trailing-500 m
+//      clip is subsumed online by the rejoin requirement — an excursion at a
+//      journey's end never sees 2 on-route fixes after it, so it never counts.
+//   2. excursion: ≥5 fixes |d| > max(50, 5×meanResidualM), ≥60 s, ≥300 m of
+//      REAL movement (ground distance across consecutive fixes ≤60 s apart —
+//      imputed jumps across gaps never count), bracketed by ≥2 on-route fixes
+//      on BOTH sides with forward s-progression, wanderer-bounded ground.
+//   3. production guards: endpoint clamp, ≥180 s in-excursion gap reset, dwell
+//      (moving fraction <30% ⇒ LOW confidence), opposite-direction reprojection.
+//   4. SITE-keyed clustering + lifecycle + API assembly + TfL enrichment live
+//      in diversion-events.ts (the pure event-store half of this pipeline).
+//
+// Every event state transition is appended to <busDataDir>/diversions/
+// YYYY-MM-DD.jsonl. On boot the detector starts empty — events rebuild from
+// live traffic within minutes, so no active-state file is needed.
+
+import { appendFile, mkdir, readdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Bus } from './bods-client';
+import {
+  addExcursion,
+  buildApiEvents,
+  createEventStore,
+  matchTfl,
+  median,
+  metresBetween,
+  noteOffRouteFix,
+  noteOnRouteFix,
+  parseDisruptionSnapshotLine,
+  tickLifecycle,
+  utcDay,
+  type CompletedExcursion,
+  type Confidence,
+  type DiversionsPayload,
+  type TflDisruptionPoint,
+  type TransitionRecord,
+} from './diversion-events';
+import { buildRouteIndex, type LonLat, type RouteIndex } from './route-projection';
+
+// --- tuning constants (task spec + prototype calibration; do not retune
+// without re-running the audit gate) ---
+const GAP_SPLIT_S = 600;
+const CLIP_M = 500;
+const MIN_RUN_FIXES = 5;
+const MIN_RUN_DURATION_S = 60;
+const MIN_RUN_REAL_GROUND_M = 300;
+/** Ground between consecutive fixes further apart than this is imputed, not real. */
+const REAL_MOVE_MAX_DT_S = 60;
+const THRESHOLD_FLOOR_M = 50;
+const THRESHOLD_RESIDUAL_MULT = 5;
+const DEFAULT_RESIDUAL_M = 15;
+const MIN_ON_ROUTE_BRACKET_FIXES = 2;
+/** Forward-progression medians use this many recent on-route fixes. */
+const BEFORE_S_WINDOW = 32;
+// wanderer guard (prototype): a genuine detour's ground distance is
+// commensurate with the skipped s-interval; terminus overruns and wrong-route
+// journeys travel far while skipping little route.
+const WANDERER_GROUND_FLOOR_M = 2500;
+const WANDERER_GROUND_MULT = 4;
+const WANDERER_MIN_SKIP_M = 500;
+// production guards (final audit)
+const EXCURSION_GAP_RESET_S = 180;
+const CLAMP_FIX_FRAC_MAX = 0.2;
+/** Projections within this of s=0 / s=max are endpoint clamps. */
+const CLAMP_END_EPS_M = 1;
+const ENDPOINT_LOCUS_M = 200;
+const DWELL_SPEED_MS = 2;
+const DWELL_MOVING_FRAC_MIN = 0.3;
+const MISLABEL_SAMPLE_N = 15;
+// memory bounds
+const EXC_FIX_CAP = 2000;
+const PENDING_CAP = 4;
+const VEHICLE_STATE_TTL_S = 30 * 60;
+
+const LIFECYCLE_TICK_MS = 60_000;
+const TFL_SNAPSHOT_TTL_MS = 10 * 60_000;
+const INDEX_BUILD_YIELD_EVERY = 100;
+/** The learner re-learns polylines daily — re-index on the same cadence so
+ * the detector never projects against boot-frozen geometry forever. */
+const INDEX_REBUILD_INTERVAL_MS = 24 * 3600_000;
+/** Guard-counter summary cadence: one line per hour, only when nonzero. */
+const GUARD_LOG_INTERVAL_MS = 3600_000;
+
+export function oppositeKey(key: string): string | null {
+  if (key.endsWith(':inbound')) return `${key.slice(0, -':inbound'.length)}:outbound`;
+  if (key.endsWith(':outbound')) return `${key.slice(0, -':outbound'.length)}:inbound`;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// per-vehicle online state machine
+// ---------------------------------------------------------------------------
+
+export interface FixInput {
+  /** epoch seconds */
+  t: number;
+  lon: number;
+  lat: number;
+}
+
+interface ExcFix {
+  t: number;
+  lon: number;
+  lat: number;
+  s: number;
+}
+
+interface ExcursionAcc {
+  t0: number;
+  tLast: number;
+  nFix: number;
+  /** ground across consecutive exc fixes ≤ REAL_MOVE_MAX_DT_S apart */
+  realGroundM: number;
+  /** ground across ALL consecutive exc fixes (wanderer guard, as in batch) */
+  totalGroundM: number;
+  movingPairs: number;
+  totalPairs: number;
+  clampCount: number;
+  maxD: number;
+  /** last on-route s before departure (batch: ss[i-1]) */
+  sExit: number;
+  /** journey on-route context frozen at excursion start */
+  beforeCount: number;
+  beforeMedianS: number;
+  fixes: ExcFix[];
+}
+
+interface PendingExcursion {
+  exc: ExcursionAcc;
+  /** first on-route s after the run (batch: ss[j]) */
+  sRejoin: number;
+  afterOnS: number[];
+}
+
+export interface VehicleState {
+  lastT: number;
+  lastLon: number;
+  lastLat: number;
+  lastS: number;
+  /** |d| of the latest projection — feeds the per-route shape gate. */
+  lastAbsD: number;
+  hasLast: boolean;
+  journeyGroundM: number;
+  /** recent on-route s values this journey, post-clip (forward progression) */
+  beforeOnS: number[];
+  beforeCount: number;
+  exc: ExcursionAcc | null;
+  pendings: PendingExcursion[];
+}
+
+export function createVehicleState(): VehicleState {
+  return {
+    lastT: 0,
+    lastLon: 0,
+    lastLat: 0,
+    lastS: 0,
+    lastAbsD: 0,
+    hasLast: false,
+    journeyGroundM: 0,
+    beforeOnS: [],
+    beforeCount: 0,
+    exc: null,
+    pendings: [],
+  };
+}
+
+/** Rejection counters — observable for tests and periodic operator logging. */
+export interface GuardCounters {
+  minorRun: number;
+  noBracket: number;
+  notForward: number;
+  wandererDropped: number;
+  clampInvalid: number;
+  mislabelDropped: number;
+  gapResets: number;
+  pendingDropped: number;
+  /** routes whose shape gate flipped to suspended (unreliable geometry). */
+  shapeSuspended: number;
+  completedHigh: number;
+  completedLow: number;
+}
+
+export function createGuardCounters(): GuardCounters {
+  return {
+    minorRun: 0,
+    noBracket: 0,
+    notForward: 0,
+    wandererDropped: 0,
+    clampInvalid: 0,
+    mislabelDropped: 0,
+    gapResets: 0,
+    pendingDropped: 0,
+    shapeSuspended: 0,
+    completedHigh: 0,
+    completedLow: 0,
+  };
+}
+
+export interface StepContext {
+  key: string;
+  veh: string;
+  /** destination sign from the live feed — carried onto excursions. */
+  dest: string;
+  thrM: number;
+  index: RouteIndex;
+  oppIndex: RouteIndex | null;
+  counters: GuardCounters;
+}
+
+export interface StepResult {
+  /** set when this fix counted as on-route evidence (post-clip) */
+  onRouteS: number | null;
+  /** guard-passed excursions finalized by this fix */
+  completed: CompletedExcursion[];
+}
+
+function resetJourney(state: VehicleState): void {
+  // A 600 s gap ends the journey: an unfinished excursion has no rejoin and a
+  // pending one loses its after-bracket — both are evidence of nothing.
+  state.hasLast = false;
+  state.journeyGroundM = 0;
+  state.beforeOnS = [];
+  state.beforeCount = 0;
+  state.exc = null;
+  state.pendings = [];
+}
+
+function startExcursion(state: VehicleState, fix: FixInput, s: number): ExcursionAcc {
+  return {
+    t0: fix.t,
+    tLast: fix.t,
+    nFix: 0,
+    realGroundM: 0,
+    totalGroundM: 0,
+    movingPairs: 0,
+    totalPairs: 0,
+    clampCount: 0,
+    maxD: 0,
+    // batch sExitRaw = ss[i-1]: the previous journey fix's s when one exists
+    sExit: state.hasLast ? state.lastS : s,
+    beforeCount: state.beforeCount,
+    beforeMedianS: median(state.beforeOnS),
+    fixes: [],
+  };
+}
+
+/** Guard (b): a >180 s hole inside an excursion resets its accumulation
+ * (exit geometry and journey context are kept — the vehicle never returned
+ * on-route, so the exit point still stands). */
+function resetExcursionAccum(exc: ExcursionAcc, fix: FixInput): void {
+  exc.t0 = fix.t;
+  exc.tLast = fix.t;
+  exc.nFix = 0;
+  exc.realGroundM = 0;
+  exc.totalGroundM = 0;
+  exc.movingPairs = 0;
+  exc.totalPairs = 0;
+  exc.clampCount = 0;
+  exc.maxD = 0;
+  exc.fixes = [];
+}
+
+function accumulateExcursionFix(
+  exc: ExcursionAcc,
+  fix: FixInput,
+  s: number,
+  absD: number,
+  totalLengthM: number,
+): void {
+  const prev = exc.fixes[exc.fixes.length - 1];
+  if (prev !== undefined) {
+    const dt = fix.t - prev.t;
+    const ground = metresBetween(prev.lon, prev.lat, fix.lon, fix.lat);
+    exc.totalGroundM += ground;
+    if (dt <= REAL_MOVE_MAX_DT_S) exc.realGroundM += ground;
+    exc.totalPairs += 1;
+    if (dt > 0 && ground / dt > DWELL_SPEED_MS) exc.movingPairs += 1;
+  }
+  exc.nFix += 1;
+  exc.tLast = fix.t;
+  if (absD > exc.maxD) exc.maxD = absD;
+  if (s <= CLAMP_END_EPS_M || s >= totalLengthM - CLAMP_END_EPS_M) exc.clampCount += 1;
+  if (exc.fixes.length < EXC_FIX_CAP) exc.fixes.push({ t: fix.t, lon: fix.lon, lat: fix.lat, s });
+}
+
+/** All guards run at finalize time, mirroring the batch order:
+ * mislabel → wanderer → bracket → forward → clamp → dwell(confidence). */
+function finalizePending(pending: PendingExcursion, ctx: StepContext): CompletedExcursion | null {
+  const { exc, sRejoin, afterOnS } = pending;
+  const c = ctx.counters;
+
+  // guard (d): direction mislabel — the excursion locus lies ON the paired
+  // opposite-direction polyline, so it is a labeling error, not a diversion.
+  if (ctx.oppIndex !== null && exc.fixes.length > 0) {
+    const sampleN = Math.min(MISLABEL_SAMPLE_N, exc.fixes.length);
+    const dOpp: number[] = [];
+    for (let i = 0; i < sampleN; i++) {
+      const fi = exc.fixes[Math.floor((i * (exc.fixes.length - 1)) / Math.max(1, sampleN - 1))];
+      if (fi !== undefined) dOpp.push(Math.abs(ctx.oppIndex.projectFix(fi.lon, fi.lat).d));
+    }
+    if (median(dOpp) < ctx.thrM) {
+      c.mislabelDropped += 1;
+      return null;
+    }
+  }
+
+  const skipped = Math.abs(sRejoin - exc.sExit);
+  const allowedGround = Math.max(
+    WANDERER_GROUND_FLOOR_M,
+    WANDERER_GROUND_MULT * Math.max(skipped, WANDERER_MIN_SKIP_M),
+  );
+  if (exc.totalGroundM > allowedGround) {
+    c.wandererDropped += 1;
+    return null;
+  }
+
+  // garage-run guards: on-route on BOTH sides, progressing forward.
+  if (
+    exc.beforeCount < MIN_ON_ROUTE_BRACKET_FIXES ||
+    afterOnS.length < MIN_ON_ROUTE_BRACKET_FIXES
+  ) {
+    c.noBracket += 1;
+    return null;
+  }
+  if (!(sRejoin > exc.sExit) || !(median(afterOnS) > exc.beforeMedianS)) {
+    c.notForward += 1;
+    return null;
+  }
+
+  // guard (a): endpoint clamp — beyond-terminus wanderings project onto the
+  // polyline ends and fabricate excursions there.
+  const mid = exc.fixes[exc.fixes.length >> 1];
+  const total = ctx.index.totalLengthM;
+  const locusNearEnd =
+    mid !== undefined && (mid.s < ENDPOINT_LOCUS_M || mid.s > total - ENDPOINT_LOCUS_M);
+  if (exc.nFix > 0 && (exc.clampCount / exc.nFix > CLAMP_FIX_FRAC_MAX || locusNearEnd)) {
+    c.clampInvalid += 1;
+    return null;
+  }
+
+  // guard (c): dwell — a stationary off-route vehicle (stand, stuck GPS) is
+  // weak evidence; kept, but only as LOW confidence.
+  const movingFrac = exc.totalPairs > 0 ? exc.movingPairs / exc.totalPairs : 0;
+  const confidence: Confidence = movingFrac >= DWELL_MOVING_FRAC_MIN ? 'high' : 'low';
+  if (confidence === 'high') c.completedHigh += 1;
+  else c.completedLow += 1;
+
+  return {
+    key: ctx.key,
+    veh: ctx.veh,
+    dest: ctx.dest,
+    t0: exc.t0,
+    t1: exc.tLast,
+    sExit: exc.sExit,
+    sRejoin,
+    sA: Math.min(exc.sExit, sRejoin),
+    sB: Math.max(exc.sExit, sRejoin),
+    maxD: Math.round(exc.maxD),
+    nFix: exc.nFix,
+    groundM: Math.round(exc.totalGroundM),
+    midLon: mid?.lon ?? 0,
+    midLat: mid?.lat ?? 0,
+    confidence,
+  };
+}
+
+/**
+ * Advance one vehicle's state by one fix. Mutates `state` (bounded per-vehicle
+ * hot-path state; immutably rebuilding it 9k times per poll would be pure GC
+ * churn). Returns on-route evidence and any excursions finalized by this fix.
+ */
+export function stepVehicle(state: VehicleState, fix: FixInput, ctx: StepContext): StepResult {
+  const out: StepResult = { onRouteS: null, completed: [] };
+  if (state.hasLast && fix.t <= state.lastT) return out; // duplicate / rewind
+
+  if (state.hasLast && fix.t - state.lastT > GAP_SPLIT_S) resetJourney(state);
+
+  const proj = ctx.index.projectFix(fix.lon, fix.lat);
+  const s = proj.s; // copy out — projectFix returns a shared scratch
+  const absD = Math.abs(proj.d);
+
+  if (state.hasLast) {
+    state.journeyGroundM += metresBetween(state.lastLon, state.lastLat, fix.lon, fix.lat);
+  }
+  const clipped = state.journeyGroundM < CLIP_M;
+
+  if (!clipped && absD <= ctx.thrM) {
+    out.onRouteS = s;
+    // feed pendings first: this fix is part of every waiting after-bracket
+    const still: PendingExcursion[] = [];
+    for (const pending of state.pendings) {
+      pending.afterOnS.push(s);
+      if (pending.afterOnS.length >= MIN_ON_ROUTE_BRACKET_FIXES) {
+        const done = finalizePending(pending, ctx);
+        if (done !== null) out.completed.push(done);
+      } else {
+        still.push(pending);
+      }
+    }
+    state.pendings = still;
+    // close the current excursion into a pending when it met the run bars
+    if (state.exc !== null) {
+      const exc = state.exc;
+      state.exc = null;
+      const dur = exc.tLast - exc.t0;
+      if (exc.nFix >= MIN_RUN_FIXES && dur >= MIN_RUN_DURATION_S && exc.realGroundM >= MIN_RUN_REAL_GROUND_M) {
+        if (state.pendings.length < PENDING_CAP) {
+          state.pendings.push({ exc, sRejoin: s, afterOnS: [s] });
+        } else {
+          ctx.counters.pendingDropped += 1;
+        }
+      } else {
+        ctx.counters.minorRun += 1;
+      }
+    }
+    state.beforeCount += 1;
+    state.beforeOnS.push(s);
+    if (state.beforeOnS.length > BEFORE_S_WINDOW) state.beforeOnS.shift();
+  } else if (!clipped) {
+    if (state.exc === null) {
+      state.exc = startExcursion(state, fix, s);
+    } else if (fix.t - state.exc.tLast > EXCURSION_GAP_RESET_S) {
+      resetExcursionAccum(state.exc, fix);
+      ctx.counters.gapResets += 1;
+    }
+    accumulateExcursionFix(state.exc, fix, s, absD, ctx.index.totalLengthM);
+  }
+  // clipped fixes are position bookkeeping only — no evidence either way
+
+  state.lastT = fix.t;
+  state.lastLon = fix.lon;
+  state.lastLat = fix.lat;
+  state.lastS = s;
+  state.lastAbsD = absD;
+  state.hasLast = true;
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// per-route shape-reliability gate
+// ---------------------------------------------------------------------------
+//
+// The offline calibration found learned shapes that sit hundreds of metres
+// from where vehicles actually drive (long coach routes with branching
+// variants, a few stale quiet routes: p50 |d| of 112-814 m vs 3-14 m on
+// healthy routes). Excursion logic on such routes emits pure noise — the
+// replay's worst false events were all of this class. This is the online port
+// of the prototype's route-day p50 sanity gate: track a rolling median of
+// |d| per route and SUSPEND detection while the median exceeds the excursion
+// threshold itself — when the MEDIAN fix reads as "diverted", the shape, not
+// the traffic, is wrong. Suspended routes keep projecting (cheap) so the gate
+// re-opens after the nightly re-learn repairs the shape.
+
+const GATE_RING = 256;
+const GATE_EVAL_EVERY = 64;
+
+export interface ShapeGate {
+  ds: Float64Array;
+  n: number;
+  i: number;
+  sinceEval: number;
+  suspended: boolean;
+}
+
+export function createShapeGate(): ShapeGate {
+  return { ds: new Float64Array(GATE_RING), n: 0, i: 0, sinceEval: 0, suspended: false };
+}
+
+/** Push one |d| sample; re-evaluates the median every GATE_EVAL_EVERY
+ * samples. Returns true when the gate just flipped to suspended. */
+export function updateShapeGate(gate: ShapeGate, absD: number, thrM: number): boolean {
+  gate.ds[gate.i] = absD;
+  gate.i = (gate.i + 1) % GATE_RING;
+  if (gate.n < GATE_RING) gate.n += 1;
+  gate.sinceEval += 1;
+  if (gate.sinceEval < GATE_EVAL_EVERY || gate.n < GATE_EVAL_EVERY) return false;
+  gate.sinceEval = 0;
+  const sorted = [...gate.ds.subarray(0, gate.n)].sort((a, b) => a - b);
+  const med = sorted[Math.floor(gate.n / 2)] ?? 0;
+  const wasSuspended = gate.suspended;
+  gate.suspended = med > thrM;
+  return gate.suspended && !wasSuspended;
+}
+
+// ---------------------------------------------------------------------------
+// detector wiring (closure, like startCoverageWriter)
+// ---------------------------------------------------------------------------
+
+interface RouteEntry {
+  poly: LonLat[];
+  index: RouteIndex;
+}
+
+export interface DiversionDetector {
+  /** Ride-along on the BODS poll callback — synchronous CPU only, no IO. */
+  record(buses: readonly Bus[], nowMs: number): void;
+  snapshot(): Promise<DiversionsPayload>;
+  stop(): void;
+}
+
+// Whether a detector instance is live in this process — consulted by the
+// capabilities route so the busDiversions flag mirrors reality instead of
+// re-deriving it from config + directories. Module-level because at most one
+// detector runs per process (app.ts starts it once, possibly after a
+// fresh-volume retry).
+let detectorRunning = false;
+export const isDiversionDetectorRunning = (): boolean => detectorRunning;
+
+export function startDiversionDetector(
+  busDataDir: string,
+  log: (msg: string) => void,
+): DiversionDetector {
+  const learnedDir = join(busDataDir, 'bus-routes', 'learned');
+  const rollupsDir = join(busDataDir, 'bus-rollups');
+  const disruptionsDir = join(busDataDir, 'road-disruptions');
+  const diversionsDir = join(busDataDir, 'diversions');
+
+  detectorRunning = true;
+  let routes = new Map<string, RouteEntry>();
+  let ready = false;
+  let building = false;
+  const states = new Map<string, VehicleState>(); // `${key}|${veh}`
+  const gates = new Map<string, ShapeGate>(); // per route key
+  const store = createEventStore();
+  const counters = createGuardCounters();
+
+  // meanResidualM thresholds — lazy, cached, refreshed when the UTC day rolls
+  // (a new rollup lands at most once a day).
+  let thresholds = new Map<string, number>();
+  let thresholdsDay = '';
+  let thresholdsLoading = false;
+
+  // TfL snapshot cache for enrichment.
+  let tflPoints: TflDisruptionPoint[] = [];
+  let tflLoadedAt = 0;
+
+  // Serialized transition-log appends: concurrent appendFile calls could
+  // interleave lines from two polls.
+  let logChain: Promise<void> = Promise.resolve();
+
+  // Boot build AND daily rebuild share this path: the learner re-learns
+  // polylines every day, so a boot-frozen index would drift from the geometry
+  // the rest of the system serves. Built into a fresh map and swapped
+  // wholesale so record() never sees a half-built set; in-flight vehicle
+  // states keyed to a rebuilt route keep working — their s/d simply
+  // re-project against the new index on the next fix.
+  async function buildIndexes(): Promise<void> {
+    if (building) return; // re-entrancy: a slow build must not overlap the next
+    building = true;
+    try {
+      let names: string[] = [];
+      try {
+        names = (await readdir(learnedDir)).filter((n) => !n.startsWith('.') && n.endsWith('.json'));
+      } catch {
+        // dir vanished after the boot check — detector idles with zero routes
+      }
+      const next = new Map<string, RouteEntry>();
+      let built = 0;
+      for (const name of names) {
+        try {
+          const doc = JSON.parse(await readFile(join(learnedDir, name), 'utf8')) as {
+            key?: unknown;
+            poly?: unknown;
+          };
+          const { key, poly } = doc;
+          const isValid =
+            typeof key === 'string' &&
+            Array.isArray(poly) &&
+            poly.length >= 2 &&
+            poly.every(
+              (p) => Array.isArray(p) && typeof p[0] === 'number' && typeof p[1] === 'number',
+            );
+          if (isValid) {
+            next.set(key, { poly: poly as LonLat[], index: buildRouteIndex(poly as LonLat[]) });
+            built += 1;
+          }
+        } catch {
+          // one unreadable learned file must not sink the detector
+        }
+        if (built % INDEX_BUILD_YIELD_EVERY === 0) {
+          await new Promise<void>((resolve) => setImmediate(resolve));
+        }
+      }
+      routes = next;
+      ready = true;
+      log(`diversions: ${routes.size} route indexes built`);
+    } finally {
+      building = false;
+    }
+  }
+  void buildIndexes();
+  const rebuildTimer = setInterval(() => void buildIndexes(), INDEX_REBUILD_INTERVAL_MS);
+  rebuildTimer.unref();
+
+  function refreshThresholds(nowMs: number): void {
+    const today = new Date(nowMs).toISOString().slice(0, 10);
+    if (thresholdsDay === today || thresholdsLoading) return;
+    thresholdsLoading = true;
+    void (async () => {
+      try {
+        const names = (await readdir(rollupsDir)).filter((n) => /^\d{4}-\d{2}-\d{2}\.json$/.test(n)).sort();
+        const newest = names[names.length - 1];
+        const next = new Map<string, number>();
+        if (newest !== undefined) {
+          const doc = JSON.parse(await readFile(join(rollupsDir, newest), 'utf8')) as {
+            routes?: Record<string, { meanResidualM?: unknown }>;
+          };
+          for (const [key, stats] of Object.entries(doc.routes ?? {})) {
+            const resid = stats?.meanResidualM;
+            if (typeof resid === 'number' && Number.isFinite(resid)) {
+              next.set(key, Math.max(THRESHOLD_FLOOR_M, THRESHOLD_RESIDUAL_MULT * resid));
+            }
+          }
+        }
+        thresholds = next;
+        thresholdsDay = today;
+      } catch {
+        thresholdsDay = today; // no rollups yet — defaults hold until tomorrow
+      } finally {
+        thresholdsLoading = false;
+      }
+    })();
+  }
+
+  const defaultThr = Math.max(THRESHOLD_FLOOR_M, THRESHOLD_RESIDUAL_MULT * DEFAULT_RESIDUAL_M);
+  const thrFor = (key: string): number => thresholds.get(key) ?? defaultThr;
+
+  function appendTransitions(transitions: readonly TransitionRecord[]): void {
+    if (transitions.length === 0) return;
+    const byDay = new Map<string, string[]>();
+    for (const rec of transitions) {
+      const day = utcDay(rec.t);
+      const lines = byDay.get(day);
+      if (lines === undefined) byDay.set(day, [JSON.stringify(rec)]);
+      else lines.push(JSON.stringify(rec));
+    }
+    logChain = logChain.then(async () => {
+      try {
+        await mkdir(diversionsDir, { recursive: true });
+        for (const [day, lines] of byDay) {
+          await appendFile(join(diversionsDir, `${day}.jsonl`), `${lines.join('\n')}\n`, 'utf8');
+        }
+      } catch (err) {
+        log(`diversions: transition log append failed: ${String(err)}`);
+      }
+    });
+  }
+
+  function pruneStates(nowSec: number): void {
+    if (states.size < 20_000) return;
+    const cutoff = nowSec - VEHICLE_STATE_TTL_S;
+    for (const [id, state] of states) {
+      if (state.lastT < cutoff) states.delete(id);
+    }
+  }
+
+  function record(buses: readonly Bus[], nowMs: number): void {
+    if (!ready) return;
+    refreshThresholds(nowMs);
+    const nowSec = Math.floor(nowMs / 1000);
+    const transitions: TransitionRecord[] = [];
+    for (const bus of buses) {
+      if (bus.line === '') continue;
+      const key = `${bus.operator}:${bus.line}:${bus.direction}`;
+      const route = routes.get(key);
+      if (route === undefined) continue;
+      let gate = gates.get(key);
+      if (gate === undefined) {
+        gate = createShapeGate();
+        gates.set(key, gate);
+      }
+      if (gate.suspended) {
+        // Untrusted shape: keep sampling (so the gate re-opens after the
+        // nightly re-learn) but run no excursion logic.
+        const proj = route.index.projectFix(bus.lon, bus.lat);
+        updateShapeGate(gate, Math.abs(proj.d), thrFor(key));
+        continue;
+      }
+      const stateKey = `${key}|${bus.id}`;
+      let state = states.get(stateKey);
+      if (state === undefined) {
+        state = createVehicleState();
+        states.set(stateKey, state);
+      }
+      const oppKey = oppositeKey(key);
+      const ctx: StepContext = {
+        key,
+        veh: bus.id,
+        dest: bus.dest,
+        thrM: thrFor(key),
+        index: route.index,
+        oppIndex: oppKey === null ? null : (routes.get(oppKey)?.index ?? null),
+        counters,
+      };
+      const fix: FixInput = { t: Math.round(bus.recordedAt / 1000), lon: bus.lon, lat: bus.lat };
+      const result = stepVehicle(state, fix, ctx);
+      if (updateShapeGate(gate, state.lastAbsD, ctx.thrM)) counters.shapeSuspended += 1;
+      if (result.onRouteS !== null) {
+        transitions.push(...noteOnRouteFix(store, key, bus.id, result.onRouteS, nowSec));
+      } else if (state.exc !== null) {
+        noteOffRouteFix(store, key, bus.id, state.lastS);
+      }
+      for (const exc of result.completed) {
+        transitions.push(...addExcursion(store, exc, nowSec));
+      }
+    }
+    pruneStates(nowSec);
+    appendTransitions(transitions);
+  }
+
+  const lifecycleTimer = setInterval(() => {
+    appendTransitions(tickLifecycle(store, Math.floor(Date.now() / 1000)));
+  }, LIFECYCLE_TICK_MS);
+  lifecycleTimer.unref();
+
+  // Hourly guard observability: without this the counters are write-only.
+  // Deltas against the last logged snapshot, one line, skipped when silent.
+  let loggedCounters = createGuardCounters();
+  function logGuardSummary(): void {
+    const parts: string[] = [];
+    for (const key of Object.keys(counters) as Array<keyof GuardCounters>) {
+      const delta = counters[key] - loggedCounters[key];
+      if (delta > 0) parts.push(`${key}=${delta}`);
+    }
+    if (parts.length === 0) return;
+    loggedCounters = { ...counters };
+    log(`diversions: 1h guards — ${parts.join(', ')}`);
+  }
+  const guardLogTimer = setInterval(logGuardSummary, GUARD_LOG_INTERVAL_MS);
+  guardLogTimer.unref();
+
+  async function loadTflPoints(): Promise<TflDisruptionPoint[]> {
+    const nowMs = Date.now();
+    if (nowMs - tflLoadedAt < TFL_SNAPSHOT_TTL_MS) return tflPoints;
+    tflLoadedAt = nowMs;
+    try {
+      const names = (await readdir(disruptionsDir)).filter((n) => /^\d{4}-\d{2}-\d{2}\.jsonl$/.test(n)).sort();
+      const newest = names[names.length - 1];
+      if (newest === undefined) return (tflPoints = []);
+      const body = await readFile(join(disruptionsDir, newest), 'utf8');
+      const lines = body.split('\n').filter((l) => l.trim() !== '');
+      const last = lines[lines.length - 1];
+      tflPoints = last === undefined ? [] : parseDisruptionSnapshotLine(last);
+    } catch {
+      tflPoints = []; // enrichment only — never let it gate the payload
+    }
+    return tflPoints;
+  }
+
+  async function snapshot(): Promise<DiversionsPayload> {
+    const points = await loadTflPoints();
+    return buildApiEvents(
+      store,
+      Math.floor(Date.now() / 1000),
+      (key) => routes.get(key)?.poly ?? null,
+      (lon, lat) => matchTfl(points, lon, lat),
+    );
+  }
+
+  return {
+    record,
+    snapshot,
+    stop: () => {
+      clearInterval(lifecycleTimer);
+      clearInterval(rebuildTimer);
+      clearInterval(guardLogTimer);
+      detectorRunning = false;
+    },
+  };
+}

--- a/backend/src/diversion-detector.ts
+++ b/backend/src/diversion-detector.ts
@@ -73,6 +73,8 @@ const CLAMP_END_EPS_M = 1;
 const ENDPOINT_LOCUS_M = 200;
 const DWELL_SPEED_MS = 2;
 const DWELL_MOVING_FRAC_MIN = 0.3;
+/** Beyond this |d|, "diversion" is no longer the credible explanation. */
+const MAX_CREDIBLE_D_M = 1500;
 const MISLABEL_SAMPLE_N = 15;
 // memory bounds
 const EXC_FIX_CAP = 2000;
@@ -348,7 +350,14 @@ function finalizePending(pending: PendingExcursion, ctx: StepContext): Completed
   // guard (c): dwell — a stationary off-route vehicle (stand, stuck GPS) is
   // weak evidence; kept, but only as LOW confidence.
   const movingFrac = exc.totalPairs > 0 ? exc.movingPairs / exc.totalPairs : 0;
-  const confidence: Confidence = movingFrac >= DWELL_MOVING_FRAC_MIN ? 'high' : 'low';
+  // guard (e): a street-level diversion stays within ~hundreds of metres of
+  // the route; a kilometres-scale |d| means the learned shape and this
+  // vehicle's actual service disagree (live case: 254s projecting 2-4 km off
+  // hitchhiked their name onto a genuine 56/106 event). LOW keeps it logged
+  // without letting it name routes or draw segments.
+  const credibleD = exc.maxD <= MAX_CREDIBLE_D_M;
+  const confidence: Confidence =
+    movingFrac >= DWELL_MOVING_FRAC_MIN && credibleD ? 'high' : 'low';
   if (confidence === 'high') c.completedHigh += 1;
   else c.completedLow += 1;
 

--- a/backend/src/diversion-events.ts
+++ b/backend/src/diversion-events.ts
@@ -1,0 +1,558 @@
+// Pure event-store half of bus-diversion detection: SITE-keyed clustering of
+// completed excursions, event lifecycle transitions, API payload assembly,
+// and TfL road-disruption enrichment. No IO and no timers — the detector
+// closure in diversion-detector.ts owns the wiring and feeds this store.
+//
+// Split out of diversion-detector.ts purely mechanically (the per-vehicle
+// state machine stays there); the shared geometry/statistics helpers live
+// here because this module must not import the detector (the dependency runs
+// detector → events only).
+
+import { slicePolyline, type LonLat } from './route-projection';
+
+// --- tuning constants (task spec + prototype calibration; do not retune
+// without re-running the audit gate) ---
+const SITE_MERGE_DIST_M = 500;
+const EVENT_WINDOW_S = 45 * 60;
+const DISPLAY_MIN_VEHICLES = 2;
+const RECOVERY_MIN_VEHICLES = 2;
+/** A recovery passage must reach within this of both bracket ends. */
+const RECOVERY_PASS_MARGIN_M = 50;
+const STALE_AFTER_S = 90 * 60;
+const STALE_DROP_AFTER_S = 6 * 3600;
+const RECOVERING_DROP_AFTER_S = 10 * 60;
+const LONG_RUNNING_S = 24 * 3600;
+const TFL_MATCH_DIST_M = 250;
+// memory bounds — members and the per-event collections (vehicles, brackets,
+// passages) all share this cap.
+const EVENT_MEMBER_CAP = 500;
+const MAX_EVENT_SEGMENTS = 12;
+
+const METRES_PER_DEG_LAT = 110_540;
+const METRES_PER_DEG_LON_EQUATOR = 111_320;
+
+// ---------------------------------------------------------------------------
+// small shared helpers (also used by the detector's state machine)
+// ---------------------------------------------------------------------------
+
+/** Planar metres between two lon/lat points (equirect at their mean lat). */
+export function metresBetween(lon1: number, lat1: number, lon2: number, lat2: number): number {
+  const kx = METRES_PER_DEG_LON_EQUATOR * Math.cos((((lat1 + lat2) / 2) * Math.PI) / 180);
+  return Math.hypot((lon2 - lon1) * kx, (lat2 - lat1) * METRES_PER_DEG_LAT);
+}
+
+export function median(values: readonly number[]): number {
+  if (values.length === 0) return NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  return sorted[sorted.length >> 1] ?? NaN;
+}
+
+/** Prototype's time proximity: windows within EVENT_WINDOW_S of each other. */
+function timesNear(t0a: number, t1a: number, t0b: number, t1b: number): boolean {
+  return t0b <= t1a + EVENT_WINDOW_S && t0a <= t1b + EVENT_WINDOW_S;
+}
+
+export function utcDay(epochSec: number): string {
+  return new Date(epochSec * 1000).toISOString().slice(0, 10);
+}
+
+/** Bounded insert for the per-event collections: Maps/Sets iterate in
+ * insertion order, so dropping the first entry evicts the oldest and keeps
+ * the newest. Call before inserting a NEW key only — replacing an existing
+ * key never grows the collection. */
+function evictOldestIfFull(coll: {
+  size: number;
+  keys(): IterableIterator<string>;
+  delete(key: string): boolean;
+}): void {
+  if (coll.size < EVENT_MEMBER_CAP) return;
+  const oldest = coll.keys().next();
+  if (!oldest.done) coll.delete(oldest.value);
+}
+
+// ---------------------------------------------------------------------------
+// completed excursions (produced by the detector's per-vehicle state machine)
+// ---------------------------------------------------------------------------
+
+export type Confidence = 'high' | 'low';
+
+export interface CompletedExcursion {
+  key: string;
+  veh: string;
+  /** the vehicle's destination sign at the time — labels the direction for
+   * humans ("SL8 → Uxbridge") far better than inbound/outbound would */
+  dest: string;
+  t0: number;
+  t1: number;
+  sExit: number;
+  sRejoin: number;
+  sA: number;
+  sB: number;
+  maxD: number;
+  nFix: number;
+  groundM: number;
+  midLon: number;
+  midLat: number;
+  confidence: Confidence;
+}
+
+// ---------------------------------------------------------------------------
+// site-keyed event clustering + lifecycle
+// ---------------------------------------------------------------------------
+
+export type EventStatus = 'active' | 'recovering' | 'stale';
+
+interface KeyBracket {
+  sA: number;
+  sB: number;
+}
+
+interface RecoveryPassage {
+  minS: number;
+  maxS: number;
+  broken: boolean;
+}
+
+export interface DiversionEvent {
+  id: string;
+  status: EventStatus;
+  displayWorthy: boolean;
+  startedAt: number;
+  lastEvidenceAt: number;
+  recoveringAt: number | null;
+  members: CompletedExcursion[];
+  vehicles: Set<string>;
+  /** per route key: merged bypassed [s_exit, s_rejoin] bracket */
+  brackets: Map<string, KeyBracket>;
+  centroid: [number, number];
+  /** `${key}|${veh}` → on-route traversal progress through the bracket */
+  passages: Map<string, RecoveryPassage>;
+  passedVehicles: Set<string>;
+}
+
+export interface EventStore {
+  events: DiversionEvent[];
+  seqDay: string;
+  daySeq: number;
+}
+
+export function createEventStore(): EventStore {
+  return { events: [], seqDay: '', daySeq: 0 };
+}
+
+export interface TransitionRecord {
+  t: number;
+  id: string;
+  transition: 'created' | 'displayed' | 'reactivated' | 'recovering' | 'stale' | 'dropped';
+  event: {
+    status: EventStatus;
+    displayWorthy: boolean;
+    startedAt: number;
+    lastEvidenceAt: number;
+    routes: string[];
+    vehicles: number;
+    members: number;
+    centroid: [number, number];
+  };
+}
+
+/** Human line names from route keys (OPERATOR:line:direction), sorted. */
+function routeNames(keys: Iterable<string>): string[] {
+  const lines = new Set<string>();
+  for (const key of keys) lines.add(key.split(':')[1] ?? key);
+  return [...lines].sort();
+}
+
+/** Human route labels with the majority destination sign of each diverting
+ * route-direction's HIGH members: "SL8 → Uxbridge" beats a bare "SL8", which
+ * read as "the whole route" to a live user watching the OTHER direction run
+ * normally. Falls back to the bare line name when no dest is known. */
+function routeLabels(
+  keys: Iterable<string>,
+  members: ReadonlyArray<CompletedExcursion>,
+): string[] {
+  const labels = new Set<string>();
+  for (const key of keys) {
+    const line = key.split(':')[1] ?? key;
+    const counts = new Map<string, number>();
+    for (const m of members) {
+      if (m.key !== key || m.confidence !== 'high' || m.dest === '') continue;
+      counts.set(m.dest, (counts.get(m.dest) ?? 0) + 1);
+    }
+    let dest = '';
+    let bestN = 0;
+    for (const [d, n] of counts) {
+      if (n > bestN) {
+        dest = d;
+        bestN = n;
+      }
+    }
+    labels.add(dest === '' ? line : `${line} → ${dest}`);
+  }
+  return [...labels].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+}
+
+/** Per-route brackets rebuilt from HIGH-confidence members only. `ev.brackets`
+ * (all confidences) still drives recovery tracking, but attribution — route
+ * names in the popup and the red sliced segments — extends the display bar's
+ * principle: a LOW-confidence excursion may corroborate a site, yet a route
+ * whose ONLY contribution is LOW must never get a red line or a name. */
+function highConfidenceBrackets(ev: DiversionEvent): Map<string, KeyBracket> {
+  const out = new Map<string, KeyBracket>();
+  for (const m of ev.members) {
+    if (m.confidence !== 'high') continue;
+    const bracket = out.get(m.key);
+    if (bracket === undefined) {
+      out.set(m.key, { sA: m.sA, sB: m.sB });
+    } else {
+      bracket.sA = Math.min(bracket.sA, m.sA);
+      bracket.sB = Math.max(bracket.sB, m.sB);
+    }
+  }
+  return out;
+}
+
+function transitionOf(ev: DiversionEvent, t: number, transition: TransitionRecord['transition']): TransitionRecord {
+  return {
+    t,
+    id: ev.id,
+    transition,
+    event: {
+      status: ev.status,
+      displayWorthy: ev.displayWorthy,
+      startedAt: ev.startedAt,
+      lastEvidenceAt: ev.lastEvidenceAt,
+      // The day log is evidence, not display: LOW-only routes stay listed here.
+      routes: routeNames(ev.brackets.keys()),
+      vehicles: ev.vehicles.size,
+      members: ev.members.length,
+      centroid: ev.centroid,
+    },
+  };
+}
+
+/** DISPLAY_MIN_VEHICLES distinct vehicles with HIGH-confidence excursions
+ * overlapping within 45 min — the display-worthiness bar. The pairwise scan
+ * IS the two-vehicle requirement; members are capped, so it stays tiny. */
+function isDisplayWorthy(ev: DiversionEvent): boolean {
+  const high = ev.members.filter((m) => m.confidence === 'high');
+  for (let i = 0; i < high.length; i++) {
+    for (let j = i + 1; j < high.length; j++) {
+      const a = high[i];
+      const b = high[j];
+      if (a === undefined || b === undefined || a.veh === b.veh) continue;
+      if (timesNear(a.t0, a.t1, b.t0, b.t1)) return true;
+    }
+  }
+  return false;
+}
+
+function recomputeCentroid(ev: DiversionEvent): void {
+  ev.centroid = [median(ev.members.map((m) => m.midLon)), median(ev.members.map((m) => m.midLat))];
+}
+
+/**
+ * Merge one completed excursion into the store (SITE-keyed: nearest live
+ * event whose centroid is within 500 m and whose time window overlaps,
+ * regardless of route family). Returns the transitions this caused.
+ */
+export function addExcursion(
+  store: EventStore,
+  exc: CompletedExcursion,
+  nowSec: number,
+): TransitionRecord[] {
+  const transitions: TransitionRecord[] = [];
+  let target: DiversionEvent | null = null;
+  let bestDist = Infinity;
+  for (const ev of store.events) {
+    if (!timesNear(exc.t0, exc.t1, ev.startedAt, ev.lastEvidenceAt)) continue;
+    const dist = metresBetween(ev.centroid[0], ev.centroid[1], exc.midLon, exc.midLat);
+    if (dist <= SITE_MERGE_DIST_M && dist < bestDist) {
+      bestDist = dist;
+      target = ev;
+    }
+  }
+
+  if (target === null) {
+    const day = utcDay(nowSec);
+    if (day !== store.seqDay) {
+      store.seqDay = day;
+      store.daySeq = 0;
+    }
+    store.daySeq += 1;
+    target = {
+      id: `div-${day}-${store.daySeq}`,
+      status: 'active',
+      displayWorthy: false,
+      startedAt: exc.t0,
+      lastEvidenceAt: exc.t1,
+      recoveringAt: null,
+      members: [],
+      vehicles: new Set(),
+      brackets: new Map(),
+      centroid: [exc.midLon, exc.midLat],
+      passages: new Map(),
+      passedVehicles: new Set(),
+    };
+    store.events.push(target);
+    transitions.push(transitionOf(target, nowSec, 'created'));
+  }
+
+  if (target.members.length < EVENT_MEMBER_CAP) target.members.push(exc);
+  if (!target.vehicles.has(exc.veh)) {
+    evictOldestIfFull(target.vehicles);
+    target.vehicles.add(exc.veh);
+  }
+  const bracket = target.brackets.get(exc.key);
+  if (bracket === undefined) {
+    evictOldestIfFull(target.brackets);
+    target.brackets.set(exc.key, { sA: exc.sA, sB: exc.sB });
+  } else {
+    bracket.sA = Math.min(bracket.sA, exc.sA);
+    bracket.sB = Math.max(bracket.sB, exc.sB);
+  }
+  target.startedAt = Math.min(target.startedAt, exc.t0);
+  target.lastEvidenceAt = Math.max(target.lastEvidenceAt, exc.t1);
+  recomputeCentroid(target);
+
+  // Fresh diversion evidence contradicts recovery/staleness: back to active,
+  // and recovery passages must be re-earned from scratch.
+  target.passages.clear();
+  target.passedVehicles.clear();
+  if (target.status !== 'active') {
+    target.status = 'active';
+    target.recoveringAt = null;
+    transitions.push(transitionOf(target, nowSec, 'reactivated'));
+  }
+
+  if (!target.displayWorthy && isDisplayWorthy(target)) {
+    target.displayWorthy = true;
+    transitions.push(transitionOf(target, nowSec, 'displayed'));
+  }
+  return transitions;
+}
+
+/**
+ * Feed one on-route fix into recovery tracking: a vehicle of an affected
+ * route traversing the bypassed bracket on-route (|d| < thr through
+ * [s_exit, s_rejoin]) is evidence the road reopened.
+ */
+export function noteOnRouteFix(
+  store: EventStore,
+  key: string,
+  veh: string,
+  s: number,
+  nowSec: number,
+): TransitionRecord[] {
+  const transitions: TransitionRecord[] = [];
+  for (const ev of store.events) {
+    if (ev.status !== 'active') continue;
+    const bracket = ev.brackets.get(key);
+    if (bracket === undefined) continue;
+    if (s < bracket.sA - RECOVERY_PASS_MARGIN_M || s > bracket.sB + RECOVERY_PASS_MARGIN_M) continue;
+    const passKey = `${key}|${veh}`;
+    let passage = ev.passages.get(passKey);
+    if (passage === undefined) {
+      evictOldestIfFull(ev.passages);
+      passage = { minS: s, maxS: s, broken: false };
+      ev.passages.set(passKey, passage);
+    }
+    passage.minS = Math.min(passage.minS, s);
+    passage.maxS = Math.max(passage.maxS, s);
+    if (
+      !passage.broken &&
+      passage.minS <= bracket.sA + RECOVERY_PASS_MARGIN_M &&
+      passage.maxS >= bracket.sB - RECOVERY_PASS_MARGIN_M
+    ) {
+      ev.passedVehicles.add(veh);
+      if (ev.passedVehicles.size >= RECOVERY_MIN_VEHICLES) {
+        ev.status = 'recovering';
+        ev.recoveringAt = nowSec;
+        transitions.push(transitionOf(ev, nowSec, 'recovering'));
+      }
+    }
+  }
+  return transitions;
+}
+
+/** An off-route fix inside a bracket breaks that vehicle's recovery passage —
+ * it demonstrably did NOT get through on-route. */
+export function noteOffRouteFix(store: EventStore, key: string, veh: string, s: number): void {
+  for (const ev of store.events) {
+    if (ev.status !== 'active') continue;
+    const bracket = ev.brackets.get(key);
+    if (bracket === undefined || s < bracket.sA || s > bracket.sB) continue;
+    const passage = ev.passages.get(`${key}|${veh}`);
+    if (passage !== undefined) passage.broken = true;
+  }
+}
+
+/** Time-driven transitions: active → stale, stale → dropped, recovering →
+ * dropped. Dropped events are removed from the store. */
+export function tickLifecycle(store: EventStore, nowSec: number): TransitionRecord[] {
+  const transitions: TransitionRecord[] = [];
+  const kept: DiversionEvent[] = [];
+  for (const ev of store.events) {
+    const sinceEvidence = nowSec - ev.lastEvidenceAt;
+    if (ev.status === 'recovering' && ev.recoveringAt !== null) {
+      if (nowSec - ev.recoveringAt >= RECOVERING_DROP_AFTER_S) {
+        transitions.push(transitionOf(ev, nowSec, 'dropped'));
+        continue;
+      }
+    } else if (ev.status === 'active' && sinceEvidence >= STALE_AFTER_S) {
+      ev.status = 'stale';
+      transitions.push(transitionOf(ev, nowSec, 'stale'));
+    } else if (ev.status === 'stale' && sinceEvidence >= STALE_AFTER_S + STALE_DROP_AFTER_S) {
+      transitions.push(transitionOf(ev, nowSec, 'dropped'));
+      continue;
+    }
+    kept.push(ev);
+  }
+  store.events = kept;
+  return transitions;
+}
+
+// ---------------------------------------------------------------------------
+// API payload assembly
+// ---------------------------------------------------------------------------
+
+export interface TflEnrichment {
+  loc: string;
+  dist: number;
+}
+
+export interface ApiDiversionEvent {
+  id: string;
+  status: EventStatus;
+  /** 'road': >=2 route-directions divert here — the road itself has a
+   * problem. 'partial': one direction of one route — those buses are
+   * diverting, but the road is otherwise flowing (drawn amber, softer
+   * wording; the SL8 case that confused a live user: inbound ran normally
+   * while outbound looped around). */
+  severity: 'road' | 'partial';
+  startedAt: number;
+  lastEvidenceAt: number;
+  /** human labels, destination-signed when known: "SL8 → Uxbridge" */
+  routes: string[];
+  vehicles: number;
+  longRunning: boolean;
+  centroid: [number, number];
+  segments: Array<Array<[number, number]>>;
+  tfl: TflEnrichment | null;
+}
+
+export interface DiversionsPayload {
+  generatedAt: number;
+  events: ApiDiversionEvent[];
+}
+
+const round5 = (v: number): number => Math.round(v * 1e5) / 1e5;
+
+export function buildApiEvents(
+  store: EventStore,
+  nowSec: number,
+  getPoly: (key: string) => readonly LonLat[] | null,
+  tflMatch: (lon: number, lat: number) => TflEnrichment | null,
+): DiversionsPayload {
+  const events: ApiDiversionEvent[] = [];
+  for (const ev of store.events) {
+    if (!ev.displayWorthy) continue;
+    // Attribution comes from HIGH-confidence members only (see
+    // highConfidenceBrackets) — never from ev.brackets, which includes
+    // LOW-only hitchhiker routes.
+    const brackets = highConfidenceBrackets(ev);
+    const segments: Array<Array<[number, number]>> = [];
+    // TfL is matched against BRACKET midpoints — the middle of the bypassed
+    // stretch ON the learned polyline, which sits at the works itself. The
+    // excursion-path midpoint (the detour apex) lies a parallel street away
+    // and the multi-route centroid drifts further still: in the replay the
+    // A23 closure matched @~100 m by bracket midpoint and missed by both
+    // alternatives.
+    let tfl: TflEnrichment | null = null;
+    for (const [key, bracket] of brackets) {
+      const poly = getPoly(key);
+      if (poly === null) continue;
+      const midS = (bracket.sA + bracket.sB) / 2;
+      const midSlice = slicePolyline(poly, midS - 1, midS + 1);
+      const mid = midSlice[0];
+      if (mid !== undefined) {
+        const hit = tflMatch(mid[0], mid[1]);
+        if (hit !== null && (tfl === null || hit.dist < tfl.dist)) tfl = hit;
+      }
+      if (segments.length >= MAX_EVENT_SEGMENTS) continue;
+      const slice = slicePolyline(poly, bracket.sA, bracket.sB);
+      if (slice.length >= 2) {
+        segments.push(slice.map(([lon, lat]) => [round5(lon), round5(lat)]));
+      }
+    }
+    events.push({
+      id: ev.id,
+      status: ev.status,
+      severity: brackets.size >= 2 ? 'road' : 'partial',
+      startedAt: ev.startedAt,
+      lastEvidenceAt: ev.lastEvidenceAt,
+      routes: routeLabels(brackets.keys(), ev.members),
+      vehicles: ev.vehicles.size,
+      longRunning: ev.lastEvidenceAt - ev.startedAt > LONG_RUNNING_S,
+      centroid: [round5(ev.centroid[0]), round5(ev.centroid[1])],
+      segments,
+      tfl,
+    });
+  }
+  return { generatedAt: nowSec, events };
+}
+
+// ---------------------------------------------------------------------------
+// TfL road-disruption enrichment (never gating)
+// ---------------------------------------------------------------------------
+
+export interface TflDisruptionPoint {
+  loc: string;
+  lon: number;
+  lat: number;
+}
+
+/** Parse the LAST line of the newest road-disruptions day file into match
+ * candidates. The snapshot recorder appends one full snapshot per line, so
+ * the last line of the newest file is the current disruption set. */
+export function parseDisruptionSnapshotLine(line: string): TflDisruptionPoint[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return [];
+  }
+  const disruptions = (parsed as { disruptions?: unknown }).disruptions;
+  if (!Array.isArray(disruptions)) return [];
+  const out: TflDisruptionPoint[] = [];
+  for (const raw of disruptions) {
+    const { loc, pt } = (raw ?? {}) as { loc?: unknown; pt?: unknown };
+    if (typeof pt !== 'string') continue;
+    let coords: unknown;
+    try {
+      coords = JSON.parse(pt);
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(coords) || typeof coords[0] !== 'number' || typeof coords[1] !== 'number') {
+      continue;
+    }
+    out.push({ loc: typeof loc === 'string' ? loc : '', lon: coords[0], lat: coords[1] });
+  }
+  return out;
+}
+
+export function matchTfl(
+  disruptions: readonly TflDisruptionPoint[],
+  lon: number,
+  lat: number,
+): TflEnrichment | null {
+  let best: TflEnrichment | null = null;
+  for (const d of disruptions) {
+    const dist = metresBetween(lon, lat, d.lon, d.lat);
+    if (dist <= TFL_MATCH_DIST_M && (best === null || dist < best.dist)) {
+      best = { loc: d.loc, dist: Math.round(dist) };
+    }
+  }
+  return best;
+}

--- a/backend/src/route-projection.test.ts
+++ b/backend/src/route-projection.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'vitest';
+import { buildRouteIndex, slicePolyline, type LonLat } from './route-projection';
+
+// Metric frame helpers matching the engine's equirectangular constants, so
+// offsets have a known size in metres.
+const LAT0 = 51.5;
+const LON0 = -0.1;
+const M_PER_DEG_LAT = 110_540;
+const mPerDegLon = (meanLat: number): number => 111_320 * Math.cos((meanLat * Math.PI) / 180);
+
+const latAt = (metres: number): number => LAT0 + metres / M_PER_DEG_LAT;
+
+/** Straight north-south line from s=0 to s=lengthM at LON0. */
+const nsLine = (lengthM: number): LonLat[] => [
+  [LON0, latAt(0)],
+  [LON0, latAt(lengthM)],
+];
+
+/** Brute-force reference: project against every segment in the same frame
+ * the index uses (mean-lat equirectangular anchored at the first vertex). */
+function bruteProject(poly: readonly LonLat[], lon: number, lat: number): { s: number; d: number } {
+  const meanLat = poly.reduce((sum, p) => sum + p[1], 0) / poly.length;
+  const kx = mPerDegLon(meanLat);
+  const ky = M_PER_DEG_LAT;
+  const lon0 = poly[0]?.[0] ?? 0;
+  const lat0 = poly[0]?.[1] ?? 0;
+  const fx = (lon - lon0) * kx;
+  const fy = (lat - lat0) * ky;
+  let cum = 0;
+  let best = { dist2: Infinity, s: 0, sign: 1 };
+  for (let i = 0; i < poly.length - 1; i++) {
+    const ax = ((poly[i]?.[0] ?? 0) - lon0) * kx;
+    const ay = ((poly[i]?.[1] ?? 0) - lat0) * ky;
+    const bx = ((poly[i + 1]?.[0] ?? 0) - lon0) * kx;
+    const by = ((poly[i + 1]?.[1] ?? 0) - lat0) * ky;
+    const dx = bx - ax;
+    const dy = by - ay;
+    const len = Math.hypot(dx, dy);
+    const len2 = dx * dx + dy * dy;
+    let t = 0;
+    if (len2 > 0) t = Math.max(0, Math.min(1, ((fx - ax) * dx + (fy - ay) * dy) / len2));
+    const qx = fx - (ax + t * dx);
+    const qy = fy - (ay + t * dy);
+    const dist2 = qx * qx + qy * qy;
+    if (dist2 < best.dist2) {
+      best = {
+        dist2,
+        s: cum + t * len,
+        sign: dx * (fy - ay) - dy * (fx - ax) >= 0 ? 1 : -1,
+      };
+    }
+    cum += len;
+  }
+  return { s: best.s, d: best.sign * Math.sqrt(best.dist2) };
+}
+
+/** Deterministic LCG so the exactness sweep is reproducible. */
+function makeRng(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) >>> 0;
+    return state / 2 ** 32;
+  };
+}
+
+describe('buildRouteIndex', () => {
+  test('matches brute force exactly on a zigzag polyline', () => {
+    // Hand zigzag: north, east, north, west — corners exercise clamped
+    // segment-end projections and sign flips.
+    const poly: LonLat[] = [
+      [LON0, latAt(0)],
+      [LON0, latAt(2000)],
+      [LON0 + 1500 / mPerDegLon(51.51), latAt(2000)],
+      [LON0 + 1500 / mPerDegLon(51.51), latAt(4000)],
+      [LON0, latAt(4000)],
+    ];
+    const index = buildRouteIndex(poly);
+    const rng = makeRng(42);
+
+    for (let i = 0; i < 300; i++) {
+      const lon = LON0 - 0.02 + rng() * 0.06;
+      const lat = latAt(-500 + rng() * 5000);
+      const got = index.projectFix(lon, lat);
+      const want = bruteProject(poly, lon, lat);
+      expect(Math.abs(got.s - want.s)).toBeLessThan(1e-6);
+      expect(Math.abs(got.d - want.d)).toBeLessThan(1e-6);
+    }
+  });
+
+  test('s progresses monotonically along the route', () => {
+    const index = buildRouteIndex(nsLine(10_000));
+    let prev = -1;
+    for (let s = 0; s <= 10_000; s += 500) {
+      const got = index.projectFix(LON0, latAt(s));
+      expect(got.s).toBeGreaterThan(prev);
+      expect(Math.abs(got.s - s)).toBeLessThan(1); // metre-accurate arc length
+      prev = got.s;
+    }
+  });
+
+  test('d is signed: left of northbound travel is positive', () => {
+    const index = buildRouteIndex(nsLine(10_000));
+    const west = index.projectFix(LON0 - 100 / mPerDegLon(51.545), latAt(5000));
+    expect(west.d).toBeGreaterThan(99);
+    expect(west.d).toBeLessThan(101);
+    const east = index.projectFix(LON0 + 100 / mPerDegLon(51.545), latAt(5000));
+    expect(east.d).toBeLessThan(-99);
+  });
+
+  test('a fix 50 km off-route never crashes and reports a genuinely large d', () => {
+    const index = buildRouteIndex(nsLine(10_000));
+    const got = index.projectFix(LON0 + 0.72, latAt(5000)); // ~50 km east
+    expect(Number.isFinite(got.d)).toBe(true);
+    expect(Math.abs(got.d)).toBeGreaterThan(49_000);
+    const want = bruteProject(nsLine(10_000), LON0 + 0.72, latAt(5000));
+    expect(Math.abs(Math.abs(got.d) - Math.abs(want.d))).toBeLessThan(1e-6);
+  });
+
+  test('beyond-terminus fixes clamp to s=0 and s=totalLengthM', () => {
+    const index = buildRouteIndex(nsLine(10_000));
+    expect(index.projectFix(LON0, latAt(-800)).s).toBe(0);
+    const past = index.projectFix(LON0, latAt(10_800));
+    expect(Math.abs(past.s - index.totalLengthM)).toBeLessThan(1e-9);
+  });
+
+  test('rejects a degenerate polyline', () => {
+    expect(() => buildRouteIndex([[LON0, LAT0]])).toThrow(/>= 2 points/);
+  });
+});
+
+describe('slicePolyline', () => {
+  test('cuts a metre-addressed slice with interpolated endpoints', () => {
+    const slice = slicePolyline(nsLine(10_000), 1000, 2000);
+    expect(slice.length).toBe(2);
+    const first = slice[0] ?? [0, 0];
+    const last = slice[slice.length - 1] ?? [0, 0];
+    expect(Math.abs((first[1] - LAT0) * M_PER_DEG_LAT - 1000)).toBeLessThan(1);
+    expect(Math.abs((last[1] - LAT0) * M_PER_DEG_LAT - 2000)).toBeLessThan(1);
+  });
+
+  test('keeps interior vertices inside the span', () => {
+    const poly: LonLat[] = [
+      [LON0, latAt(0)],
+      [LON0, latAt(1000)],
+      [LON0, latAt(2000)],
+      [LON0, latAt(3000)],
+    ];
+    const slice = slicePolyline(poly, 500, 2500);
+    // interpolated start + vertices at 1000/2000 + interpolated end
+    expect(slice.length).toBe(4);
+  });
+
+  test('clamps to the polyline extent', () => {
+    const slice = slicePolyline(nsLine(1000), -500, 5000);
+    const last = slice[slice.length - 1] ?? [0, 0];
+    expect(Math.abs((last[1] - LAT0) * M_PER_DEG_LAT - 1000)).toBeLessThan(1);
+  });
+
+  test('returns [] for an empty or inverted-then-empty span', () => {
+    expect(slicePolyline(nsLine(1000), 700, 700)).toEqual([]);
+    expect(slicePolyline([], 0, 100)).toEqual([]);
+  });
+});

--- a/backend/src/route-projection.ts
+++ b/backend/src/route-projection.ts
@@ -1,0 +1,280 @@
+// Pure geometry for bus-diversion detection: project GPS fixes onto learned
+// route polylines by arc length, and slice a polyline between two arc lengths.
+//
+// buildRouteIndex(poly).projectFix(lon, lat) returns
+//   s : along-route metres from the polyline start (arc length of the nearest
+//       point on the nearest segment)
+//   d : SIGNED cross-track metres; positive = fix to the LEFT of the travel
+//       direction. Use Math.abs(d) for excursion magnitude.
+//
+// Geometry is a local equirectangular frame at the polyline's mean latitude —
+// error well under 0.1% at route scale (<70 km), far below the ≥50 m
+// excursion thresholds this feeds. A uniform grid over segment bounding boxes
+// with an expanding-ring search keeps projection ~O(1) per fix; fixes far
+// off-route never crash — the ring search is capped and falls back to a
+// brute-force scan, returning a genuinely large d.
+//
+// Ported from the validated prototype (projection-engine.cjs, audit gate
+// 8/10 confirmed / 0 garage artifacts) — the algorithm is intentionally
+// byte-for-byte equivalent so the online detector inherits its calibration.
+
+const METRES_PER_DEG_LAT = 110_540; // mean; good enough at city latitudes
+const METRES_PER_DEG_LON_EQUATOR = 111_320;
+const DEFAULT_CELL_SIZE_M = 500;
+const MAX_RING_CELLS = 40; // 20 km at 500 m cells before brute-force fallback
+
+export type LonLat = readonly [number, number];
+
+export interface RouteProjection {
+  s: number;
+  d: number;
+}
+
+export interface RouteIndex {
+  readonly totalLengthM: number;
+  readonly nSegments: number;
+  /**
+   * Project one fix. The returned object is a SHARED SCRATCH reused between
+   * calls (this runs for every vehicle on every poll — per-call allocation
+   * would be pure GC pressure): copy `s`/`d` out before the next call.
+   */
+  projectFix(lon: number, lat: number): RouteProjection;
+}
+
+interface BestMatch {
+  dist2: number;
+  seg: number;
+  t: number;
+  sign: number;
+}
+
+export function buildRouteIndex(poly: readonly LonLat[], cellSizeM?: number): RouteIndex {
+  if (!Array.isArray(poly) || poly.length < 2) {
+    throw new Error(`buildRouteIndex: polyline needs >= 2 points, got ${poly?.length}`);
+  }
+  const cellSize = cellSizeM ?? DEFAULT_CELL_SIZE_M;
+
+  // --- local equirectangular frame ---
+  let latSum = 0;
+  for (const p of poly) latSum += p[1];
+  const meanLat = latSum / poly.length;
+  const kx = METRES_PER_DEG_LON_EQUATOR * Math.cos((meanLat * Math.PI) / 180);
+  const ky = METRES_PER_DEG_LAT;
+  const lon0 = poly[0]?.[0] ?? 0;
+  const lat0 = poly[0]?.[1] ?? 0;
+
+  // --- segment arrays ---
+  const nSeg = poly.length - 1;
+  const ax = new Float64Array(nSeg);
+  const ay = new Float64Array(nSeg);
+  const dx = new Float64Array(nSeg);
+  const dy = new Float64Array(nSeg);
+  const len = new Float64Array(nSeg);
+  const cum = new Float64Array(nSeg); // arc length at segment start
+
+  let running = 0;
+  let px = 0;
+  let py = 0;
+  for (let i = 0; i <= nSeg; i++) {
+    const x = ((poly[i]?.[0] ?? 0) - lon0) * kx;
+    const y = ((poly[i]?.[1] ?? 0) - lat0) * ky;
+    if (i > 0) {
+      const j = i - 1;
+      ax[j] = px;
+      ay[j] = py;
+      dx[j] = x - px;
+      dy[j] = y - py;
+      len[j] = Math.hypot(dx[j] ?? 0, dy[j] ?? 0);
+      cum[j] = running;
+      running += len[j] ?? 0;
+    }
+    px = x;
+    py = y;
+  }
+  const totalLengthM = running;
+
+  // --- uniform grid over segment bboxes ---
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  for (let i = 0; i < nSeg; i++) {
+    const x1 = ax[i] ?? 0;
+    const y1 = ay[i] ?? 0;
+    const x2 = x1 + (dx[i] ?? 0);
+    const y2 = y1 + (dy[i] ?? 0);
+    if (Math.min(x1, x2) < minX) minX = Math.min(x1, x2);
+    if (Math.min(y1, y2) < minY) minY = Math.min(y1, y2);
+    if (Math.max(x1, x2) > maxX) maxX = Math.max(x1, x2);
+    if (Math.max(y1, y2) > maxY) maxY = Math.max(y1, y2);
+  }
+  const gridW = Math.max(1, Math.ceil((maxX - minX) / cellSize));
+  const gridH = Math.max(1, Math.ceil((maxY - minY) / cellSize));
+  const cells = new Map<number, number[]>(); // cellIdx → segment indices
+
+  const cellOf = (cx: number, cy: number): number => cy * gridW + cx;
+  const clampCx = (cx: number): number => (cx < 0 ? 0 : cx >= gridW ? gridW - 1 : cx);
+  const clampCy = (cy: number): number => (cy < 0 ? 0 : cy >= gridH ? gridH - 1 : cy);
+
+  for (let i = 0; i < nSeg; i++) {
+    const x1 = ax[i] ?? 0;
+    const y1 = ay[i] ?? 0;
+    const x2 = x1 + (dx[i] ?? 0);
+    const y2 = y1 + (dy[i] ?? 0);
+    const cx1 = clampCx(Math.floor((Math.min(x1, x2) - minX) / cellSize));
+    const cx2 = clampCx(Math.floor((Math.max(x1, x2) - minX) / cellSize));
+    const cy1 = clampCy(Math.floor((Math.min(y1, y2) - minY) / cellSize));
+    const cy2 = clampCy(Math.floor((Math.max(y1, y2) - minY) / cellSize));
+    for (let cy = cy1; cy <= cy2; cy++) {
+      for (let cx = cx1; cx <= cx2; cx++) {
+        const key = cellOf(cx, cy);
+        const list = cells.get(key);
+        if (list === undefined) cells.set(key, [i]);
+        else list.push(i);
+      }
+    }
+  }
+
+  // Scratch result reused between calls — see the projectFix doc comment.
+  const result: RouteProjection = { s: 0, d: 0 };
+
+  function testSegment(i: number, fx: number, fy: number, best: BestMatch): void {
+    const ddx = dx[i] ?? 0;
+    const ddy = dy[i] ?? 0;
+    const rx = fx - (ax[i] ?? 0);
+    const ry = fy - (ay[i] ?? 0);
+    const len2 = ddx * ddx + ddy * ddy;
+    let t = 0;
+    if (len2 > 0) {
+      t = (rx * ddx + ry * ddy) / len2;
+      if (t < 0) t = 0;
+      else if (t > 1) t = 1;
+    }
+    const qx = rx - t * ddx;
+    const qy = ry - t * ddy;
+    const dist2 = qx * qx + qy * qy;
+    if (dist2 < best.dist2) {
+      best.dist2 = dist2;
+      best.seg = i;
+      best.t = t;
+      // cross-product sign: >0 means the fix is left of the travel direction
+      best.sign = ddx * ry - ddy * rx >= 0 ? 1 : -1;
+    }
+  }
+
+  function projectFix(lon: number, lat: number): RouteProjection {
+    const fx = (lon - lon0) * kx;
+    const fy = (lat - lat0) * ky;
+    const best: BestMatch = { dist2: Infinity, seg: 0, t: 0, sign: 1 };
+
+    const ccx = clampCx(Math.floor((fx - minX) / cellSize));
+    const ccy = clampCy(Math.floor((fy - minY) / cellSize));
+
+    // How far outside the grid is the fix? Rings closer than that are useless.
+    const gxDist = Math.max(minX - fx, fx - (minX + gridW * cellSize), 0);
+    const gyDist = Math.max(minY - fy, fy - (minY + gridH * cellSize), 0);
+    const outside = Math.hypot(gxDist, gyDist);
+    const maxRing = Math.max(gridW, gridH);
+
+    let resolved = false;
+    if (outside <= MAX_RING_CELLS * cellSize) {
+      for (let r = 0; r <= maxRing; r++) {
+        // Every cell in ring r is at least (r-1)*cellSize metres from the fix
+        // (conservative), so once best is closer than that we can stop.
+        if (best.dist2 < Infinity) {
+          const ringMin = (r - 1) * cellSize;
+          if (ringMin > 0 && ringMin * ringMin > best.dist2) {
+            resolved = true;
+            break;
+          }
+        }
+        if (r > MAX_RING_CELLS && best.dist2 === Infinity) break; // fall back
+        const cx1 = ccx - r;
+        const cx2 = ccx + r;
+        const cy1 = ccy - r;
+        const cy2 = ccy + r;
+        for (let cy = cy1; cy <= cy2; cy++) {
+          if (cy < 0 || cy >= gridH) continue;
+          const onYEdge = cy === cy1 || cy === cy2;
+          for (let cx = cx1; cx <= cx2; cx++) {
+            if (cx < 0 || cx >= gridW) continue;
+            if (!onYEdge && cx !== cx1 && cx !== cx2) continue; // ring only
+            const list = cells.get(cellOf(cx, cy));
+            if (list === undefined) continue;
+            for (let li = 0; li < list.length; li++) {
+              testSegment(list[li] ?? 0, fx, fy, best);
+            }
+          }
+        }
+        if (r === maxRing && best.dist2 < Infinity) resolved = true;
+      }
+    }
+
+    if (!resolved && best.dist2 === Infinity) {
+      // Far off-route (or ring search exhausted): brute-force every segment.
+      for (let i = 0; i < nSeg; i++) testSegment(i, fx, fy, best);
+    }
+
+    result.s = (cum[best.seg] ?? 0) + best.t * (len[best.seg] ?? 0);
+    result.d = best.sign * Math.sqrt(best.dist2);
+    return result;
+  }
+
+  return { projectFix, totalLengthM, nSegments: nSeg };
+}
+
+/**
+ * Slice of a polyline between two arc lengths (metres), endpoints
+ * interpolated. Used to cut the bypassed [s_exit, s_rejoin] bracket out of a
+ * learned polyline for the frontend's red diversion highlight. Arc lengths
+ * are measured in the same equirectangular frame as buildRouteIndex, so a
+ * bracket produced by projectFix slices back to the matching geometry.
+ */
+export function slicePolyline(
+  poly: readonly LonLat[],
+  s0: number,
+  s1: number,
+): Array<[number, number]> {
+  if (poly.length < 2) return [];
+  let latSum = 0;
+  for (const p of poly) latSum += p[1];
+  const kx = METRES_PER_DEG_LON_EQUATOR * Math.cos(((latSum / poly.length) * Math.PI) / 180);
+  const ky = METRES_PER_DEG_LAT;
+
+  const cum = new Float64Array(poly.length);
+  for (let i = 1; i < poly.length; i++) {
+    const ddx = ((poly[i]?.[0] ?? 0) - (poly[i - 1]?.[0] ?? 0)) * kx;
+    const ddy = ((poly[i]?.[1] ?? 0) - (poly[i - 1]?.[1] ?? 0)) * ky;
+    cum[i] = (cum[i - 1] ?? 0) + Math.hypot(ddx, ddy);
+  }
+  const total = cum[poly.length - 1] ?? 0;
+  const a = Math.max(0, Math.min(s0, s1));
+  const b = Math.min(total, Math.max(s0, s1));
+  if (b - a < 1e-9) return [];
+
+  const pointAt = (s: number): [number, number] => {
+    let lo = 0;
+    let hi = poly.length - 1;
+    while (lo + 1 < hi) {
+      const mid = (lo + hi) >> 1;
+      if ((cum[mid] ?? 0) <= s) lo = mid;
+      else hi = mid;
+    }
+    const segLen = (cum[hi] ?? 0) - (cum[lo] ?? 0);
+    const t = segLen > 0 ? (s - (cum[lo] ?? 0)) / segLen : 0;
+    const p0 = poly[lo] ?? [0, 0];
+    const p1 = poly[hi] ?? [0, 0];
+    return [p0[0] + t * (p1[0] - p0[0]), p0[1] + t * (p1[1] - p0[1])];
+  };
+
+  const out: Array<[number, number]> = [pointAt(a)];
+  for (let i = 0; i < poly.length; i++) {
+    const s = cum[i] ?? 0;
+    if (s > a && s < b) {
+      const p = poly[i] ?? [0, 0];
+      out.push([p[0], p[1]]);
+    }
+  }
+  out.push(pointAt(b));
+  return out;
+}

--- a/backend/src/routes/capabilities.test.ts
+++ b/backend/src/routes/capabilities.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import Fastify, { type FastifyInstance } from 'fastify';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { registerCapabilitiesRoute } from './capabilities';
+import { startDiversionDetector } from '../diversion-detector';
 import type { AppConfig } from '../config';
 
 // Only the fields buildCapabilities reads; everything credential-ish is unset
@@ -64,5 +65,18 @@ describe('capabilities busCoverage flag', () => {
     await writeFile(join(busDataDir, 'coverage', 'latest.json'), '{"type":"FeatureCollection"}');
 
     expect((await layers()).busCoverage).toBe(true);
+  });
+
+  it('busDiversions flips true WITHOUT a restart once the detector starts', async () => {
+    // Same bug class: on a fresh volume app.ts starts the detector from a
+    // retry timer long after boot; the flag mirrors the running detector.
+    expect((await layers()).busDiversions).toBe(false);
+
+    const detector = startDiversionDetector(busDataDir, () => {});
+    try {
+      expect((await layers()).busDiversions).toBe(true);
+    } finally {
+      detector.stop();
+    }
   });
 });

--- a/backend/src/routes/capabilities.ts
+++ b/backend/src/routes/capabilities.ts
@@ -14,6 +14,7 @@ import { stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { FastifyInstance } from 'fastify';
 import type { AppConfig } from '../config';
+import { isDiversionDetectorRunning } from '../diversion-detector';
 
 /** The coverage flag means "GET /api/coverage will answer 200 right now", so
  * it watches the ARTIFACT file, not the writer's inputs — anything else opens
@@ -49,6 +50,14 @@ export function buildCapabilities(
   // key can still draw the map it already earned. True only once the writer
   // has actually produced a servable artifact.
   const hasBusCoverage = existsSync(coverageArtifactPath(busDataDir));
+
+  // Diversion detection rides the BODS poll. The flag mirrors the detector
+  // ACTUALLY running — not a re-derivation from config + directories — so it
+  // can never disagree with app.ts's start decision (which now includes a
+  // fresh-volume retry that starts the detector long after boot). The flag
+  // can never dead-click: /api/diversions answers 200 with an empty event
+  // list even before the detector exists.
+  const hasBusDiversions = isDiversionDetectorRunning();
 
   // Line geometry and station points come from baked data on disk, NOT from a
   // credential — a region can have a drawn network with no operator API at all
@@ -86,6 +95,7 @@ export function buildCapabilities(
       // Independent feeds, each gated by its own credential or flag.
       buses: config.bodsApiKey !== undefined,
       busCoverage: hasBusCoverage,
+      busDiversions: hasBusDiversions,
       nationalRail: config.darwinToken !== undefined,
       bikeStations: config.gbfsUrl !== undefined,
       vessels: config.aisApiKey !== undefined,
@@ -106,13 +116,12 @@ export function registerCapabilitiesRoute(
 ): void {
   let payload = buildCapabilities(config, bakedDataDir, busDataDir);
   app.get('/api/capabilities', async () => {
-    // busCoverage is the one flag derived from a runtime-WRITTEN file rather
-    // than config or baked data: on a fresh volume it is false at boot and
-    // flips days later within this same process, when the coverage writer's
-    // first artifact lands. Re-check per request until it flips (the artifact
-    // is never deleted), then stop paying the stat. Async so the pre-flip
-    // window never blocks the event loop — every other flag stays a boot-time
-    // constant.
+    // busCoverage and busDiversions are the two flags that can flip mid-
+    // process on a fresh volume, days after boot: coverage when the writer's
+    // first artifact lands, diversions when the retry timer in app.ts starts
+    // the detector. Both use the same sticky lazy re-check — probe per
+    // request only until true, then stop paying. Coverage needs an async stat
+    // (never block the event loop pre-flip); diversions is a plain flag read.
     if (!payload.layers.busCoverage) {
       const servable = await stat(coverageArtifactPath(busDataDir)).then(
         (s) => s.isFile(),
@@ -121,6 +130,9 @@ export function registerCapabilitiesRoute(
       if (servable) {
         payload = { ...payload, layers: { ...payload.layers, busCoverage: true } };
       }
+    }
+    if (!payload.layers.busDiversions && isDiversionDetectorRunning()) {
+      payload = { ...payload, layers: { ...payload.layers, busDiversions: true } };
     }
     return payload;
   });

--- a/backend/src/routes/data-export.ts
+++ b/backend/src/routes/data-export.ts
@@ -33,6 +33,7 @@ const DATASETS: Readonly<Record<string, DatasetSpec>> = {
     ext: '.jsonl',
     contentType: 'application/x-ndjson',
   },
+  diversions: { dir: 'diversions', ext: '.jsonl', contentType: 'application/x-ndjson' },
 };
 
 /** Constant-time bearer-token check; hashing first equalises lengths. */

--- a/backend/src/routes/diversions.test.ts
+++ b/backend/src/routes/diversions.test.ts
@@ -1,0 +1,85 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerDiversionsRoute } from './diversions';
+import type { DiversionDetector } from '../diversion-detector';
+import type { DiversionsPayload } from '../diversion-events';
+
+describe('diversions route', () => {
+  let app: FastifyInstance;
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('answers an empty payload with the cache header when no detector runs', async () => {
+    app = Fastify();
+    registerDiversionsRoute(app, () => null);
+
+    const res = await app.inject({ method: 'GET', url: '/api/diversions' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['cache-control']).toBe('public, max-age=60');
+    const body = res.json() as DiversionsPayload;
+    expect(body.events).toEqual([]);
+    expect(typeof body.generatedAt).toBe('number');
+  });
+
+  it('serves the detector snapshot verbatim', async () => {
+    const payload: DiversionsPayload = {
+      generatedAt: 1_756_300_000,
+      events: [
+        {
+          id: 'div-2026-08-28-1',
+          status: 'active',
+        severity: 'road',
+          startedAt: 1_756_290_000,
+          lastEvidenceAt: 1_756_299_000,
+          routes: ['133', '45'],
+          vehicles: 3,
+          longRunning: false,
+          centroid: [-0.1, 51.5],
+          segments: [
+            [
+              [-0.1, 51.5],
+              [-0.1, 51.51],
+            ],
+          ],
+          tfl: { loc: 'HIGH ROAD closed', dist: 80 },
+        },
+      ],
+    };
+    const detector: DiversionDetector = {
+      record: () => {},
+      snapshot: () => Promise.resolve(payload),
+      stop: () => {},
+    };
+    app = Fastify();
+    registerDiversionsRoute(app, () => detector);
+
+    const res = await app.inject({ method: 'GET', url: '/api/diversions' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['cache-control']).toBe('public, max-age=60');
+    expect(res.json()).toEqual(payload);
+  });
+
+  it('serves a detector that starts AFTER route registration (fresh-volume start)', async () => {
+    // On a fresh volume app.ts starts the detector from a retry timer long
+    // after the route registers — the getter must observe that late start.
+    const payload: DiversionsPayload = { generatedAt: 1_756_300_000, events: [] };
+    let detector: DiversionDetector | null = null;
+    app = Fastify();
+    registerDiversionsRoute(app, () => detector);
+
+    const before = await app.inject({ method: 'GET', url: '/api/diversions' });
+    expect((before.json() as DiversionsPayload).events).toEqual([]);
+
+    detector = {
+      record: () => {},
+      snapshot: () => Promise.resolve(payload),
+      stop: () => {},
+    };
+    const after = await app.inject({ method: 'GET', url: '/api/diversions' });
+    expect(after.json()).toEqual(payload);
+  });
+});

--- a/backend/src/routes/diversions.ts
+++ b/backend/src/routes/diversions.ts
@@ -1,0 +1,37 @@
+// Live bus-diversion events.
+//
+//   GET /api/diversions → { generatedAt, events: [...] } (contract in
+//   diversion-detector.ts: only display-worthy events; the frontend renders
+//   exactly what this returns, with no client-side filtering rules)
+//
+// max-age=60: events change on the 15 s BODS cadence but the display bar
+// (two vehicles, high confidence) moves in minutes, so a minute of edge cache
+// costs no correctness and absorbs the polling fan-out. When the detector is
+// not running (no BODS key or no learned routes) the route still answers with
+// an empty event list — the capabilities flag keeps the frontend from asking,
+// but a stray fetch must not 404 into an edge cache.
+//
+// Takes a GETTER, not a detector instance: on a fresh volume app.ts starts
+// the detector long after this route registers (once learned routes appear),
+// and the route must serve it from that moment.
+
+import type { FastifyInstance } from 'fastify';
+import type { DiversionDetector } from '../diversion-detector';
+
+const DIVERSIONS_MAX_AGE_S = 60;
+
+export function registerDiversionsRoute(
+  app: FastifyInstance,
+  getDetector: () => DiversionDetector | null,
+): void {
+  app.get('/api/diversions', async (_req, reply) => {
+    const detector = getDetector();
+    const payload =
+      detector === null
+        ? { generatedAt: Math.floor(Date.now() / 1000), events: [] }
+        : await detector.snapshot();
+    return reply
+      .header('cache-control', `public, max-age=${DIVERSIONS_MAX_AGE_S}`)
+      .send(payload);
+  });
+}

--- a/frontend/src/layers/diversions.ts
+++ b/frontend/src/layers/diversions.ts
@@ -1,0 +1,276 @@
+// Live bus-diversion events from the detector (/api/diversions). Each event's
+// bypassed learned-polyline slices draw as a prominent red line with a small
+// dot at the centroid. The API returns only display-worthy events — the
+// frontend renders exactly what it is given, no client-side filtering.
+//
+// Polling is gated on the overlay toggle (default ON): the detector output
+// only changes every rollup pass, so a hidden overlay polling anyway would be
+// pure egress waste. Re-enabling refreshes immediately since the last picture
+// may be a whole off-interval stale.
+
+import {
+  Popup,
+  type ExpressionSpecification,
+  type GeoJSONSource,
+  type Map as MaplibreMap,
+  type MapLayerMouseEvent,
+} from 'maplibre-gl';
+import { registerPoll } from '../util/lifecycle';
+import { below } from '../util/layer-order';
+
+export const DIVERSIONS_SEGMENTS_LAYER_ID = 'diversions-segments';
+export const DIVERSIONS_DOTS_LAYER_ID = 'diversions-dots';
+export const DIVERSIONS_LAYER_IDS = [DIVERSIONS_SEGMENTS_LAYER_ID, DIVERSIONS_DOTS_LAYER_ID];
+
+const SOURCE_ID = 'diversions';
+const DIVERSIONS_URL = '/api/diversions';
+/** The API caches for 60 s; 90 s keeps at most one wasted hit per fresh copy. */
+const POLL_INTERVAL_MS = 90_000;
+
+/** Status drives the lifecycle look (recovering = healing green, stale =
+ * faded furniture); among ACTIVE events, severity splits red from amber:
+ * 'road' (>=2 route-directions divert — the road has a problem) stays loud
+ * red, 'partial' (one direction of one route; the road otherwise flows)
+ * drops to amber so it never reads as a closure. */
+const STATUS_COLOR: ExpressionSpecification = [
+  'match', ['get', 'status'],
+  'recovering', '#4c5',
+  'stale', '#8a94a0',
+  ['match', ['get', 'severity'], 'partial', '#f0a030', '#e33'],
+];
+const STATUS_OPACITY: ExpressionSpecification =
+  ['match', ['get', 'status'], 'recovering', 0.7, 'stale', 0.35, 0.9];
+
+type LngLat = [number, number];
+
+interface DiversionEvent {
+  id?: string;
+  status?: 'active' | 'recovering' | 'stale';
+  severity?: 'road' | 'partial';
+  startedAt?: number;
+  lastEvidenceAt?: number;
+  routes?: string[];
+  vehicles?: number;
+  longRunning?: boolean;
+  centroid?: unknown;
+  segments?: unknown;
+  tfl?: { loc?: string; dist?: number } | null;
+}
+
+interface DiversionsResponse {
+  generatedAt?: number;
+  events?: DiversionEvent[];
+}
+
+/** Flat because maplibre JSON-round-trips feature properties; a nested `tfl`
+ * object would come back out of queryRenderedFeatures as a string. */
+interface DiversionProps {
+  routes: string;
+  vehicles: number;
+  status: string;
+  severity: string;
+  longRunning: boolean;
+  startedAt: number;
+  hasTfl: boolean;
+  tflLoc: string;
+  tflDist: number;
+}
+
+const esc = (s: string): string =>
+  s.replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c] ?? c);
+
+function isLngLat(value: unknown): value is LngLat {
+  return (
+    Array.isArray(value) &&
+    value.length >= 2 &&
+    Number.isFinite(value[0]) &&
+    Number.isFinite(value[1])
+  );
+}
+
+function toProps(ev: DiversionEvent): DiversionProps {
+  return {
+    // Numeric-aware so "9" sorts before "10" and "N136" after "45" — the same
+    // idiom as listActiveBusLines in layers/buses.ts.
+    routes: [...(ev.routes ?? [])]
+      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+      .join(', '),
+    vehicles: ev.vehicles ?? 0,
+    status: ev.status ?? 'active',
+    severity: ev.severity ?? 'road',
+    longRunning: ev.longRunning === true,
+    startedAt: ev.startedAt ?? 0,
+    hasTfl: ev.tfl != null,
+    tflLoc: ev.tfl?.loc ?? '',
+    tflDist: ev.tfl?.dist ?? 0,
+  };
+}
+
+function toFeatures(events: DiversionEvent[]): GeoJSON.Feature[] {
+  return events.flatMap((ev) => {
+    const props = toProps(ev);
+    const features: GeoJSON.Feature[] = [];
+    // One MultiLineString per event, not a feature per slice: the popup should
+    // hit the whole event wherever it is clicked.
+    // Every point must validate — one bad coordinate in an otherwise-valid
+    // segment would otherwise reach setData and break the whole source.
+    const segments = Array.isArray(ev.segments)
+      ? ev.segments.filter(
+          (seg): seg is LngLat[] => Array.isArray(seg) && seg.length >= 2 && seg.every(isLngLat),
+        )
+      : [];
+    if (segments.length > 0) {
+      features.push({
+        type: 'Feature',
+        properties: props,
+        geometry: { type: 'MultiLineString', coordinates: segments },
+      });
+    }
+    if (isLngLat(ev.centroid)) {
+      features.push({
+        type: 'Feature',
+        properties: props,
+        geometry: { type: 'Point', coordinates: [ev.centroid[0], ev.centroid[1]] },
+      });
+    }
+    return features;
+  });
+}
+
+const STATUS_WORDS: Record<string, string> = {
+  active: 'Buses diverting now',
+  recovering: 'Buses returning to route',
+  stale: 'No recent evidence',
+};
+
+/** Bare HH:MM misleads once the event started on an earlier day (or has run
+ * >24 h): "since 09:15" would read as this morning. Add the date then. */
+const timeLabel = (epochSec: number, longRunning: boolean): string => {
+  const started = new Date(epochSec * 1000);
+  const isToday = started.toDateString() === new Date().toDateString();
+  return isToday && !longRunning
+    ? started.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    : started.toLocaleString([], {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+};
+
+function popupHtml(p: DiversionProps): string {
+  // 'partial' softens everything: one direction of one route is diverting
+  // while the road itself flows — "Diversion" + red would read as a closure.
+  const partial = p.severity === 'partial';
+  const title = partial ? '⚠️ Some buses diverting' : '🚧 Diversion';
+  const status = partial && p.status === 'active'
+    ? 'Other routes and directions running normally'
+    : (STATUS_WORDS[p.status] ?? p.status);
+  const ongoing = p.longRunning ? ' · ongoing >24h' : '';
+  const tfl = p.hasTfl
+    ? `TfL: ${esc(p.tflLoc)} (~${Math.round(p.tflDist)}m)`
+    : 'no matching roadworks record';
+  return `<div class="vp"><div class="sp-title">${title} — ${esc(p.routes)}</div>
+    <div>${esc(status)}${ongoing}</div>
+    <div>since ${timeLabel(p.startedAt, p.longRunning)} · ${p.vehicles} vehicle${p.vehicles === 1 ? '' : 's'}</div>
+    <div class="vp-dim">${tfl}</div></div>`;
+}
+
+function wireInteractions(map: MaplibreMap, layerId: string): void {
+  const detail = new Popup({ closeButton: true, closeOnClick: true, offset: 12, maxWidth: '320px' });
+  map.on('click', layerId, (e: MapLayerMouseEvent) => {
+    const p = e.features?.[0]?.properties as DiversionProps | undefined;
+    if (!p) return;
+    detail.setLngLat(e.lngLat).setHTML(popupHtml(p)).addTo(map);
+  });
+  map.on('mouseenter', layerId, () => {
+    map.getCanvas().style.cursor = 'pointer';
+  });
+  map.on('mouseleave', layerId, () => {
+    map.getCanvas().style.cursor = '';
+  });
+}
+
+/** ON by default, mirroring the legend row (no startOff). */
+let overlayOn = true;
+/** Set by startDiversions so the toggle can force an immediate refresh. */
+let refresh: (() => void) | null = null;
+
+/** Legend toggle handler: visibility flip + poll gate. */
+export function setDiversionsVisible(map: MaplibreMap, visible: boolean): void {
+  overlayOn = visible;
+  for (const id of DIVERSIONS_LAYER_IDS) {
+    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', visible ? 'visible' : 'none');
+  }
+  if (visible) refresh?.();
+}
+
+export async function startDiversions(map: MaplibreMap): Promise<void> {
+  map.addSource(SOURCE_ID, {
+    type: 'geojson',
+    data: { type: 'FeatureCollection', features: [] },
+  });
+  // Same anchor as roadworks: stations-circle sits above the transit lines
+  // (and the coverage glow beneath them) but below every vehicle layer, so
+  // inserting under it lands exactly between the static network and the dots.
+  map.addLayer(
+    {
+      id: DIVERSIONS_SEGMENTS_LAYER_ID,
+      type: 'line',
+      source: SOURCE_ID,
+      filter: ['==', ['geometry-type'], 'LineString'],
+      layout: { 'line-cap': 'round', 'line-join': 'round' },
+      paint: {
+        'line-color': STATUS_COLOR,
+        'line-opacity': STATUS_OPACITY,
+        'line-width': ['interpolate', ['linear'], ['zoom'], 9, 2, 13, 4, 16, 6],
+      },
+    },
+    below(map, 'stations-circle'),
+  );
+  map.addLayer(
+    {
+      id: DIVERSIONS_DOTS_LAYER_ID,
+      type: 'circle',
+      source: SOURCE_ID,
+      filter: ['==', ['geometry-type'], 'Point'],
+      paint: {
+        'circle-radius': ['interpolate', ['linear'], ['zoom'], 9, 3, 15, 6],
+        'circle-color': STATUS_COLOR,
+        'circle-opacity': STATUS_OPACITY,
+        'circle-stroke-color': '#0a0a0a',
+        'circle-stroke-width': 1,
+      },
+    },
+    below(map, 'stations-circle'),
+  );
+
+  async function poll(): Promise<void> {
+    if (!overlayOn) return;
+    try {
+      const res = await fetch(DIVERSIONS_URL);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const body = (await res.json()) as DiversionsResponse;
+      // A 200 from an intermediary (error page, captive portal) must not reach
+      // setData; empty `events` is fine and clears the layer.
+      if (!Array.isArray(body?.events)) throw new Error('unexpected diversions payload shape');
+      const src = map.getSource(SOURCE_ID);
+      if (src && 'setData' in src) {
+        (src as GeoJSONSource).setData({
+          type: 'FeatureCollection',
+          features: toFeatures(body.events),
+        });
+      }
+    } catch (error) {
+      // Keep the last picture; the next poll retries.
+      console.warn('[diversions]', error);
+    }
+  }
+  refresh = () => void poll();
+
+  wireInteractions(map, DIVERSIONS_SEGMENTS_LAYER_ID);
+  wireInteractions(map, DIVERSIONS_DOTS_LAYER_ID);
+
+  await poll();
+  registerPoll(() => void poll(), POLL_INTERVAL_MS);
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -32,6 +32,7 @@ import { startRainRadar, RAIN_RADAR_LAYER_ID } from './layers/rain-radar';
 import { startBikeStations, BIKE_STATIONS_LAYER_ID } from './layers/bike-stations';
 import { startSimulatedTrains, SIMULATED_TRAINS_LAYER_ID } from './layers/simulated-trains';
 import { startBusCoverage, setBusCoverageVisible, BUS_COVERAGE_LAYER_ID } from './layers/coverage';
+import { startDiversions, setDiversionsVisible, DIVERSIONS_LAYER_IDS } from './layers/diversions';
 import { hasLayer, loadCapabilities } from './region';
 
 const TOAST_DISMISS_MS = 4000;
@@ -464,6 +465,19 @@ async function addTransitOverlays(target: maplibregl.Map): Promise<void> {
         // Custom handler because the first toggle-on also triggers the lazy
         // one-time artifact fetch; afterwards it is a plain visibility flip.
         onToggle: (visible: boolean) => setBusCoverageVisible(target, visible),
+      },
+    },
+    {
+      name: 'busDiversions',
+      row: 11,
+      start: () => startDiversions(target),
+      overlay: {
+        // Default ON (no startOff): a live diversion is exactly the kind of
+        // thing the map exists to surface. The custom handler gates the 90 s
+        // poll on the toggle, so hiding it also stops the fetches.
+        label: 'Diversions',
+        layerIds: DIVERSIONS_LAYER_IDS,
+        onToggle: (visible: boolean) => setDiversionsVisible(target, visible),
       },
     },
   ];

--- a/frontend/src/region.ts
+++ b/frontend/src/region.ts
@@ -52,6 +52,7 @@ const LONDON_FALLBACK: Capabilities = {
     bikePoints: true,
     buses: true,
     busCoverage: true,
+    busDiversions: true,
     nationalRail: true,
     bikeStations: true,
     vessels: true,


### PR DESCRIPTION
## Summary

A default-on **Diversions** overlay showing where buses are *actually* diverting right now, derived purely from live GPS vs learned route geometry:

- **Red** segments: ≥2 route-directions bypass the same stretch → the road has a problem
- **Amber**: one direction of one route diverts while the road otherwise flows (softer wording — a live user saw "SL8 diverting" while inbound SL8s ran normally; amber + "Some buses diverting · other routes and directions running normally" resolves that ambiguity)
- Popup: destination-signed routes ("SL8 → Uxbridge"), start time (dated when >24h), vehicle count, TfL roadworks match — or "no matching record", which often means an incident the official feed hasn't recorded

## How it works

Rides the existing BODS poll (like the trace writer): each fix projects onto its route's learned polyline (grid-accelerated arc-length index, ~800k fixes/s measured). An online state machine flags sustained excursions that **leave and rejoin** the route travelling forward — the rejoin requirement kills garage pull-ins/outs, the dominant false positive in the offline audit. Ported guards from the 7-day prototype: direction-mislabel reprojection, endpoint clamping, gap resets, dwell-fraction confidence, per-route shape-reliability gate (suspends untrustworthy learned geometry until the nightly re-learn repairs it), site-keyed clustering.

**Self-resolving lifecycle**: ≥2 vehicles traversing the bypassed bracket on-route = the buses announce the road reopened → event greens then drops; stale after 90 min of silence; longRunning flag past 24 h. Day logs under `diversions/` (exported + archived). Fresh-volume safe: detector + capability flag start when learned routes appear, no redeploy.

## Validation

- Offline prototype over 7 archived days (54M fixes, 87 s): adversarial audit **8/10 top events confirmed, 0 garage artifacts**; A23 Streatham Hill nightly closure captured 4 consecutive nights, TfL-matched @52-77 m
- **End-to-end replay** of the archived Aug 25 evening (1.45M fixes) through THIS implementation: the real A23 closure re-emerged (73 vehicles, 8 routes, TfL @77 m)
- Live soak on the dev machine caught the real SL8 partial diversion that shaped the amber tier

## Egress

`/api/diversions` is a few KB, max-age=60, polled every 90 s via the battery-saver lifecycle. Detection itself is in-process CPU (~600 projections per 15 s poll), zero network.

## Test plan

- [x] backend `tsc` + **124/124** (27 detector/state-machine tests incl. garage pull-in, dwell, gap, clamp, mislabel, site merge, recovery, hitchhiker attribution, severity tiers, shape gate; 10 projection-exactness tests; route + capabilities contract tests)
- [x] frontend `tsc` + 89/89 + `vite build`
- [x] Replay verification + live-data soak as above; screenshots user-approved