### PR TITLE
feat: searching a bus line draws that line's route on the map

### DIFF
--- a/frontend/src/layers/bus-route-shape.test.ts
+++ b/frontend/src/layers/bus-route-shape.test.ts
@@ -1,0 +1,634 @@
+// Unit tests for the route-shape layer: line → learned-file-key resolution, the
+// fallback fetch caps, the region test, the FeatureCollection built from
+// resolved geometry, and the progressive paint.
+//
+// ./buses is mocked wholesale — it value-imports maplibre-gl (Popup), and the
+// fleet/index/geometry accessors are exactly the seams these tests drive.
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import type { BusRouteKey } from './bus-route-shape';
+// Types only — vi.mock below replaces the module's runtime exports, not these.
+import type { BusRouteIndex } from './buses';
+
+const loadRouteGeometry = vi.fn<(fileKey: string) => Promise<[number, number][] | null>>();
+const forgetRouteGeometry = vi.fn<(fileKey: string) => void>();
+const activeBusRoutes = vi.fn<() => Iterable<{ line: string; routeFileKey: string }>>(() => []);
+const busRouteIndex = vi.fn<() => BusRouteIndex | null>(() => null);
+
+vi.mock('./buses', () => ({
+  BUSES_DOTS_LAYER_ID: 'buses-dots',
+  activeBusRoutes: () => activeBusRoutes(),
+  busRouteIndex: () => busRouteIndex(),
+  forgetRouteGeometry: (key: string) => forgetRouteGeometry(key),
+  loadRouteGeometry: (key: string) => loadRouteGeometry(key),
+  setBusRouteShapeHook: () => {},
+}));
+
+const {
+  BUS_ROUTE_SHAPE_LINE_LAYER_ID,
+  buildRouteShapeData,
+  capRouteKeys,
+  indexedKey,
+  insideFraction,
+  parseRouteStem,
+  resolveRouteKeys,
+  setBusRouteShapeLines,
+  startBusRouteShapes,
+} = await import('./bus-route-shape');
+
+/** The fold buses.ts builds at index load, rebuilt here so the fixture below
+ * is a plain list of stems. */
+function index(stems: readonly string[]): BusRouteIndex {
+  const set = new Set(stems);
+  const folded = new Map<string, string>();
+  for (const stem of set) {
+    const lower = stem.toLowerCase();
+    if (!folded.has(lower)) folded.set(lower, stem);
+  }
+  return { stems: set, folded };
+}
+
+/** Real stems from the learner output, plus its own run marker. ARHE_724 is
+ * inbound-only, as it genuinely is in data/bus-routes/learned. */
+const INDEX = index([
+  '.last-run',
+  'ARHE_20_inbound',
+  'ARHE_20_outbound',
+  'ARHE_724_inbound',
+  'ENSB_x80_inbound',
+  'GOCH_Go2_outbound',
+  'LGEN_HE_clockwise',
+  'METR_460_inbound',
+  'METR_460_outbound',
+  'NATX_032_inbound',
+  'NATX_460_inbound',
+  'NATX_460_outbound',
+  'TFLO_20_inbound',
+  'TFLO_24_inbound',
+  'TFLO_24_outbound',
+  'TFLO_32_inbound',
+  'TFLO_460_inbound',
+  'TFLO_460_outbound',
+  'TMSB_20_outbound',
+]);
+
+const live = (line: string, routeFileKey: string) => ({ line, routeFileKey });
+
+const key = (k: string, line: string, source: 'live' | 'index'): BusRouteKey => ({
+  key: k,
+  line,
+  source,
+});
+
+/** `inside` vertices in central London followed by `outside` ones in Oxford.
+ * region.ts is untouched here, so the active region is its London fallback. */
+function polyline(inside: number, outside: number): [number, number][] {
+  const poly: [number, number][] = [];
+  for (let i = 0; i < inside; i += 1) poly.push([-0.12 + i * 0.001, 51.5]);
+  for (let i = 0; i < outside; i += 1) poly.push([-1.25 + i * 0.001, 51.75]);
+  return poly;
+}
+
+describe('parseRouteStem', () => {
+  test('splits operator / line / direction', () => {
+    // Arrange + Act
+    const parsed = parseRouteStem('TFLO_24_outbound');
+
+    // Assert
+    expect(parsed).toEqual({ operator: 'TFLO', line: '24', direction: 'outbound' });
+  });
+
+  test('accepts directions beyond inbound/outbound', () => {
+    expect(parseRouteStem('LGEN_HE_clockwise')).toEqual({
+      operator: 'LGEN',
+      line: 'HE',
+      direction: 'clockwise',
+    });
+  });
+
+  test('joins the middle segments so a sanitized line survives', () => {
+    // Arrange — a BODS line containing a space sanitizes to an underscore
+    // Act
+    const parsed = parseRouteStem('TFLO_SL8_A_inbound');
+
+    // Assert
+    expect(parsed).toEqual({ operator: 'TFLO', line: 'SL8_A', direction: 'inbound' });
+  });
+
+  test('rejects the learner run marker the index also lists', () => {
+    // '.last-run'.split('_') is ['.last', 'run'] — without the guard this would
+    // parse as operator '.last' with an empty line.
+    expect(parseRouteStem('.last-run')).toBeNull();
+    expect(parseRouteStem('TFLO_24')).toBeNull();
+  });
+});
+
+describe('indexedKey', () => {
+  test('returns the index spelling for a key that differs only by case', () => {
+    // Arrange + Act + Assert — the file is served by exact name off a
+    // case-sensitive filesystem, so the tracker's own casing would 404
+    expect(indexedKey('GOCH_go2_outbound', INDEX)).toBe('GOCH_Go2_outbound');
+  });
+
+  test('returns an exactly-indexed key untouched', () => {
+    expect(indexedKey('TFLO_24_inbound', INDEX)).toBe('TFLO_24_inbound');
+  });
+
+  test('returns the key unchanged when nothing in the index folds onto it', () => {
+    expect(indexedKey('NOPE_999_inbound', INDEX)).toBe('NOPE_999_inbound');
+  });
+
+  test('returns the key unchanged before the index has loaded', () => {
+    expect(indexedKey('GOCH_go2_outbound', null)).toBe('GOCH_go2_outbound');
+  });
+});
+
+describe('resolveRouteKeys', () => {
+  test('uses the keys of the buses actually running the line', () => {
+    // Arrange — the index also lists TFLO_24_outbound, but only inbound is live
+    const fleet = [live('24', 'TFLO_24_inbound'), live('24', 'TFLO_24_inbound')];
+
+    // Act
+    const keys = resolveRouteKeys(new Set(['24']), fleet, INDEX);
+
+    // Assert — deduplicated, and the outbound stem is NOT pulled in
+    expect(keys).toEqual([{ key: 'TFLO_24_inbound', line: '24', source: 'live' }]);
+  });
+
+  test('falls back to every indexed stem when the line has no live bus', () => {
+    // Act
+    const keys = resolveRouteKeys(new Set(['24']), [], INDEX);
+
+    // Assert
+    expect(keys).toEqual([
+      { key: 'TFLO_24_inbound', line: '24', source: 'index' },
+      { key: 'TFLO_24_outbound', line: '24', source: 'index' },
+    ]);
+  });
+
+  test('falls through to the index when the live key is not a file that exists', () => {
+    // Arrange — ARHE runs 724 in both directions but the learner only ever
+    // wrote the inbound shape, so half the fleet names a guaranteed 404
+    const fleet = [live('724', 'ARHE_724_outbound'), live('724', 'ARHE_724_outbound')];
+
+    // Act
+    const keys = resolveRouteKeys(new Set(['724']), fleet, INDEX);
+
+    // Assert — the missing key is neither fetched nor allowed to suppress the
+    // fallback: selecting 724 draws the inbound shape rather than nothing
+    expect(keys).toEqual([{ key: 'ARHE_724_inbound', line: '724', source: 'index' }]);
+  });
+
+  test('a live key that does exist still suppresses the fallback for its line', () => {
+    // Arrange — both directions of 460 are indexed; only one is running
+    const fleet = [live('460', 'TFLO_460_inbound')];
+
+    // Act
+    const keys = resolveRouteKeys(new Set(['460']), fleet, INDEX);
+
+    // Assert
+    expect(keys).toEqual([{ key: 'TFLO_460_inbound', line: '460', source: 'live' }]);
+  });
+
+  test('resolves live and fallback lines independently in one selection', () => {
+    // Arrange — 24 is running, 460 is not
+    const fleet = [live('24', 'TFLO_24_outbound')];
+
+    // Act
+    const keys = resolveRouteKeys(new Set(['24', '460']), fleet, INDEX);
+
+    // Assert
+    expect(keys.filter((k) => k.line === '24')).toEqual([
+      { key: 'TFLO_24_outbound', line: '24', source: 'live' },
+    ]);
+    expect(keys.filter((k) => k.line === '460').map((k) => k.key)).toEqual([
+      'METR_460_inbound',
+      'METR_460_outbound',
+      'NATX_460_inbound',
+      'NATX_460_outbound',
+      'TFLO_460_inbound',
+      'TFLO_460_outbound',
+    ]);
+  });
+
+  test('a multi-operator line yields one fallback key per operator+direction', () => {
+    // Act
+    const keys = resolveRouteKeys(new Set(['20']), [], INDEX);
+
+    // Assert
+    expect(keys.map((k) => k.key)).toEqual([
+      'ARHE_20_inbound',
+      'ARHE_20_outbound',
+      'TFLO_20_inbound',
+      'TMSB_20_outbound',
+    ]);
+    expect(keys.every((k) => k.source === 'index')).toBe(true);
+  });
+
+  test('matches lines case-insensitively (typed GO2 vs BODS Go2)', () => {
+    // Arrange — the tracker keeps BODS casing, the chip may be uppercased
+    const fleet = [live('Go2', 'GOCH_go2_outbound')];
+
+    // Act
+    const keys = resolveRouteKeys(new Set(['GO2']), fleet, INDEX);
+
+    // Assert — the INDEX spelling wins, because the file is served by exact
+    // name off a case-sensitive filesystem
+    expect(keys).toEqual([{ key: 'GOCH_Go2_outbound', line: 'GO2', source: 'live' }]);
+  });
+
+  test('finds a lowercase indexed stem for an uppercased line', () => {
+    expect(resolveRouteKeys(new Set(['X80']), [], INDEX)).toEqual([
+      { key: 'ENSB_x80_inbound', line: 'X80', source: 'index' },
+    ]);
+  });
+
+  test('never conflates a zero-padded coach line with the London one', () => {
+    // Act
+    const padded = resolveRouteKeys(new Set(['032']), [], INDEX);
+    const plain = resolveRouteKeys(new Set(['32']), [], INDEX);
+
+    // Assert
+    expect(padded.map((k) => k.key)).toEqual(['NATX_032_inbound']);
+    expect(plain.map((k) => k.key)).toEqual(['TFLO_32_inbound']);
+  });
+
+  test('skips the run marker and unknown lines without throwing', () => {
+    expect(resolveRouteKeys(new Set(['N7']), [], INDEX)).toEqual([]);
+    expect(resolveRouteKeys(new Set([]), [], INDEX)).toEqual([]);
+  });
+
+  test('works before the index has loaded, on live keys alone', () => {
+    // Act — with no index there is nothing to check the key against, so it is
+    // taken at face value
+    const keys = resolveRouteKeys(new Set(['24']), [live('24', 'TFLO_24_inbound')], null);
+
+    // Assert
+    expect(keys).toEqual([{ key: 'TFLO_24_inbound', line: '24', source: 'live' }]);
+  });
+});
+
+describe('insideFraction', () => {
+  test('counts vertices within the region bounds', () => {
+    expect(insideFraction(polyline(8, 2))).toBeCloseTo(0.8, 6);
+    expect(insideFraction(polyline(0, 5))).toBe(0);
+    expect(insideFraction(polyline(5, 0))).toBe(1);
+  });
+
+  test('treats the bounds as inclusive at their corners', () => {
+    // Arrange — exactly [[west, south], [east, north]] of the London fallback
+    const corners: [number, number][] = [
+      [-0.65, 51.2],
+      [0.45, 51.77],
+    ];
+
+    // Act + Assert
+    expect(insideFraction(corners)).toBe(1);
+  });
+
+  test('is 0 for an empty polyline rather than NaN', () => {
+    expect(insideFraction([])).toBe(0);
+  });
+});
+
+describe('capRouteKeys', () => {
+  test('leaves live keys alone — they are already cached, not fetches', () => {
+    // Arrange — more live keys than either fallback cap allows
+    const keys = Array.from({ length: 20 }, (_, i) => key(`TFLO_24_${i}`, '24', 'live'));
+
+    // Act
+    const capped = capRouteKeys(keys);
+
+    // Assert
+    expect(capped).toHaveLength(20);
+  });
+
+  test('caps fallback stems per line at the corpus maximum', () => {
+    // Arrange — more stems than any real line carries
+    const keys = Array.from({ length: 10 }, (_, i) => key(`OP${i}_20_inbound`, '20', 'index'));
+
+    // Act
+    const capped = capRouteKeys(keys);
+
+    // Assert
+    expect(capped.map((k) => k.key)).toEqual([
+      'OP0_20_inbound',
+      'OP1_20_inbound',
+      'OP2_20_inbound',
+      'OP3_20_inbound',
+      'OP4_20_inbound',
+      'OP5_20_inbound',
+    ]);
+  });
+
+  test('keeps the local operator when the per-line cap truncates', () => {
+    // Arrange — the alphabetically-last operator is the London one, as TFLO is
+    // for the real 460 (METR_/NATX_/TFLO_ inbound+outbound)
+    const keys = [
+      ...Array.from({ length: 8 }, (_, i) => key(`AAA${i}_460_inbound`, '460', 'index')),
+      key('TFLO_460_inbound', '460', 'index'),
+      key('TFLO_460_outbound', '460', 'index'),
+    ];
+
+    // Act
+    const capped = capRouteKeys(keys);
+
+    // Assert — the out-of-town coaches must not crowd out the route the user
+    // actually typed
+    expect(capped.slice(0, 2).map((k) => k.key)).toEqual([
+      'TFLO_460_inbound',
+      'TFLO_460_outbound',
+    ]);
+    expect(capped).toHaveLength(6);
+  });
+
+  test('ranks the local operator first even when nothing is truncated', () => {
+    // Arrange — the real 460 index order
+    const keys = resolveRouteKeys(new Set(['460']), [], INDEX);
+
+    // Act
+    const capped = capRouteKeys(keys);
+
+    // Assert
+    expect(capped.map((k) => k.key)).toEqual([
+      'TFLO_460_inbound',
+      'TFLO_460_outbound',
+      'METR_460_inbound',
+      'METR_460_outbound',
+      'NATX_460_inbound',
+      'NATX_460_outbound',
+    ]);
+  });
+
+  test('gives every selected line a stem when the global ceiling binds', () => {
+    // Arrange — five lines × ten stems each; 6 per line would be 30
+    const lines = ['20', '21', '22', '242', '251'];
+    const keys = lines.flatMap((line) =>
+      Array.from({ length: 10 }, (_, i) => key(`OP${i}_${line}_inbound`, line, 'index')),
+    );
+
+    // Act
+    const capped = capRouteKeys(keys);
+
+    // Assert — the ceiling costs each line depth, never its whole shape: two
+    // full rounds of five, then the remaining two go to the first two lines
+    expect(capped).toHaveLength(12);
+    for (const line of lines) {
+      const forLine = capped.filter((k) => k.line === line).map((k) => k.key);
+      expect(forLine.length).toBeGreaterThanOrEqual(2);
+      expect(forLine.slice(0, 2)).toEqual([`OP0_${line}_inbound`, `OP1_${line}_inbound`]);
+    }
+  });
+
+  test('keeps the local operator for every line when the ceiling binds', () => {
+    // Arrange — six lines, so only two stems each fit under the ceiling
+    const lines = ['20', '21', '22', '242', '251', '460'];
+    const keys = lines.flatMap((line) => [
+      key(`AAAA_${line}_inbound`, line, 'index'),
+      key(`BBBB_${line}_inbound`, line, 'index'),
+      key(`TFLO_${line}_inbound`, line, 'index'),
+    ]);
+
+    // Act
+    const capped = capRouteKeys(keys);
+
+    // Assert
+    expect(capped).toHaveLength(12);
+    for (const line of lines) {
+      expect(capped.some((k) => k.key === `TFLO_${line}_inbound`)).toBe(true);
+    }
+  });
+
+  test('keeps every live key while capping the fallback ones beside it', () => {
+    // Arrange
+    const keys = [
+      ...Array.from({ length: 6 }, (_, i) => key(`TFLO_24_${i}`, '24', 'live')),
+      ...Array.from({ length: 10 }, (_, i) => key(`OP${i}_20_inbound`, '20', 'index')),
+    ];
+
+    // Act
+    const capped = capRouteKeys(keys);
+
+    // Assert — live first, then at most six fallbacks
+    expect(capped.filter((k) => k.source === 'live')).toHaveLength(6);
+    expect(capped.filter((k) => k.source === 'index')).toHaveLength(6);
+    expect(capped.slice(0, 6).every((k) => k.source === 'live')).toBe(true);
+  });
+});
+
+describe('buildRouteShapeData', () => {
+  test('an empty selection produces an empty FeatureCollection', () => {
+    // Act
+    const data = buildRouteShapeData([], []);
+
+    // Assert
+    expect(data).toEqual({ type: 'FeatureCollection', features: [] });
+  });
+
+  test('a selection with geometry produces one LineString per key', () => {
+    // Arrange
+    const keys = [key('TFLO_24_inbound', '24', 'live'), key('TFLO_24_outbound', '24', 'live')];
+    const geometries = [polyline(4, 0), polyline(6, 0)];
+
+    // Act
+    const data = buildRouteShapeData(keys, geometries);
+
+    // Assert
+    expect(data.features).toHaveLength(2);
+    expect(data.features[0].geometry).toEqual({ type: 'LineString', coordinates: geometries[0] });
+    // `line` is carried for a future hover/tap; nothing in the paint reads it.
+    expect(data.features.map((f) => f.properties)).toEqual([
+      { line: '24', key: 'TFLO_24_inbound' },
+      { line: '24', key: 'TFLO_24_outbound' },
+    ]);
+  });
+
+  test('drops an index-derived shape that mostly lies outside the region', () => {
+    // Arrange — an Oxford-Tube-shaped coach: 16% of its vertices inside London
+    const keys = [key('SCOX_TUBE_outbound', 'TUBE', 'index')];
+
+    // Act
+    const data = buildRouteShapeData(keys, [polyline(4, 21)]);
+
+    // Assert
+    expect(data.features).toEqual([]);
+  });
+
+  test('keeps an outer-London index shape that is mostly inside', () => {
+    // Arrange — 72% inside, like the real METR_460 stems
+    const keys = [key('METR_460_inbound', '460', 'index')];
+
+    // Act
+    const data = buildRouteShapeData(keys, [polyline(18, 7)]);
+
+    // Assert
+    expect(data.features).toHaveLength(1);
+  });
+
+  test('never region-drops a live shape — a running bus is proof of region', () => {
+    // Arrange — same geometry that was dropped as an index key above
+    const keys = [key('SCOX_TUBE_outbound', 'TUBE', 'live')];
+
+    // Act
+    const data = buildRouteShapeData(keys, [polyline(4, 21)]);
+
+    // Assert
+    expect(data.features).toHaveLength(1);
+  });
+
+  test('skips missing and degenerate geometry without shifting the others', () => {
+    // Arrange — key/geometry arrays stay index-aligned across the skips
+    const keys = [
+      key('TFLO_24_inbound', '24', 'live'),
+      key('TFLO_88_inbound', '88', 'live'),
+      key('TFLO_29_inbound', '29', 'live'),
+    ];
+    const geometries = [null, polyline(1, 0), polyline(3, 0)];
+
+    // Act
+    const data = buildRouteShapeData(keys, geometries);
+
+    // Assert — only the third key survives, and it keeps its own properties
+    expect(data.features).toHaveLength(1);
+    expect(data.features[0].properties).toEqual({ line: '29', key: 'TFLO_29_inbound' });
+  });
+});
+
+describe('setBusRouteShapeLines', () => {
+  /** Enough of a MapLibre map for the layer's own calls, recording setData. */
+  function fakeMap() {
+    const painted: GeoJSON.FeatureCollection[] = [];
+    const layers = new Set<string>();
+    const map = {
+      addSource: () => {},
+      addLayer: (layer: { id: string }) => layers.add(layer.id),
+      getLayer: (id: string) => (layers.has(id) ? { id } : undefined),
+      getSource: () => ({ setData: (data: GeoJSON.FeatureCollection) => painted.push(data) }),
+      setLayoutProperty: () => {},
+    };
+    return { map: map as unknown as Parameters<typeof startBusRouteShapes>[0], painted };
+  }
+
+  /** A deferred promise, so a test can hold one key's fetch open. */
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    const promise = new Promise<T>((r) => {
+      resolve = r;
+    });
+    return { promise, resolve };
+  }
+
+  const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activeBusRoutes.mockReturnValue([]);
+    busRouteIndex.mockReturnValue(INDEX);
+  });
+
+  test('paints a resolved key without waiting for a slow one', async () => {
+    // Arrange — line 24's two indexed stems; the outbound fetch never settles
+    const { map, painted } = fakeMap();
+    await startBusRouteShapes(map);
+    const stalled = deferred<[number, number][] | null>();
+    loadRouteGeometry.mockImplementation(async (fileKey) =>
+      fileKey === 'TFLO_24_outbound' ? stalled.promise : polyline(6, 0),
+    );
+
+    // Act
+    setBusRouteShapeLines(map, new Set(['24']));
+    await flush();
+
+    // Assert — the inbound shape is on screen while outbound is still in flight
+    const last = painted[painted.length - 1];
+    expect(last.features).toHaveLength(1);
+    expect(last.features[0].properties).toEqual({ line: '24', key: 'TFLO_24_inbound' });
+
+    // Act — and the slow one merges in when it finally lands
+    stalled.resolve(polyline(4, 0));
+    await flush();
+
+    // Assert
+    expect(painted[painted.length - 1].features).toHaveLength(2);
+  });
+
+  test('a superseded selection never paints, however late it resolves', async () => {
+    // Arrange
+    const { map, painted } = fakeMap();
+    await startBusRouteShapes(map);
+    const stalled = deferred<[number, number][] | null>();
+    loadRouteGeometry.mockImplementation(async (fileKey) =>
+      fileKey.startsWith('TFLO_24') ? stalled.promise : polyline(6, 0),
+    );
+
+    // Act — select 24, then switch to 32 before 24 resolves
+    setBusRouteShapeLines(map, new Set(['24']));
+    await flush();
+    setBusRouteShapeLines(map, new Set(['32']));
+    await flush();
+    const afterSwitch = painted.length;
+    stalled.resolve(polyline(9, 0));
+    await flush();
+
+    // Assert — the abandoned selection landed on nothing
+    expect(painted).toHaveLength(afterSwitch);
+    expect(painted[afterSwitch - 1].features[0].properties).toEqual({
+      line: '32',
+      key: 'TFLO_32_inbound',
+    });
+  });
+
+  test('releases index-derived geometry so it cannot evict the snapping cache', async () => {
+    // Arrange
+    const { map } = fakeMap();
+    await startBusRouteShapes(map);
+    activeBusRoutes.mockReturnValue([live('24', 'TFLO_24_inbound')]);
+    loadRouteGeometry.mockResolvedValue(polyline(6, 0));
+
+    // Act — 24 is live (its key stays cached for snapping), 460 is a fallback
+    setBusRouteShapeLines(map, new Set(['24', '460']));
+    await flush();
+
+    // Assert
+    const released = forgetRouteGeometry.mock.calls.map(([k]) => k);
+    expect(released).not.toContain('TFLO_24_inbound');
+    expect(new Set(released)).toEqual(
+      new Set([
+        'TFLO_460_inbound',
+        'TFLO_460_outbound',
+        'METR_460_inbound',
+        'METR_460_outbound',
+        'NATX_460_inbound',
+        'NATX_460_outbound',
+      ]),
+    );
+  });
+
+  test('clearing the filter empties the source and hides the layers', async () => {
+    // Arrange
+    const { map, painted } = fakeMap();
+    await startBusRouteShapes(map);
+    loadRouteGeometry.mockResolvedValue(polyline(6, 0));
+    setBusRouteShapeLines(map, new Set(['24']));
+    await flush();
+
+    // Act
+    setBusRouteShapeLines(map, null);
+    await flush();
+
+    // Assert
+    expect(painted[painted.length - 1]).toEqual({ type: 'FeatureCollection', features: [] });
+    expect(loadRouteGeometry).not.toHaveBeenCalledWith(expect.stringContaining('_32_'));
+  });
+
+  test('does nothing in a region that never built the layer', () => {
+    // Arrange — a map without the bus-route-shape layers
+    const { map, painted } = fakeMap();
+
+    // Act
+    setBusRouteShapeLines(map, new Set(['24']));
+
+    // Assert
+    expect(painted).toEqual([]);
+    expect(map.getLayer(BUS_ROUTE_SHAPE_LINE_LAYER_ID)).toBeUndefined();
+  });
+});

