### PR TITLE
fix: actually expire vehicle state instead of retaining it for the day

### DIFF
--- a/backend/src/diversion-detector.test.ts
+++ b/backend/src/diversion-detector.test.ts
@@ -8,6 +8,7 @@ import {
   createVehicleState,
   isDiversionDetectorRunning,
   oppositeKey,
+  pruneVehicleStates,
   startDiversionDetector,
   stepVehicle,
   type FixInput,
@@ -841,5 +842,41 @@ describe('credible-bracket guard', () => {
 
     expect(completed).toHaveLength(1);
     expect(completed[0]?.confidence).toBe('low');
+  });
+});
+
+describe('pruneVehicleStates', () => {
+  const TTL_S = 30 * 60;
+
+  function stateAt(lastT: number) {
+    const s = createVehicleState();
+    s.lastT = lastT;
+    return s;
+  }
+
+  test('drops only vehicles silent for longer than the TTL', () => {
+    const now = T0 + 100_000;
+    const states = new Map([
+      ['fresh', stateAt(now - 60)],
+      ['borderline', stateAt(now - TTL_S + 30)],
+      ['finished-its-shift', stateAt(now - TTL_S - 1)],
+    ]);
+
+    const removed = pruneVehicleStates(states, now);
+
+    expect(removed).toBe(1);
+    expect([...states.keys()]).toEqual(['fresh', 'borderline']);
+  });
+
+  test('prunes a small map — the old size>=20000 throttle never fired at fleet scale', () => {
+    // London's live fleet peaks near 9,000, so a threshold of 20,000 meant the
+    // TTL never applied and stale states were retained indefinitely.
+    const now = T0 + 100_000;
+    const states = new Map(
+      Array.from({ length: 9_000 }, (_, i) => [`v${i}`, stateAt(now - TTL_S - 1)] as const),
+    );
+
+    expect(pruneVehicleStates(states, now)).toBe(9_000);
+    expect(states.size).toBe(0);
   });
 });

--- a/backend/src/diversion-detector.ts
+++ b/backend/src/diversion-detector.ts
@@ -162,6 +162,30 @@ export interface VehicleState {
   pendings: PendingExcursion[];
 }
 
+/**
+ * Forget vehicles that have gone quiet for longer than the TTL, and report how
+ * many were dropped.
+ *
+ * This used to be throttled by `states.size < 20_000`, a guard against
+ * scanning on every poll — but London's fleet peaks near 9,000, so the
+ * threshold was never reached and the TTL never applied. A bus that ended its
+ * shift mid-excursion kept its state forever, including up to EXC_FIX_CAP
+ * fixes accumulated for a rejoin that would never come. It now runs on the
+ * once-a-minute lifecycle tick, where a full scan of the live fleet is
+ * microseconds and the TTL is what bounds the map.
+ */
+export function pruneVehicleStates(states: Map<string, VehicleState>, nowSec: number): number {
+  const cutoff = nowSec - VEHICLE_STATE_TTL_S;
+  let removed = 0;
+  for (const [id, state] of states) {
+    if (state.lastT < cutoff) {
+      states.delete(id);
+      removed += 1;
+    }
+  }
+  return removed;
+}
+
 export function createVehicleState(): VehicleState {
   return {
     lastT: 0,
@@ -673,14 +697,6 @@ export function startDiversionDetector(
     });
   }
 
-  function pruneStates(nowSec: number): void {
-    if (states.size < 20_000) return;
-    const cutoff = nowSec - VEHICLE_STATE_TTL_S;
-    for (const [id, state] of states) {
-      if (state.lastT < cutoff) states.delete(id);
-    }
-  }
-
   function record(buses: readonly Bus[], nowMs: number): void {
     if (!ready) return;
     refreshThresholds(nowMs);
@@ -731,12 +747,13 @@ export function startDiversionDetector(
         transitions.push(...addExcursion(store, exc, nowSec));
       }
     }
-    pruneStates(nowSec);
     appendTransitions(transitions);
   }
 
   const lifecycleTimer = setInterval(() => {
-    appendTransitions(tickLifecycle(store, Math.floor(Date.now() / 1000)));
+    const nowSec = Math.floor(Date.now() / 1000);
+    pruneVehicleStates(states, nowSec);
+    appendTransitions(tickLifecycle(store, nowSec));
   }, LIFECYCLE_TICK_MS);
   lifecycleTimer.unref();
 


### PR DESCRIPTION
## The bug

The diversion detector keeps per-vehicle state — last position, distance along the route, and any excursion in progress — so it can recognise a bus leaving its route and rejoining it later. That state was meant to expire after `VEHICLE_STATE_TTL_S` (30 min) of silence:

```ts
function pruneStates(nowSec: number): void {
  if (states.size < 20_000) return;   // ← never true
  const cutoff = nowSec - VEHICLE_STATE_TTL_S;
  ...
}
```

The size check was a throttle against scanning on every 15-second poll. But **London's live fleet is 6,202 right now and peaks near 9,000**, so `states.size` never reaches 20,000, so the sweep never ran and the TTL never applied. Entries accumulated for the life of the process.

They are not small: a bus that ended its shift *mid-excursion* kept its `ExcursionAcc` holding up to `EXC_FIX_CAP` = 2,000 fixes, gathered for a rejoin that would never come, plus up to `PENDING_CAP` pending excursions with their own fix arrays.

## The fix

The sweep moves to the once-a-minute lifecycle tick — a full scan of the live fleet is microseconds at that cadence — and loses the size guard, so the TTL is what bounds the map. Extracted as `pruneVehicleStates(states, nowSec)` so the expiry rule is testable without standing up the detector.

## How it was found

`/health` began reporting memory in #34. Sampling a freshly started production process:

| | RSS | heapUsed |
|---|---|---|
| T+0 | 774 MB | 515 MB |
| T+10min | 925 MB | 587 MB |
| T+20min | 1021 MB | 677 MB |
| T+30min | 1184 MB | 814 MB |

heapUsed climbing steadily is live objects accumulating, not V8 sitting on freed pages — which pointed at retention rather than fragmentation.

## Verification

`tsc --noEmit` clean, **142 backend tests pass** (2 new: only past-TTL entries are dropped; a 9,000-entry map — fleet scale — is now swept, which the old throttle would have skipped entirely).

Whether this accounts for all of the climb is measurable rather than assumed: the same `/health` sampler is still running, so the post-deploy curve is directly comparable to the table above.