### PR TITLE
perf: expose memory on /health and rebuild coverage daily, not 4x a day

### DIFF
--- a/backend/src/coverage-writer.test.ts
+++ b/backend/src/coverage-writer.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   assignBucket,
   buildCoverageArtifact,
@@ -6,6 +9,7 @@ import {
   quantizePolyline,
   selectWindowDays,
   simplifyPolyline,
+  olderThanOneCycle,
   type LonLat,
 } from './coverage-writer';
 
@@ -412,5 +416,37 @@ describe('buildCoverageArtifact (corridor merge)', () => {
     for (const value of coords) {
       expect(value).toBe(Number(value.toFixed(4)));
     }
+  });
+});
+
+describe('olderThanOneCycle', () => {
+  const CYCLE_MS = 24 * 60 * 60_000;
+
+  test('a missing artifact always triggers a build', async () => {
+    await expect(olderThanOneCycle('/nonexistent/coverage/latest.json', Date.now())).resolves.toBe(
+      true,
+    );
+  });
+
+  test('a just-written artifact does not', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'coverage-age-'));
+    const path = join(dir, 'latest.json');
+    await writeFile(path, '{}');
+
+    await expect(olderThanOneCycle(path, Date.now())).resolves.toBe(false);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test('an artifact a full cycle old does — this is what survives a restart', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'coverage-age-'));
+    const path = join(dir, 'latest.json');
+    await writeFile(path, '{}');
+
+    // Advance the clock rather than backdating the file: same comparison,
+    // no dependence on the filesystem's mtime resolution.
+    await expect(olderThanOneCycle(path, Date.now() + CYCLE_MS + 1_000)).resolves.toBe(true);
+
+    await rm(dir, { recursive: true, force: true });
   });
 });

--- a/backend/src/coverage-writer.ts
+++ b/backend/src/coverage-writer.ts
@@ -34,7 +34,11 @@ export const COVERAGE_WINDOW_DAYS = 7;
 /** Absolute bucket lower bounds in journeys/day (b = index 0..5). */
 export const COVERAGE_BUCKET_EDGES = [0, 10, 30, 75, 150, 300] as const;
 const COORD_DECIMALS = 4;
-const REGEN_INTERVAL_MS = 6 * 60 * 60_000;
+/** The inputs are completed daily rollups averaged over a rolling week, so the
+ * output cannot change more than once a day. Rebuilding four times a day only
+ * bought staleness that did not exist — and each build is the process's
+ * largest memory peak, which Railway bills for long after it subsides. */
+const REGEN_INTERVAL_MS = 24 * 60 * 60_000;
 const ROLLUP_FILE_RE = /^\d{4}-\d{2}-\d{2}\.json$/;
 /** Metres per degree of latitude (equirectangular; fine at route scale). */
 const M_PER_DEG = 111_320;
@@ -503,12 +507,16 @@ export async function buildCoverageArtifact(
   return { type: 'FeatureCollection', day, windowDays, features };
 }
 
-async function fileExists(path: string): Promise<boolean> {
+/** Missing, unreadable, or last built at least one cycle ago. The mtime check
+ * is what makes a 24 h cycle safe across restarts: the interval timer restarts
+ * with the process, so a deploy would otherwise push the next rebuild a full
+ * cycle further out and could leave a two-day-old artifact serving. */
+export async function olderThanOneCycle(path: string, nowMs: number): Promise<boolean> {
   try {
-    await stat(path);
-    return true;
+    const info = await stat(path);
+    return nowMs - info.mtimeMs >= REGEN_INTERVAL_MS;
   } catch {
-    return false;
+    return true;
   }
 }
 
@@ -614,9 +622,10 @@ export async function generateCoverage(
   );
 }
 
-/** Boot build only when the artifact is missing, then every 6 h regardless —
- * the recompute is pure local-disk work, so unconditional beats tracking
- * which rollup day it last saw. `baseDir` is the resolved bus data dir. */
+/** Boot build when the artifact is missing or a cycle old, then every
+ * REGEN_INTERVAL_MS regardless — the recompute is pure local-disk work, so
+ * unconditional beats tracking which rollup day it last saw. `baseDir` is the
+ * resolved bus data dir. */
 export function startCoverageWriter(
   baseDir: string,
   log: (msg: string) => void,
@@ -635,7 +644,7 @@ export function startCoverageWriter(
     }
   };
   void (async () => {
-    if (!(await fileExists(join(baseDir, 'coverage', 'latest.json')))) await run();
+    if (await olderThanOneCycle(join(baseDir, 'coverage', 'latest.json'), Date.now())) await run();
   })();
   const timer = setInterval(() => void run(), REGEN_INTERVAL_MS);
   timer.unref();

