### PR TITLE
perf: report component sizes on /health

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -248,7 +248,6 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
   const bikePointsCache = new TtlCache<unknown>(BIKE_POINTS_TTL_MS);
   const tflBudget = new RateBudget(TFL_BUDGET_LIMIT, TFL_BUDGET_WINDOW_MS);
 
-  registerHealthRoute(app);
   registerCapabilitiesRoute(app, config, DATA_DIR, busDataDir);
   registerArrivalsRoute(app, { config, cache: arrivalsCache, budget: tflBudget });
   registerStopArrivalsRoute(app, { config, cache: stopArrivalsCache, budget: tflBudget });
@@ -302,6 +301,20 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
     nrSampler,
   });
   leaderboard.start();
+  // Registered here rather than at boot so the closure can see the leaderboard
+  // and the caches: /health reports what each structure is holding, and the
+  // caches are the ones keyed by stop and vehicle id.
+  registerHealthRoute(app, () => ({
+    ...(diversions?.sizes() ?? {}),
+    ...leaderboard.sizes(),
+    cacheArrivals: arrivalsCache.size,
+    cacheStopArrivals: stopArrivalsCache.size,
+    cacheVehicleArrivals: vehicleArrivalsCache.size,
+    cacheStopDetail: stopDetailCache.size,
+    cacheCrowding: crowdingCache.size,
+    cacheLiftDisruptions: liftDisruptionsCache.size,
+    cacheBikePoints: bikePointsCache.size,
+  }));
   app.addHook('onClose', () => leaderboard.stop());
   registerLeaderboardRoute(app, leaderboard);
   // Persistence diagnostic (no secrets — path + booleans only).

--- a/backend/src/cache.test.ts
+++ b/backend/src/cache.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+import { TtlCache } from './cache';
+
+const TTL_MS = 60_000;
+
+describe('TtlCache.size', () => {
+  test('counts distinct keys, not writes', () => {
+    const cache = new TtlCache<string>(TTL_MS);
+
+    cache.set('a', '1');
+    cache.set('a', '2');
+    cache.set('b', '1');
+
+    expect(cache.size).toBe(2);
+  });
+
+  test('expired entries still count — nothing is evicted, by design', () => {
+    // getStale() serves these when the upstream is down, so they are kept.
+    // That is why size only ever grows, and why it is worth reporting for
+    // caches keyed by stop or vehicle id.
+    const cache = new TtlCache<string>(TTL_MS);
+    const t0 = 1_000_000;
+
+    cache.set('stop-490000001', 'arrivals', t0);
+    const later = t0 + TTL_MS * 10;
+
+    expect(cache.getFresh('stop-490000001', later)).toBeUndefined();
+    expect(cache.getStale('stop-490000001')).toBe('arrivals');
+    expect(cache.size).toBe(1);
+  });
+});

--- a/backend/src/cache.ts
+++ b/backend/src/cache.ts
@@ -28,4 +28,13 @@ export class TtlCache<T> {
   set(key: string, value: T, now: number = Date.now()): void {
     this.entries.set(key, { value, storedAt: now });
   }
+
+  /** Entry count. Nothing is ever evicted here — expired entries are kept on
+   * purpose so `getStale` can degrade gracefully — so this only ever grows,
+   * once per distinct key the process has seen. Reported on /health because
+   * "how many keys has it seen" is exactly the question that matters for
+   * caches keyed by stop or vehicle id. */
+  get size(): number {
+    return this.entries.size;
+  }
 }

--- a/backend/src/diversion-detector.ts
+++ b/backend/src/diversion-detector.ts
@@ -546,6 +546,8 @@ export interface DiversionDetector {
   /** Ride-along on the BODS poll callback — synchronous CPU only, no IO. */
   record(buses: readonly Bus[], nowMs: number): void;
   snapshot(): Promise<DiversionsPayload>;
+  /** Live map sizes for /health — the retention question, not the cost one. */
+  sizes(): Record<string, number>;
   stop(): void;
 }
 