--- a/frontend/src/layers/bus-route-shape.ts
+++ b/frontend/src/layers/bus-route-shape.ts
@@ -1,0 +1,419 @@
+// Learned route shape for the filtered bus line(s). Selecting "24" in the Bus
+// Filter draws the polylines the backend learner built for that route — the
+// path the buses actually take, not a schematic — so the spotlighted dots have
+// a road to sit on. Clearing the filter removes it.
+//
+// Which shapes: live vehicles first. A selected line with buses running
+// contributes exactly THOSE buses' route keys, so what is drawn is what is
+// moving. A line with nothing live falls back to the learner's index, which is
+// keyed only by line NUMBER — and numbers are reused by intercity coaches, so
+// index-derived shapes must additionally sit inside the region (see
+// INSIDE_FRACTION_MIN). Resolution lives here (resolveRouteKeys) over the fleet
+// and index accessors buses.ts exposes; geometry comes from the SAME cache the
+// snapping path fills, so a line already on screen costs zero network.
+//
+// Both directions are drawn identically, with no offset: where they share a
+// road the opaque strokes coincide into one line, and where they genuinely
+// diverge (gyratories, terminus loops) two strands appear — the picture splits
+// exactly where the route does.
+//
+// Not a legend layer: it has no toggle and is driven purely by the filter via
+// the hook registered below.
+//
+// v1 limitation: shapes resolve on filter change only. A line that gains its
+// first live bus after being selected keeps its index-derived shape until the
+// filter is re-applied.
+
+import type { ExpressionSpecification, GeoJSONSource, Map as MaplibreMap } from 'maplibre-gl';
+import { below } from '../util/layer-order';
+import { isInsideRegion } from '../region';
+import {
+  BUSES_DOTS_LAYER_ID,
+  activeBusRoutes,
+  busRouteIndex,
+  forgetRouteGeometry,
+  loadRouteGeometry,
+  setBusRouteShapeHook,
+  type BusRouteIndex,
+  type LiveBusRoute,
+} from './buses';
+
+export const BUS_ROUTE_SHAPE_CASING_LAYER_ID = 'bus-route-shape-casing';
+export const BUS_ROUTE_SHAPE_LINE_LAYER_ID = 'bus-route-shape-line';
+const SOURCE_ID = 'bus-route-shape';
+
+/** Pure white — the only line channel this map has not spent. Central-line red
+ * (#E32017), Bus Flow ice (#0891b2/#a5f3fc) and the Diversions orange/red are
+ * all taken, and white is also the one achromatic choice that survives every
+ * CVD type on a basemap already carrying eleven tube brand hues. */
+const HIGHLIGHT_CORE_COLOR = '#FFFFFF';
+/** Near-black with a faint blue bias so it reads as shadow, not mud, against
+ * the basemap's #1f1f1f earth. */
+const HIGHLIGHT_CASING_COLOR = '#05070A';
+/** Opaque core: translucent white greys out against a dark basemap. */
+const HIGHLIGHT_CORE_OPACITY = 1;
+/** Semi-transparent casing so a crossing tube line is dimmed, never erased. */
+const HIGHLIGHT_CASING_OPACITY = 0.55;
+
+/** Same curve as the transit-line width ramps, so the highlight tracks the
+ * network it sits on rather than drifting relative to it with zoom. */
+const HIGHLIGHT_CORE_WIDTH: ExpressionSpecification = [
+  'interpolate',
+  ['exponential', 1.4],
+  ['zoom'],
+  9,
+  2.0,
+  12,
+  3.2,
+  14,
+  4.4,
+  16,
+  6.0,
+];
+const HIGHLIGHT_CASING_WIDTH: ExpressionSpecification = [
+  'interpolate',
+  ['exponential', 1.4],
+  ['zoom'],
+  9,
+  5.0,
+  12,
+  7.0,
+  14,
+  9.0,
+  16,
+  11.5,
+];
+/** Halo softness grows with the casing so it never hardens into a black bar. */
+const HIGHLIGHT_CASING_BLUR: ExpressionSpecification = [
+  'interpolate',
+  ['linear'],
+  ['zoom'],
+  9,
+  0.8,
+  16,
+  2.0,
+];
+
+/** Above the transit geometry and Bus Flow, below station dots/labels and both
+ * bus vehicle tiers — the white must win over the tube colours but must not
+ * slice through station names or hide the bullets it is drawn for. */
+const INSERT_BEFORE_LAYER_ID = 'stations-circle';
+
+/**
+ * An index-derived shape is dropped when fewer than this fraction of its
+ * vertices fall inside the region: line numbers are reused by intercity
+ * coaches, and at 0.5 exactly the out-of-town ones (Oxford Tube, Metrobus 400,
+ * Reading RA1) fail while every genuine outer-London route passes. A bbox
+ * intersection test would drop nothing — those coaches all touch London.
+ */
+const INSIDE_FRACTION_MIN = 0.5;
+/** Fallback stems per line — the measured corpus maximum: no line number
+ * carries more than six learned stems (460, 200, 20 and 21 each do, as three
+ * operators × two directions), so this truncates nothing today while still
+ * bounding a line the learner later splits further. */
+const MAX_FALLBACK_STEMS_PER_LINE = 6;
+/** …and a hard ceiling across the whole selection: the fallback path is the
+ * only branch that can request many uncached files at once. */
+const MAX_FALLBACK_FETCHES = 12;
+/**
+ * The local operator, ranked ahead of every other operator's stems within a
+ * line before the caps apply. TFLO is BODS's code for TfL-contracted London
+ * buses, and line numbers are shared with intercity coaches (460 is METR_,
+ * NATX_ and TFLO_): index order is alphabetical, so without this ranking a
+ * binding cap keeps the coaches and drops the route the user meant. A region
+ * with no TFLO stems keeps index order.
+ */
+const PRIMARY_OPERATOR = 'TFLO';
+
+const EMPTY: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
+
+/** Where a route key came from: an index-derived one has never been confirmed
+ * by a live vehicle, so it still has to pass the region test. */
+export type BusRouteKeySource = 'live' | 'index';
+
+export interface BusRouteKey {
+  /** Sanitized learned-file stem, e.g. "TFLO_24_outbound". */
+  readonly key: string;
+  /** Uppercased line the key was matched on. */
+  readonly line: string;
+  readonly source: BusRouteKeySource;
+}
+
+/**
+ * Split a learned-file stem into operator / line / direction: first segment is
+ * the operator, LAST is the direction, everything between is the line (BODS
+ * line names are sanitized, so a space or slash would add segments).
+ *
+ * Fewer than three segments is a reject, not a best effort — /api/bus-routes-index
+ * lists every file matching the served-name pattern, which includes the
+ * learner's own ".last-run.json" marker.
+ */
+export function parseRouteStem(
+  stem: string,
+): { operator: string; line: string; direction: string } | null {
+  const parts = stem.split('_');
+  if (parts.length < 3) return null;
+  const operator = parts[0];
+  const direction = parts[parts.length - 1];
+  const line = parts.slice(1, -1).join('_');
+  if (operator === '' || line === '' || direction === '') return null;
+  return { operator, line, direction };
+}
+
+/**
+ * The index's own casing for `key` when the two differ only by case. Learned
+ * files are served by exact name off a case-sensitive filesystem, and the
+ * learner has written at least one whose name is cased differently from the
+ * key inside it (GOCH_Go2_outbound.json ← "GOCH:go2:outbound"), so a live
+ * tracker's own key can 404 while the indexed spelling resolves.
+ */
+export function indexedKey(key: string, index: BusRouteIndex | null): string {
+  if (index === null || index.stems.has(key)) return key;
+  return index.folded.get(key.toLowerCase()) ?? key;
+}
+
+/**
+ * Learned-route file keys to draw for `lines`, live-vehicle first: a line with
+ * buses running contributes the distinct routeFileKeys of THOSE buses; a line
+ * with none falls back to every indexed stem carrying that line number. Line
+ * comparison is exact once uppercased — never numeric, never zero-stripped, as
+ * "032" (a coach) and "32" (the London bus) are different routes.
+ */
+export function resolveRouteKeys(
+  lines: ReadonlySet<string>,
+  live: Iterable<LiveBusRoute>,
+  index: BusRouteIndex | null,
+): readonly BusRouteKey[] {
+  if (lines.size === 0) return [];
+  const wanted = new Set<string>();
+  for (const line of lines) wanted.add(line.toUpperCase());
+
+  const out: BusRouteKey[] = [];
+  const seen = new Set<string>();
+  const hasLive = new Set<string>();
+
+  for (const tr of live) {
+    const line = tr.line.toUpperCase();
+    if (!wanted.has(line) || tr.routeFileKey === '') continue;
+    const key = indexedKey(tr.routeFileKey, index);
+    // A live tracker routinely names a file the learner never wrote: 52
+    // operator+line pairs are indexed for one direction only (ARHE has 724
+    // inbound and no outbound). Fetching that key is a guaranteed 404 — and
+    // counting the line as "has live" would additionally suppress the fallback
+    // that DOES hold its shape, leaving the selection drawing nothing at all.
+    if (index !== null && !index.stems.has(key)) continue;
+    hasLive.add(line);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push({ key, line, source: 'live' });
+  }
+
+  if (index !== null) {
+    for (const stem of index.stems) {
+      const parsed = parseRouteStem(stem);
+      if (parsed === null) continue;
+      const line = parsed.line.toUpperCase();
+      if (!wanted.has(line) || hasLive.has(line) || seen.has(stem)) continue;
+      seen.add(stem);
+      out.push({ key: stem, line, source: 'index' });
+    }
+  }
+  return out;
+}
+
+/**
+ * Monotonic selection counter. Every call to setBusRouteShapeLines bumps it and
+ * captures the value; a resolution whose capture no longer matches has been
+ * superseded and must not paint, or a slow fetch from an abandoned selection
+ * would land on top of the current one.
+ */
+let generation = 0;
+
+/** Fraction of `poly`'s vertices inside the active region; 0 when empty. */
+export function insideFraction(poly: readonly (readonly [number, number])[]): number {
+  if (poly.length === 0) return 0;
+  let inside = 0;
+  for (const [lon, lat] of poly) {
+    if (isInsideRegion(lon, lat)) inside += 1;
+  }
+  return inside / poly.length;
+}
+
+/**
+ * FeatureCollection for `keys` and their loaded geometry (index-aligned; null
+ * where the learned file was missing or malformed). Index-derived keys must
+ * also clear INSIDE_FRACTION_MIN — a live vehicle is proof enough of region on
+ * its own, and clipping a route the user is watching would be worse than
+ * drawing a coach.
+ */
+export function buildRouteShapeData(
+  keys: readonly BusRouteKey[],
+  geometries: readonly ([number, number][] | null)[],
+): GeoJSON.FeatureCollection {
+  const features: GeoJSON.Feature[] = [];
+  for (let i = 0; i < keys.length; i += 1) {
+    const poly = geometries[i];
+    if (!poly || poly.length < 2) continue;
+    if (keys[i].source === 'index' && insideFraction(poly) < INSIDE_FRACTION_MIN) continue;
+    features.push({
+      type: 'Feature',
+      geometry: { type: 'LineString', coordinates: poly },
+      // `line` is carried for a future hover/tap; styling reads neither it nor
+      // the direction (owner call: one white treatment for every selected line).
+      properties: { line: keys[i].line, key: keys[i].key },
+    });
+  }
+  return { type: 'FeatureCollection', features };
+}
+
+/** One line's fallback stems, PRIMARY_OPERATOR's first, otherwise index order.
+ * A stable partition rather than a sort: index order carries no meaning beyond
+ * operator grouping, so nothing else is worth reordering. */
+function rankFallbackStems(stems: readonly BusRouteKey[]): BusRouteKey[] {
+  const primary: BusRouteKey[] = [];
+  const rest: BusRouteKey[] = [];
+  for (const stem of stems) {
+    if (parseRouteStem(stem.key)?.operator === PRIMARY_OPERATOR) primary.push(stem);
+    else rest.push(stem);
+  }
+  return [...primary, ...rest];
+}
+
+/** Live keys uncapped (already cached by the snapping path); fallback keys
+ * capped per line and in total, since only they can trigger a fetch burst. */
+export function capRouteKeys(keys: readonly BusRouteKey[]): readonly BusRouteKey[] {
+  const byLine = new Map<string, BusRouteKey[]>();
+  for (const key of keys) {
+    if (key.source !== 'index') continue;
+    const stems = byLine.get(key.line);
+    if (stems === undefined) byLine.set(key.line, [key]);
+    else stems.push(key);
+  }
+  for (const [line, stems] of byLine) byLine.set(line, rankFallbackStems(stems));
+
+  // Round-robin, not first-come: every selected line gets its best stem before
+  // any line gets a second. Allocating in order would let a binding ceiling
+  // drop whole lines, and which lines survived would be decided by nothing more
+  // meaningful than alphabetical operator order.
+  const fallback: BusRouteKey[] = [];
+  for (
+    let rank = 0;
+    rank < MAX_FALLBACK_STEMS_PER_LINE && fallback.length < MAX_FALLBACK_FETCHES;
+    rank += 1
+  ) {
+    for (const stems of byLine.values()) {
+      if (fallback.length >= MAX_FALLBACK_FETCHES) break;
+      if (rank < stems.length) fallback.push(stems[rank]);
+    }
+  }
+  return [...keys.filter((key) => key.source === 'live'), ...fallback];
+}
+
+/**
+ * Adds the (empty, hidden) source + both layers, and registers the filter hook.
+ * No network traffic here — geometry arrives on the first non-empty selection.
+ */
+export function startBusRouteShapes(map: MaplibreMap): Promise<void> {
+  map.addSource(SOURCE_ID, { type: 'geojson', data: EMPTY });
+  // Regions without a drawn transit network lack the station anchor; the bus
+  // dots are the next-best "stay under the vehicles" target, and undefined
+  // (add on top) is the last resort.
+  const beforeId = below(map, INSERT_BEFORE_LAYER_ID) ?? below(map, BUSES_DOTS_LAYER_ID);
+  // Casing first: layers sharing a beforeId splice in at the same index, so the
+  // core added next ends up directly above it.
+  map.addLayer(
+    {
+      id: BUS_ROUTE_SHAPE_CASING_LAYER_ID,
+      type: 'line',
+      source: SOURCE_ID,
+      layout: { 'line-cap': 'round', 'line-join': 'round', visibility: 'none' },
+      paint: {
+        'line-color': HIGHLIGHT_CASING_COLOR,
+        'line-width': HIGHLIGHT_CASING_WIDTH,
+        'line-opacity': HIGHLIGHT_CASING_OPACITY,
+        'line-blur': HIGHLIGHT_CASING_BLUR,
+      },
+    },
+    beforeId,
+  );
+  map.addLayer(
+    {
+      id: BUS_ROUTE_SHAPE_LINE_LAYER_ID,
+      type: 'line',
+      source: SOURCE_ID,
+      layout: { 'line-cap': 'round', 'line-join': 'round', visibility: 'none' },
+      paint: {
+        'line-color': HIGHLIGHT_CORE_COLOR,
+        'line-width': HIGHLIGHT_CORE_WIDTH,
+        'line-opacity': HIGHLIGHT_CORE_OPACITY,
+        // Crisp: this layer's whole claim is "the route goes down THAT road".
+        'line-blur': 0,
+      },
+    },
+    beforeId,
+  );
+  setBusRouteShapeHook(setBusRouteShapeLines);
+  return Promise.resolve();
+}
+
+/**
+ * Draw the learned shapes for `lines`; null or an empty set clears them. Called
+ * only on a real filter change (see setBusLineFilter) — never per keystroke.
+ */
+export function setBusRouteShapeLines(map: MaplibreMap, lines: ReadonlySet<string> | null): void {
+  if (!map.getLayer(BUS_ROUTE_SHAPE_LINE_LAYER_ID)) return; // region without buses
+  generation += 1;
+  const gen = generation;
+  // Clear before any await: a superseded selection's shape must never linger on
+  // screen while the new one loads.
+  setData(map, EMPTY);
+  if (lines === null || lines.size === 0) {
+    setVisible(map, false);
+    return;
+  }
+  setVisible(map, true);
+  void resolveShapes(map, lines, gen);
+}
+
+async function resolveShapes(
+  map: MaplibreMap,
+  lines: ReadonlySet<string>,
+  gen: number,
+): Promise<void> {
+  try {
+    const keys = capRouteKeys(resolveRouteKeys(lines, activeBusRoutes(), busRouteIndex()));
+    if (keys.length === 0) return; // no learned route for this line — draw nothing
+    // Index-aligned with `keys`, filled in as fetches land.
+    const geometries: ([number, number][] | null)[] = keys.map(() => null);
+    await Promise.all(
+      keys.map(async (key, i) => {
+        geometries[i] = await loadRouteGeometry(key.key);
+        // The feature below owns its own coordinate array, so the cached route
+        // can go now: an index key exists precisely because the line has no
+        // live vehicles, so the snapping engine can never read it, and leaving
+        // it in would evict routes that on-screen buses are snapped to.
+        if (key.source === 'index') forgetRouteGeometry(key.key);
+        if (geometries[i] === null) return;
+        if (gen !== generation) return; // a newer selection has already won
+        // Repaint per arrival rather than once after the batch: one stalled key
+        // must not hide the shapes that were already in memory.
+        setData(map, buildRouteShapeData(keys, geometries));
+      }),
+    );
+  } catch (error) {
+    // Degrade to no shape: the filter itself (dot colouring) is unaffected, and
+    // the next filter change retries from scratch.
+    console.warn('[bus-route-shape]', error);
+  }
+}
+
+function setData(map: MaplibreMap, data: GeoJSON.FeatureCollection): void {
+  const src = map.getSource(SOURCE_ID);
+  if (src && 'setData' in src) (src as GeoJSONSource).setData(data);
+}
+
+function setVisible(map: MaplibreMap, visible: boolean): void {
+  for (const id of [BUS_ROUTE_SHAPE_CASING_LAYER_ID, BUS_ROUTE_SHAPE_LINE_LAYER_ID]) {
+    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', visible ? 'visible' : 'none');
+  }
+}

