### PR TITLE
fix: credible-bracket guard + drop the centroid dot

### DIFF
--- a/backend/src/diversion-detector.test.ts
+++ b/backend/src/diversion-detector.test.ts
@@ -686,3 +686,23 @@ describe('credible-offset guard', () => {
     expect(completed[0]?.confidence).toBe('low');
   });
 });
+
+describe('credible-bracket guard', () => {
+  test('a kilometres-long bypassed stretch is LOW confidence even when clean', () => {
+    const ctx = makeCtx();
+    const fixes = warmupFixes();
+    let t = AFTER_WARMUP_T;
+    // clean 150 m lateral offset, but skips 5 km of route before rejoining
+    for (let i = 0; i < 40; i++) {
+      t += STEP_S;
+      fixes.push(fixAt(t, 1200 + i * 120, 150));
+    }
+    fixes.push(fixAt(t + STEP_S, 6200));
+    fixes.push(fixAt(t + 2 * STEP_S, 6320));
+
+    const { completed } = drive(fixes, ctx);
+
+    expect(completed).toHaveLength(1);
+    expect(completed[0]?.confidence).toBe('low');
+  });
+});

--- a/backend/src/diversion-detector.ts
+++ b/backend/src/diversion-detector.ts
@@ -75,6 +75,11 @@ const DWELL_SPEED_MS = 2;
 const DWELL_MOVING_FRAC_MIN = 0.3;
 /** Beyond this |d|, "diversion" is no longer the credible explanation. */
 const MAX_CREDIBLE_D_M = 1500;
+/** Beyond this bypassed-stretch length, likewise: a street closure diverts
+ * you around hundreds of metres, occasionally 2-3 km — never 10+. Live case:
+ * coach/mismatched-shape vehicles leaving near a route's start and rejoining
+ * near its end painted 11-15 km washes across half of north-west London. */
+const MAX_CREDIBLE_BRACKET_M = 4000;
 const MISLABEL_SAMPLE_N = 15;
 // memory bounds
 const EXC_FIX_CAP = 2000;
@@ -356,8 +361,14 @@ function finalizePending(pending: PendingExcursion, ctx: StepContext): Completed
   // hitchhiked their name onto a genuine 56/106 event). LOW keeps it logged
   // without letting it name routes or draw segments.
   const credibleD = exc.maxD <= MAX_CREDIBLE_D_M;
+  // guard (f): the bypassed stretch itself must be street-closure sized —
+  // laterally credible but kilometres-long brackets are shape/service
+  // mismatch, not a diversion.
+  const credibleBracket =
+    Math.abs(Math.max(exc.sExit, sRejoin) - Math.min(exc.sExit, sRejoin)) <=
+    MAX_CREDIBLE_BRACKET_M;
   const confidence: Confidence =
-    movingFrac >= DWELL_MOVING_FRAC_MIN && credibleD ? 'high' : 'low';
+    movingFrac >= DWELL_MOVING_FRAC_MIN && credibleD && credibleBracket ? 'high' : 'low';
   if (confidence === 'high') c.completedHigh += 1;
   else c.completedLow += 1;
 

--- a/frontend/src/layers/diversions.ts
+++ b/frontend/src/layers/diversions.ts
@@ -1,6 +1,6 @@
 // Live bus-diversion events from the detector (/api/diversions). Each event's
 // bypassed learned-polyline slices draw as a translucent highlighter band
-// with a small dot at the centroid. The API returns only display-worthy
+// (no separate centroid marker — the wide band itself is the click target). The API returns only display-worthy
 // events — the frontend renders exactly what it is given, no filtering.
 //
 // Polling is gated on the overlay toggle (default OFF): the detector output
@@ -19,11 +19,7 @@ import { registerPoll } from '../util/lifecycle';
 import { below } from '../util/layer-order';
 
 export const DIVERSIONS_SEGMENTS_LAYER_ID = 'diversions-segments';
-export const DIVERSIONS_DOTS_LAYER_ID = 'diversions-dots';
-export const DIVERSIONS_LAYER_IDS = [
-  DIVERSIONS_SEGMENTS_LAYER_ID,
-  DIVERSIONS_DOTS_LAYER_ID,
-];
+export const DIVERSIONS_LAYER_IDS = [DIVERSIONS_SEGMENTS_LAYER_ID];
 
 const SOURCE_ID = 'diversions';
 const DIVERSIONS_URL = '/api/diversions';
@@ -135,13 +131,6 @@ function toFeatures(events: DiversionEvent[]): GeoJSON.Feature[] {
         geometry: { type: 'MultiLineString', coordinates: segments },
       });
     }
-    if (isLngLat(ev.centroid)) {
-      features.push({
-        type: 'Feature',
-        properties: props,
-        geometry: { type: 'Point', coordinates: [ev.centroid[0], ev.centroid[1]] },
-      });
-    }
     return features;
   });
 }
@@ -247,25 +236,6 @@ export async function startDiversions(map: MaplibreMap): Promise<void> {
     },
     below(map, 'stations-circle'),
   );
-  map.addLayer(
-    {
-      id: DIVERSIONS_DOTS_LAYER_ID,
-      type: 'circle',
-      source: SOURCE_ID,
-      filter: ['==', ['geometry-type'], 'Point'],
-      layout: { visibility: 'none' },
-      paint: {
-        'circle-radius': ['interpolate', ['linear'], ['zoom'], 9, 3, 15, 6],
-        'circle-color': STATUS_COLOR,
-        // The dot is the click anchor — it stays crisp while the band is a
-        // wash, so a faint highlight is still findable and tappable.
-        'circle-opacity': ['match', ['get', 'status'], 'recovering', 0.6, 'stale', 0.3, 0.9],
-        'circle-stroke-color': '#0a0a0a',
-        'circle-stroke-width': 1,
-      },
-    },
-    below(map, 'stations-circle'),
-  );
 
   async function poll(): Promise<void> {
     if (!overlayOn) return;
@@ -291,7 +261,6 @@ export async function startDiversions(map: MaplibreMap): Promise<void> {
   refresh = () => void poll();
 
   wireInteractions(map, DIVERSIONS_SEGMENTS_LAYER_ID);
-  wireInteractions(map, DIVERSIONS_DOTS_LAYER_ID);
 
   await poll();
   registerPoll(() => void poll(), POLL_INTERVAL_MS);


### PR DESCRIPTION
Two fixes from live-map use:

1. **Credible-bracket guard (f)** — the longest displayed events were 11-15 km washes (Southampton/Bideford/Crawley coaches, plus a 92/206 shape mismatch painting half of NW London red). They pass the lateral 1.5 km `maxD` cap but nothing bounded the bypassed-stretch LENGTH. A street closure diverts you around hundreds of metres, occasionally 2-3 km — never 10+. Brackets over **4 km** now drop the excursion to LOW confidence: logged, never drawn or attributed. (Many of these will also self-fix when the learner's repaired shapes land, but coaches never will — the detector-side cap is required regardless.)

2. **Centroid dot removed** (user call): redundant with the band; the wide blurred wash is itself the click target.

Backend **126/126** (new regression: clean 150 m lateral offset that skips 5 km → LOW), frontend 89/89, builds clean. Deploy restarts the detector, so existing giant events clear immediately and rebuild under the new guard.