@@ -804,6 +806,22 @@ export function startDiversionDetector(
   return {
     record,
     snapshot,
+    sizes: () => {
+      let eventMembers = 0;
+      let eventPassages = 0;
+      for (const ev of store.events) {
+        eventMembers += ev.members.length;
+        eventPassages += ev.passages.size;
+      }
+      return {
+        vehicleStates: states.size,
+        routeIndexes: routes.size,
+        shapeGates: gates.size,
+        events: store.events.length,
+        eventMembers,
+        eventPassages,
+      };
+    },
     stop: () => {
       clearInterval(lifecycleTimer);
       clearInterval(rebuildTimer);

--- a/backend/src/leaderboard.ts
+++ b/backend/src/leaderboard.ts
@@ -285,6 +285,14 @@ export class LeaderboardTracker {
     this.filePath = persistPath('leaderboard.json');
   }
 
+  /** Live map sizes for /health. Unlike persistenceStatus() this touches no
+   * disk, so it is safe to poll. */
+  sizes(): Record<string, number> {
+    let vehicleTotals = 0;
+    for (const bucket of this.buckets.values()) vehicleTotals += bucket.size;
+    return { lbBuckets: this.buckets.size, lbVehicleTotals: vehicleTotals, lbLastFixes: this.last.size };
+  }
+
   /** Diagnostics for the persistence path (which file, does it exist, when saved). */
   persistenceStatus(): {
     persistDirSet: boolean;

--- a/backend/src/routes/diversions.test.ts
+++ b/backend/src/routes/diversions.test.ts
@@ -51,6 +51,7 @@ describe('diversions route', () => {
     const detector: DiversionDetector = {
       record: () => {},
       snapshot: () => Promise.resolve(payload),
+      sizes: () => ({}),
       stop: () => {},
     };
     app = Fastify();
@@ -77,6 +78,7 @@ describe('diversions route', () => {
     detector = {
       record: () => {},
       snapshot: () => Promise.resolve(payload),
+      sizes: () => ({}),
       stop: () => {},
     };
     const after = await app.inject({ method: 'GET', url: '/api/diversions' });

--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -10,6 +10,22 @@ describe('health route', () => {
     registerHealthRoute(app);
   });
 
+  it('reports component sizes when a reporter is supplied', async () => {
+    const counted = Fastify();
+    registerHealthRoute(counted, () => ({ vehicleStates: 6202, cacheVehicleArrivals: 41 }));
+
+    const body = res(await counted.inject({ method: 'GET', url: '/health' }));
+
+    expect(body.components).toEqual({ vehicleStates: 6202, cacheVehicleArrivals: 41 });
+    await counted.close();
+  });
+
+  it('reports an empty component set when none is supplied', async () => {
+    const body = res(await app.inject({ method: 'GET', url: '/health' }));
+
+    expect(body.components).toEqual({});
+  });
+
   afterEach(async () => {
     await app.close();
   });
@@ -38,6 +54,7 @@ describe('health route', () => {
 interface HealthBody {
   status: string;
   uptimeS: number;
+  components: Record<string, number>;
   memory: { rssMB: number; heapUsedMB: number; heapTotalMB: number; externalMB: number };
 }
 

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -3,12 +3,21 @@ import type { FastifyInstance } from 'fastify';
 const BYTES_PER_MB = 1024 * 1024;
 const mb = (bytes: number): number => Math.round(bytes / BYTES_PER_MB);
 
-export function registerHealthRoute(app: FastifyInstance): void {
+/**
+ * `components` reports live map/cache sizes. Memory alone says the process is
+ * growing; it cannot say which structure is doing the growing, which is the
+ * question that actually leads to a fix.
+ */
+export function registerHealthRoute(
+  app: FastifyInstance,
+  components: () => Record<string, number> = () => ({}),
+): void {
   app.get('/health', async () => {
     const usage = process.memoryUsage();
     return {
       status: 'ok',
       uptimeS: Math.round(process.uptime()),
+      components: components(),
       // Railway bills memory as an integral over time, so RSS is the number
       // that costs money: it includes what V8 has grown into and not returned
       // to the OS after a peak. heapUsed alone hides exactly that.


### PR DESCRIPTION
## Why

#34 made memory visible; #35 fixed a real retention bug it exposed. But the follow-up measurement was honest about its limits: RSS at 60 min came down only ~7.5%, against a confound (fleet had dropped from 6,202 to 3,990 buses overnight), and the trend was still upward. Memory alone can say the process is growing. It cannot say **what** is growing — so the next step would have been another guess.

## What

`/health` now returns a `components` object next to `memory`:

- **detector** — `vehicleStates`, `routeIndexes`, `shapeGates`, `events`, `eventMembers`, `eventPassages`
- **leaderboard** — `lbBuckets`, `lbVehicleTotals`, `lbLastFixes` (a new `sizes()` that touches no disk, unlike `persistenceStatus()`)
- **caches** — entry count for all seven `TtlCache` instances

`TtlCache` gains a `size` getter and the comment it deserved: **nothing is ever evicted** — expired entries are kept on purpose so `getStale` can serve them when TfL is down — so the count only ever grows, once per distinct key. `cacheStopArrivals` is keyed by stop id (~19,000 in London) and `cacheVehicleArrivals` by vehicle id (~9,000/day). That is the shape worth watching.

## First reading (local dev, real BODS data)

```
vehicleStates 6488 | routeIndexes 1588 | shapeGates 1277 | events 0
lbBuckets 11 | lbVehicleTotals 180164 | lbLastFixes 7203
cacheArrivals 1 | every other cache 0
```

The leaderboard holds **180,164** per-vehicle totals — an order of magnitude above anything else. `vehicleStates` sitting at ~fleet size is #35 behaving as intended. The caches read zero only because no one clicked a stop locally, which is exactly why this needs production numbers.

## Not in this PR

No eviction, no caps, no behaviour change at all. Measure first — that discipline is what turned the last round from "probably V8 ratcheting" into a specific, provable retention bug.

## Verification

`tsc --noEmit` clean, **146 backend tests pass** (4 new: two for the component payload, two for `TtlCache.size` including that expired entries still count).