### PR TITLE
fix: locate lands at north on phones (fly-to bearing race)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -276,15 +276,18 @@ async function bootstrap(): Promise<void> {
     showAccuracyCircle: true,
     showUserLocation: true,
     // Cap the fly-to zoom at ~14 (default is 15). maxBounds still clamps the
-    // camera so it can never pan outside the region.
-    fitBoundsOptions: { maxZoom: 14 },
+    // camera so it can never pan outside the region. bearing 0: with the
+    // compass button gone, locate doubles as the way back to north — and it
+    // must be HERE, not a click-time resetNorth(), because the success
+    // fly-to explicitly preserves the bearing it finds (a fast phone fix
+    // lands mid-reset-animation and locks the rotation back in).
+    fitBoundsOptions: { maxZoom: 14, bearing: 0 },
   });
   map.addControl(geolocate, 'top-right');
   setupHeadingBeam(map, geolocate);
 
-  // With the compass button gone, a touch-rotated map had no way back to
-  // north — tapping locate now doubles as the reset. The heading beam tracks
-  // the animation via its map `rotate` listener, so the wedge stays true.
+  // Failed/denied locates never fly, so the fitBoundsOptions bearing never
+  // applies — the click still straightens the map on its own.
   map
     .getContainer()
     .querySelector('.maplibregl-ctrl-geolocate')


### PR DESCRIPTION
User-reported on a real phone: locate wasn't resetting to north. Root cause is a race — with cached permission and warm GPS the fix arrives in a few hundred ms, and maplibre's geolocate fly-to **explicitly preserves the bearing it finds at that moment** (`bearing: this._map.getBearing()` in `_updateCamera`), cancelling the half-finished click-time `resetNorth()` and locking the rotation back in. Desktop's slower fixes let the reset finish first, hiding the bug.

Fix: `bearing: 0` in `fitBoundsOptions` — it overrides the preserve-bearing default, so the success fly-to itself lands at north in one smooth animation, raceless. The click-time reset stays for the failed/denied path (no fly-to runs there).

`tsc` clean, 89/89 frontend tests.