--- a/frontend/src/layers/bus-routes.test.ts
+++ b/frontend/src/layers/bus-routes.test.ts
@@ -1,0 +1,199 @@
+// Unit tests for the learned-route store buses.ts owns: the case-folded index,
+// the meter-space geometry inversion, and which fetch failures are allowed to
+// be remembered. Line → file-key resolution lives in bus-route-shape.ts and is
+// tested there. buses.ts value-imports maplibre-gl (Popup), so we stub that
+// module to keep the test in the fast node environment — same pattern as
+// ui/bus-filter.test.ts.
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('maplibre-gl', () => ({ Popup: class {} }));
+
+const { foldRouteIndex, loadRouteGeometry } = await import('./buses');
+
+describe('foldRouteIndex', () => {
+  test('keeps the served stems and a lowercased lookup beside them', () => {
+    // Arrange + Act
+    const index = foldRouteIndex(['TFLO_24_inbound', 'GOCH_Go2_outbound']);
+
+    // Assert
+    expect(index.stems.has('TFLO_24_inbound')).toBe(true);
+    expect(index.folded.get('goch_go2_outbound')).toBe('GOCH_Go2_outbound');
+  });
+
+  test('keeps the first spelling when two stems differ only by case', () => {
+    // Arrange + Act
+    const index = foldRouteIndex(['GOCH_Go2_outbound', 'GOCH_go2_outbound']);
+
+    // Assert — either is equally right; what matters is that it is stable
+    expect(index.folded.get('goch_go2_outbound')).toBe('GOCH_Go2_outbound');
+    expect(index.stems.size).toBe(2);
+  });
+});
+
+describe('loadRouteGeometry', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const okBody = {
+    poly: [
+      [-0.1, 51.5],
+      [-0.11, 51.51],
+    ],
+  };
+
+  /** A fetch whose Response carries `status`; `body` is what .json() yields. */
+  const stubFetch = (body: unknown, status = 200): ReturnType<typeof vi.fn> => {
+    const ok = status >= 200 && status < 300;
+    const fetchMock = vi.fn(async () => ({ ok, status, json: async () => body }));
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+
+  /** A fetch that rejects, as AbortSignal.timeout and an offline browser do. */
+  const stubFailingFetch = (error: Error): ReturnType<typeof vi.fn> => {
+    const fetchMock = vi.fn(async () => {
+      throw error;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  };
+
+  test('round-trips lon/lat through the meter-space cache', async () => {
+    // Arrange — sub-metre coordinates: the inverse must be exact enough that
+    // vertices land back on the same road, not merely nearby
+    const poly = [
+      [-0.143063, 51.495601],
+      [0.000123, 51.2],
+      [0.45, 51.770987],
+    ];
+    stubFetch({ poly, quality: { meanResidualM: 5.6 } });
+
+    // Act
+    const out = await loadRouteGeometry('TEST_roundtrip_outbound');
+
+    // Assert
+    expect(out).not.toBeNull();
+    expect(out).toHaveLength(3);
+    for (let i = 0; i < poly.length; i += 1) {
+      expect(out![i][0]).toBeCloseTo(poly[i][0], 9);
+      expect(out![i][1]).toBeCloseTo(poly[i][1], 9);
+    }
+  });
+
+  test('passes an abort signal so a stalled origin cannot hang the selection', async () => {
+    // Arrange
+    const fetchMock = stubFetch(okBody);
+
+    // Act
+    await loadRouteGeometry('TEST_signal_inbound');
+
+    // Assert
+    const init = fetchMock.mock.calls[0][1] as RequestInit | undefined;
+    expect(init?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('shares one fetch across concurrent callers for the same key', async () => {
+    // Arrange
+    const fetchMock = stubFetch(okBody);
+
+    // Act
+    const [a, b] = await Promise.all([
+      loadRouteGeometry('TEST_shared_inbound'),
+      loadRouteGeometry('TEST_shared_inbound'),
+    ]);
+    const c = await loadRouteGeometry('TEST_shared_inbound');
+
+    // Assert — the cache is shared with the bus-snapping path; a second
+    // request must never mean a second file off the origin
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(a).toEqual(b);
+    expect(c).toEqual(a);
+  });
+
+  test('negative-caches a 404 — the learner never wrote that route', async () => {
+    // Arrange
+    const fetchMock = stubFetch(null, 404);
+
+    // Act
+    const first = await loadRouteGeometry('TEST_missing_inbound');
+    const second = await loadRouteGeometry('TEST_missing_inbound');
+
+    // Assert
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries after a timeout instead of blanking the route for the session', async () => {
+    // Arrange — what AbortSignal.timeout throws
+    stubFailingFetch(new DOMException('The operation was aborted.', 'TimeoutError'));
+
+    // Act — the blip, then a later selection of the same line
+    const first = await loadRouteGeometry('TEST_timeout_inbound');
+    const retryMock = stubFetch(okBody);
+    const second = await loadRouteGeometry('TEST_timeout_inbound');
+
+    // Assert — one connectivity blip must not be permanent
+    expect(first).toBeNull();
+    expect(retryMock).toHaveBeenCalledTimes(1);
+    expect(second).toHaveLength(2);
+  });
+
+  test('retries after a network error', async () => {
+    // Arrange
+    stubFailingFetch(new TypeError('Failed to fetch'));
+
+    // Act
+    const first = await loadRouteGeometry('TEST_offline_inbound');
+    const retryMock = stubFetch(okBody);
+    const second = await loadRouteGeometry('TEST_offline_inbound');
+
+    // Assert
+    expect(first).toBeNull();
+    expect(retryMock).toHaveBeenCalledTimes(1);
+    expect(second).toHaveLength(2);
+  });
+
+  test('retries after a 5xx — the file may well exist', async () => {
+    // Arrange
+    stubFetch(null, 503);
+
+    // Act
+    const first = await loadRouteGeometry('TEST_5xx_inbound');
+    const retryMock = stubFetch(okBody);
+    const second = await loadRouteGeometry('TEST_5xx_inbound');
+
+    // Assert
+    expect(first).toBeNull();
+    expect(retryMock).toHaveBeenCalledTimes(1);
+    expect(second).toHaveLength(2);
+  });
+
+  test('negative-caches a malformed polyline rather than emitting NaN', async () => {
+    // Arrange
+    const fetchMock = stubFetch({ poly: [[-0.1, 51.5], ['nope', 51.51]] });
+
+    // Act
+    const first = await loadRouteGeometry('TEST_badvertex_inbound');
+    const second = await loadRouteGeometry('TEST_badvertex_inbound');
+
+    // Assert — a corrupt payload is as definitive as a 404
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('negative-caches a too-short polyline', async () => {
+    // Arrange — one vertex is not a line
+    const fetchMock = stubFetch({ poly: [[-0.1, 51.5]] });
+
+    // Act
+    await loadRouteGeometry('TEST_short_inbound');
+    const second = await loadRouteGeometry('TEST_short_inbound');
+
+    // Assert
+    expect(second).toBeNull();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/layers/buses.ts
+++ b/frontend/src/layers/buses.ts
@@ -288,6 +288,21 @@ let activeTrackers: ReadonlyMap<string, BusTracker> | null = null;
 let refreshBuses: (() => void) | null = null;
 
 /**
+ * The route-shape layer's update function, registered by
+ * layers/bus-route-shape.ts at start. A hook rather than an import because that
+ * module already imports the geometry accessors below — calling it directly
+ * would close an import cycle. Same shape as `refreshBuses`.
+ */
+let routeShapeHook: ((map: MaplibreMap, lines: ReadonlySet<string> | null) => void) | null = null;
+
+/** Registers the route-shape update called on every real line-filter change. */
+export function setBusRouteShapeHook(
+  hook: (map: MaplibreMap, lines: ReadonlySet<string> | null) => void,
+): void {
+  routeShapeHook = hook;
+}
+
+/**
  * Displayed [lng, lat] of a live bus by operator-qualified vehicle id
  * ("OPERATOR:VehicleRef"), or null when it isn't currently tracked.
  */
@@ -369,8 +384,15 @@ function applyBusDisplay(map: MaplibreMap): void {
 export function setBusLineFilter(map: MaplibreMap, lines: ReadonlySet<string> | null): void {
   // Stored uppercased: lineMatch upcases the feature side, so together the
   // whole comparison is case-insensitive regardless of how callers cased it.
-  filterLines = lines ? [...lines].map((line) => line.toUpperCase()) : [];
+  const next = lines ? [...lines].map((line) => line.toUpperCase()) : [];
+  const changed =
+    next.length !== filterLines.length || next.some((line) => !filterLines.includes(line));
+  filterLines = next;
   applyBusDisplay(map);
+  // Only on a REAL change: resolving shapes walks the whole fleet and can
+  // fetch, while apply() upstream re-pushes the entire selection on every chip
+  // add/remove, and the search input's `change` also fires on blur.
+  if (changed) routeShapeHook?.(map, lines);
 }
 
 /** Reflect the Buses overlay toggle (Lines tab). Combined with any active filter. */
@@ -404,11 +426,93 @@ export function countActiveBusesOnLines(lines: ReadonlySet<string>): number {
 }
 
 /** Sanitized keys with a learned route on the server; null until loaded. */
-let routeIndex: Set<string> | null = null;
-/** fileKey → geometry, or a load-state marker. */
-const routeCache = new Map<string, LearnedRoute | 'pending' | 'absent'>();
+let routeIndex: BusRouteIndex | null = null;
+/**
+ * fileKey → geometry, the in-flight fetch, or 'absent'. The promise IS the
+ * pending marker: a second caller awaits the same fetch instead of starting
+ * another, and the eviction loop below keeps its "settled vs in flight" test.
+ */
+const routeCache = new Map<string, LearnedRoute | Promise<LearnedRoute | null> | 'absent'>();
 /** Cache cap — oldest settled entry evicted first (trackers keep their own ref). */
 const ROUTE_CACHE_MAX = 600;
+/** A cold learned route can be a ~200 KB polyline over a phone connection. */
+const ROUTE_FETCH_TIMEOUT_MS = 10_000;
+/** The only response status that proves the learner never wrote this route. */
+const HTTP_NOT_FOUND = 404;
+
+/** The tracker fields route-key resolution reads — every BusTracker is one. */
+export interface LiveBusRoute {
+  readonly line: string;
+  readonly routeFileKey: string;
+}
+
+export interface BusRouteIndex {
+  /** Served stems, exactly as named on a case-sensitive filesystem. */
+  readonly stems: ReadonlySet<string>;
+  /** Lowercased stem → the index's own spelling of it. */
+  readonly folded: ReadonlyMap<string, string>;
+}
+
+/**
+ * Index `stems` with a case-folded lookup beside them, built once here because
+ * its consumer (indexedKey in bus-route-shape.ts) runs on the synchronous click
+ * path, once per matching tracker, against ~1430 stems. First spelling wins:
+ * two stems differing only by case both serve, so either is equally right.
+ */
+export function foldRouteIndex(stems: Iterable<string>): BusRouteIndex {
+  const set = new Set(stems);
+  const folded = new Map<string, string>();
+  for (const stem of set) {
+    const lower = stem.toLowerCase();
+    if (!folded.has(lower)) folded.set(lower, stem);
+  }
+  return { stems: set, folded };
+}
+
+/** The live fleet's line + learned-route key, for route-key resolution. */
+export function activeBusRoutes(): Iterable<LiveBusRoute> {
+  return activeTrackers?.values() ?? [];
+}
+
+/** The loaded learner index, or null while it is still in flight / absent. */
+export function busRouteIndex(): BusRouteIndex | null {
+  return routeIndex;
+}
+
+/**
+ * Learned polyline for `fileKey` as [lng, lat] pairs, or null when the file is
+ * missing or malformed. Awaits an in-flight fetch rather than starting a second
+ * one — this shares routeCache with the snapping path, so a selected line whose
+ * buses are already on screen costs no network at all.
+ *
+ * lon/lat come from inverting the SAME affine transform the cache stores
+ * (M_PER_DEG_LON/LAT above, exact to ~1e-11°). The returned array is built
+ * fresh per call and owned by the caller — nothing here retains it, so it
+ * outlives any later eviction of the cached route.
+ */
+export async function loadRouteGeometry(fileKey: string): Promise<[number, number][] | null> {
+  const route = await requestRoute(fileKey);
+  if (route === null) return null;
+  const { xs, ys } = route;
+  const poly: [number, number][] = new Array(xs.length);
+  for (let i = 0; i < xs.length; i += 1) {
+    poly[i] = [xs[i] / M_PER_DEG_LON, ys[i] / M_PER_DEG_LAT];
+  }
+  return poly;
+}
+
+/**
+ * Drop `fileKey`'s cached geometry — for index-derived route shapes, which the
+ * snapping engine can never reach and which would otherwise evict routes that
+ * on-screen buses ARE snapped to. Only settled geometry goes: an in-flight
+ * entry still has callers awaiting it, and 'absent' is the negative cache that
+ * stops a 404 repeating.
+ */
+export function forgetRouteGeometry(fileKey: string): void {
+  const cached = routeCache.get(fileKey);
+  if (cached === undefined || cached === 'absent' || cached instanceof Promise) return;
+  routeCache.delete(fileKey);
+}
 
 async function loadRouteIndex(): Promise<void> {
   try {
@@ -416,34 +520,53 @@ async function loadRouteIndex(): Promise<void> {
     if (!res.ok) return;
     const list: unknown = await res.json();
     if (!Array.isArray(list)) return;
-    routeIndex = new Set(list.filter((k): k is string => typeof k === 'string'));
+    routeIndex = foldRouteIndex(list.filter((k): k is string => typeof k === 'string'));
   } catch {
     // no learner output yet — every bus simply renders unsnapped
   }
 }
 
-/** Lazy-load one learned route (dev: Vite publicDir; prod: backend route). */
-function requestRoute(fileKey: string): void {
-  if (routeCache.has(fileKey)) return;
+/**
+ * Lazy-load one learned route (dev: Vite publicDir; prod: backend route).
+ * Resolves null when the file is missing or malformed; callers that only want
+ * the side effect can drop the promise.
+ */
+function requestRoute(fileKey: string): Promise<LearnedRoute | null> {
+  const cached = routeCache.get(fileKey);
+  if (cached !== undefined) {
+    if (cached === 'absent') return Promise.resolve(null);
+    return cached instanceof Promise ? cached : Promise.resolve(cached);
+  }
   if (routeCache.size >= ROUTE_CACHE_MAX) {
     for (const [key, value] of routeCache) {
-      if (value !== 'pending') {
+      if (!(value instanceof Promise)) {
         routeCache.delete(key);
         break;
       }
     }
   }
-  routeCache.set(fileKey, 'pending');
-  void (async () => {
+  const inFlight = (async (): Promise<LearnedRoute | null> => {
+    // Whether a failure below is proof this route will never load. A 404 or a
+    // corrupt payload is; a timeout, an offline blip or a 5xx is not, and
+    // negative-caching one of those kills the route for the life of the page.
+    let definitive = false;
     try {
-      const res = await fetch(`/bus-routes/learned/${fileKey}.json`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const res = await fetch(`/bus-routes/learned/${fileKey}.json`, {
+        signal: AbortSignal.timeout(ROUTE_FETCH_TIMEOUT_MS),
+      });
+      if (!res.ok) {
+        definitive = res.status === HTTP_NOT_FOUND;
+        throw new Error(`HTTP ${res.status}`);
+      }
       const body = (await res.json()) as {
         poly?: [number, number][];
         quality?: { meanResidualM?: number };
       };
       const poly = body.poly;
-      if (!Array.isArray(poly) || poly.length < 2) throw new Error('bad poly');
+      if (!Array.isArray(poly) || poly.length < 2) {
+        definitive = true;
+        throw new Error('bad poly');
+      }
       const xs = new Float64Array(poly.length);
       const ys = new Float64Array(poly.length);
       for (let i = 0; i < poly.length; i += 1) {
@@ -453,20 +576,34 @@ function requestRoute(fileKey: string): void {
         // the cumulative arc-length sum from that vertex on, and NaN defeats
         // the filter's gate comparisons (every NaN compare is false) — far
         // worse than simply rendering this route's buses unsnapped.
-        if (!Number.isFinite(lon) || !Number.isFinite(lat)) throw new Error('bad vertex');
+        if (!Number.isFinite(lon) || !Number.isFinite(lat)) {
+          definitive = true;
+          throw new Error('bad vertex');
+        }
         xs[i] = lon * M_PER_DEG_LON;
         ys[i] = lat * M_PER_DEG_LAT;
       }
-      routeCache.set(fileKey, {
+      const route: LearnedRoute = {
         xs,
         ys,
         cum: cumulativeLengthsM(xs, ys),
         measVar: measurementVariance(body.quality?.meanResidualM),
-      });
+      };
+      routeCache.set(fileKey, route);
+      return route;
     } catch {
-      routeCache.set(fileKey, 'absent');
+      // A missing or corrupt learned file is routine (the learner only writes
+      // routes it has seen enough journeys for): this bus renders unsnapped and
+      // the route-shape layer simply skips the key.
+      if (definitive) routeCache.set(fileKey, 'absent');
+      else routeCache.delete(fileKey); // transient — a later selection retries
+      return null;
     }
   })();
+  // Safe after the IIFE: its first statement awaits, so it cannot have settled
+  // and overwritten this entry yet.
+  routeCache.set(fileKey, inFlight);
+  return inFlight;
 }
 
 /** Nearest point on route segments [from,to) to (px,py), meter space. */
@@ -786,13 +923,13 @@ export async function startBuses(map: MaplibreMap): Promise<void> {
 
   /** Attach a learned route to the tracker once index + geometry are ready. */
   function resolveRoute(tr: BusTracker): void {
-    if (tr.route !== null || routeIndex === null || !routeIndex.has(tr.routeFileKey)) return;
+    if (tr.route !== null || routeIndex === null || !routeIndex.stems.has(tr.routeFileKey)) return;
     const cached = routeCache.get(tr.routeFileKey);
     if (cached === undefined) {
-      requestRoute(tr.routeFileKey);
+      void requestRoute(tr.routeFileKey);
       return;
     }
-    if (cached !== 'pending' && cached !== 'absent') tr.route = cached;
+    if (cached !== 'absent' && !(cached instanceof Promise)) tr.route = cached;
   }
 
   /** Scratch for pointAtArclen — per-tick path, keep it allocation-free. */

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -32,8 +32,9 @@ import { startRainRadar, RAIN_RADAR_LAYER_ID } from './layers/rain-radar';
 import { startBikeStations, BIKE_STATIONS_LAYER_ID } from './layers/bike-stations';
 import { startSimulatedTrains, SIMULATED_TRAINS_LAYER_ID } from './layers/simulated-trains';
 import { startBusCoverage, setBusCoverageVisible, BUS_COVERAGE_LAYER_ID } from './layers/coverage';
+import { startBusRouteShapes } from './layers/bus-route-shape';
 import { startDiversions, setDiversionsVisible, DIVERSIONS_LAYER_IDS } from './layers/diversions';
-import { hasLayer, loadCapabilities } from './region';
+import { hasLayer, isInsideRegion, loadCapabilities } from './region';
 
 const TOAST_DISMISS_MS = 4000;
 let activeToast: HTMLDivElement | null = null;
@@ -293,10 +294,7 @@ async function bootstrap(): Promise<void> {
     .querySelector('.maplibregl-ctrl-geolocate')
     ?.addEventListener('click', () => map.resetNorth());
 
-  const isOutsideRegion = (lon: number, lat: number): boolean => {
-    const [[west, south], [east, north]] = bounds;
-    return lon < west || lon > east || lat < south || lat > north;
-  };
+  const isOutsideRegion = (lon: number, lat: number): boolean => !isInsideRegion(lon, lat);
   const showOutsideRegionToast = (): void => {
     showToast(`You appear to be outside ${region.name} — showing the nearest edge.`);
   };
@@ -497,6 +495,18 @@ async function addTransitOverlays(target: maplibregl.Map): Promise<void> {
 
   const available = LAYERS.filter((layer) => hasLayer(layer.name));
   await Promise.allSettled(available.map((layer) => layer.start()));
+
+  // Filter-driven, not user-togglable, so deliberately NOT a LAYERS entry —
+  // every entry there mints a Lines-tab row. Started after the registry so the
+  // bus layers it anchors against already exist, and before the control panel
+  // below, whose bus filter applies its (empty) selection on construction.
+  if (hasLayer('buses')) {
+    try {
+      await startBusRouteShapes(target);
+    } catch (error) {
+      console.error('[bus-route-shape]', error);
+    }
+  }
 
   // Offer a toggle only for layers that actually exist. A capability being on
   // is not the same as a layer having been created: a start can decline (the

--- a/frontend/src/region.ts
+++ b/frontend/src/region.ts
@@ -90,6 +90,17 @@ export function hasLayer(name: string): boolean {
 }
 
 /**
+ * Whether (lon, lat) falls within the active region's maxBounds, corners
+ * inclusive. The one definition of "is this in the city we are rendering" —
+ * the geolocate toast and the route-shape layer's coach filter must not be
+ * able to disagree about where the region ends.
+ */
+export function isInsideRegion(lon: number, lat: number): boolean {
+  const [[west, south], [east, north]] = active.region.maxBounds;
+  return lon >= west && lon <= east && lat >= south && lat <= north;
+}
+
+/**
  * Fetches capabilities, falling back to London on any failure. Never rejects:
  * a backend hiccup must degrade the layer set, not blank the page — before
  * this existed the map rendered regardless of what the API did, and that


### PR DESCRIPTION
## What

Selecting bus lines in the 🚌 Filter tab now draws those lines' learned polylines on the map — a white highlight over a dark casing. Clearing the filter removes them. Nothing else changes: Bus Flow is deliberately untouched, and the layer has no legend row (it exists only while a filter is active).

Before: the filter recoloured vehicles but the map never showed *where the line runs*.

## How

**Key resolution is live-vehicle-first.** Buses currently running on a selected line already carry their `operator:line:direction` key, and their geometry is usually warm in the snapping cache — so a search normally costs **zero requests**. A dormant line falls back to `/api/bus-routes-index`, ordered TFLO-first (460 is also two coach routes; the London one must survive the cap) with out-of-region shapes dropped.

**A live vehicle whose key the learner never wrote does not count as coverage.** 52 operator+line pairs are learned in one direction only; counting them would both suppress the fallback and fire a request that can only 404 — the line would draw nothing. Caught in review, verified against the real corpus.

**One cache, one fetch path.** Geometry comes from the existing `routeCache` in `buses.ts`; the meter-space transform is affine, so lon/lat is recovered by inverting it rather than storing a second copy. `requestRoute`'s in-flight promise is now the pending marker (concurrent callers share one fetch), it carries a timeout, and only a definitive 404 or malformed body is negative-cached — a connectivity blip no longer kills a route for the page's lifetime. Index-derived shapes release their cache slot once drawn.

Shapes paint progressively as each key resolves, guarded by a generation counter so a superseded selection never lands.

## Verification

- `tsc --noEmit` clean · `vitest` **140 passed** · `vite build` OK
- Local dev with **live data** (`/api/buses` 641 KB, 1333 learned routes): searching 24 draws Camden → Mornington Crescent → Euston → Gower St → Tottenham Court Road, with the inbound/outbound split visible where 24 genuinely uses different streets; live 24 buses stay red on the line.
- Against the real 1333-file corpus: `724` (learned inbound-only) resolves `ARHE_724_inbound` both dormant and with a live bus on the unwritten outbound key; `460` keeps `TFLO_460_*` ahead of METR/NATX; 7 dormant lines → 12 keys with all 7 covered; `GO2` typed uppercase still resolves `GOCH_Go2_outbound`.

## Review

Three-lens review (types/async, repo rules & domain correctness, performance/egress) returned 14 findings — the HIGH plus every MEDIUM and LOW is fixed in this branch.

## Not in this PR

`/bus-routes/learned/*` is `cf-cache-status: DYNAMIC` today — Cloudflare never caches it, so every visitor's snapping fetches (~1,187 keys) hit the Paris origin from the London edge. That is a dashboard Cache Rule, not code; details in the PR discussion.