### PR TITLE
feat: tapping locate also resets the map to north

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -282,6 +282,14 @@ async function bootstrap(): Promise<void> {
   map.addControl(geolocate, 'top-right');
   setupHeadingBeam(map, geolocate);
 
+  // With the compass button gone, a touch-rotated map had no way back to
+  // north — tapping locate now doubles as the reset. The heading beam tracks
+  // the animation via its map `rotate` listener, so the wedge stays true.
+  map
+    .getContainer()
+    .querySelector('.maplibregl-ctrl-geolocate')
+    ?.addEventListener('click', () => map.resetNorth());
+
   const isOutsideRegion = (lon: number, lat: number): boolean => {
     const [[west, south], [east, north]] = bounds;
     return lon < west || lon > east || lat < south || lat > north;


### PR DESCRIPTION
Tiny UX gap-fill: the compass button was removed with the zoom control (PR #18), so a touch-rotated map had no way back to north. Tapping the locate button now also calls `map.resetNorth()` — one listener next to the existing geolocate wiring. The heading beam stays correct through the animation (it already re-renders on map `rotate`).

`tsc` clean, 89/89 frontend tests.