### PR TITLE
feat: flag the drawn route path as beta in the filter panel

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -203,6 +203,10 @@
       }
       .bf-chip-x:hover { color: #fff; }
       .bf-feedback { color: #9c9; font-size: 10px; font-variant-numeric: tabular-nums; }
+      .bf-note {
+        color: #b9975b; font-size: 10px; line-height: 1.4;
+        border-left: 2px solid #4a3f26; padding-left: 6px;
+      }
       .bf-clear {
         align-self: flex-start; background: none; border: 1px solid #333; color: #aaa;
         border-radius: 4px; padding: 3px 9px; cursor: pointer; font: 10px/1 system-ui, sans-serif;

--- a/frontend/src/ui/bus-filter.ts
+++ b/frontend/src/ui/bus-filter.ts
@@ -135,13 +135,20 @@ export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
   const feedback = document.createElement('div');
   feedback.className = 'bf-feedback';
 
+  // Shown only while a route path is drawn: the path is inferred from vehicle
+  // GPS, which drifts between tall buildings, so it can differ from the road
+  // the bus legally runs on.
+  const note = document.createElement('div');
+  note.className = 'bf-note';
+  note.textContent = 'Beta · route path learned from bus GPS, which drifts in cities.';
+
   const clear = document.createElement('button');
   clear.type = 'button';
   clear.className = 'bf-clear';
   clear.textContent = 'Clear';
 
   inputRow.append(input, add);
-  wrap.append(hint, inputRow, datalist, chips, feedback, clear);
+  wrap.append(hint, inputRow, datalist, chips, feedback, note, clear);
   container.append(wrap);
 
   /** Push the current selection down to the map and refresh chips + feedback. */
@@ -173,6 +180,9 @@ export function addBusFilter(container: HTMLElement, map: MaplibreMap): void {
   }
 
   function renderFeedback(): void {
+    // The caveat belongs to the drawn path, so it tracks the same condition
+    // the route-shape layer does: a non-empty selection.
+    note.hidden = selected.size === 0;
     if (selected.size === 0) {
       feedback.textContent = 'No filter — all buses shown normally.';
       clear.disabled = true;


### PR DESCRIPTION
Small follow-up to #31. While a route is selected, the Filter panel shows one muted amber line under the live-bus count:

> Beta · route path learned from bus GPS, which drifts in cities.

It appears on exactly the condition that draws the white path (a non-empty selection) and hides again on Clear — no separate state.

**Verified locally** (real data, headless Chrome): `no selection → hidden`, `route 24 selected → note shown`, `after Clear → hidden`. `tsc --noEmit` clean, 140 tests pass, build OK.

No DOM test: the frontend suite runs in the node environment with no jsdom/happy-dom installed, and adding one for a text note isn't worth a new dependency — the toggle is verified in a real browser instead.