--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -1,0 +1,44 @@
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { registerHealthRoute } from './health';
+
+describe('health route', () => {
+  let app: FastifyInstance;
+
+  beforeEach(() => {
+    app = Fastify();
+    registerHealthRoute(app);
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  it('still answers ok, so existing uptime checks keep working', async () => {
+    const res = await app.inject({ method: 'GET', url: '/health' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe('ok');
+  });
+
+  it('reports memory in whole MB, with RSS at least as large as the heap in use', async () => {
+    const body = res(await app.inject({ method: 'GET', url: '/health' }));
+
+    expect(body.memory.rssMB).toBeGreaterThan(0);
+    for (const value of Object.values(body.memory)) expect(Number.isInteger(value)).toBe(true);
+    // heapUsed <= heapTotal is the only ordering that actually holds. RSS is
+    // NOT necessarily the largest: heapTotal counts committed pages, and on a
+    // host that compresses or pages them out RSS reads lower — measured 258 MB
+    // RSS against 476 MB heapUsed on this machine.
+    expect(body.memory.heapUsedMB).toBeLessThanOrEqual(body.memory.heapTotalMB);
+    expect(body.uptimeS).toBeGreaterThanOrEqual(0);
+  });
+});
+
+interface HealthBody {
+  status: string;
+  uptimeS: number;
+  memory: { rssMB: number; heapUsedMB: number; heapTotalMB: number; externalMB: number };
+}
+
+const res = (r: { json: () => unknown }): HealthBody => r.json() as HealthBody;

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,5 +1,23 @@
 import type { FastifyInstance } from 'fastify';
 
+const BYTES_PER_MB = 1024 * 1024;
+const mb = (bytes: number): number => Math.round(bytes / BYTES_PER_MB);
+
 export function registerHealthRoute(app: FastifyInstance): void {
-  app.get('/health', async () => ({ status: 'ok' }));
+  app.get('/health', async () => {
+    const usage = process.memoryUsage();
+    return {
+      status: 'ok',
+      uptimeS: Math.round(process.uptime()),
+      // Railway bills memory as an integral over time, so RSS is the number
+      // that costs money: it includes what V8 has grown into and not returned
+      // to the OS after a peak. heapUsed alone hides exactly that.
+      memory: {
+        rssMB: mb(usage.rss),
+        heapUsedMB: mb(usage.heapUsed),
+        heapTotalMB: mb(usage.heapTotal),
+        externalMB: mb(usage.external),
+      },
+    };
+  });
 }


### PR DESCRIPTION
## Why

The Railway bill has inverted since the last time it was measured:

| | Jul 24 – Aug 24 | current cycle (~8 days) |
|---|---|---|
| Egress | **137.64 GB — 72% of the bill** | **3.66 GB — 3.7% ($0.18)** |
| Memory | not the concern | **$4.32 — 86%** |

The poller pausing plus the Cloudflare cache rules solved egress. Memory is now essentially the whole bill: ~1.6 GB average, peaks to 5.33 GB, and a sawtooth that trends upward — the signature of V8 growing after a transient and not returning it.

## What

**`/health` reports memory.** Nothing in the server exposed `process.memoryUsage()`, so every claim about where the memory goes was speculation. It now returns `rssMB`, `heapUsedMB`, `heapTotalMB`, `externalMB` and `uptimeS`. RSS is the billed quantity.

**Coverage rebuilds daily instead of every 6 h.** Its inputs are completed daily rollups averaged over a rolling week, so the artifact cannot change more than once a day — three of every four builds recomputed a byte-identical file while producing the process's largest memory peak. Since the interval timer restarts with the process, the boot build changes from "only if missing" to "if missing **or a cycle old**", so a deploy can't push the next rebuild a full extra cycle out.

## Verification

`tsc --noEmit` clean, **140 backend tests pass** (5 new: 2 for the health payload, 3 for the staleness check). Hot-reloaded locally and confirmed the real payload:

```
{"status":"ok","uptimeS":38,"memory":{"rssMB":258,"heapUsedMB":476,"heapTotalMB":578,"externalMB":70}}
```

That reading also caught a bad assertion in my own first draft of the test: I had asserted `rss >= heapUsed`, which is **not** an invariant — `heapTotal` counts committed pages, and a host that compresses or pages them out reports lower RSS. The test now asserts `heapUsed <= heapTotal`, which does hold.

## Not in this PR

No heap cap (`--max-old-space-size`) yet — that is the next lever if RSS keeps ratcheting, but it should be chosen against measured numbers rather than guessed, which is what the `/health` change makes possible.