### PR TITLE
perf: keep closed leaderboard periods as a per-mode top-200 summary

### DIFF
--- a/backend/src/leaderboard.test.ts
+++ b/backend/src/leaderboard.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from 'vitest';
+import {
+  compactBucket,
+  londonPeriodKeys,
+  openBucketKeys,
+  type VehicleTotal,
+} from './leaderboard';
+
+const NOW = Date.UTC(2026, 8, 2, 9, 0); // 2026-09-02, a Wednesday
+
+function bucket(entries: readonly VehicleTotal[]): Map<string, VehicleTotal> {
+  return new Map(entries.map((entry) => [entry.id, entry]));
+}
+
+const totals = (mode: VehicleTotal['mode'], count: number, from = 0): VehicleTotal[] =>
+  Array.from({ length: count }, (_, i) => ({
+    mode,
+    id: `${mode}-${i}`,
+    label: `${mode} ${i}`,
+    m: from + i, // higher index ⇒ further travelled
+  }));
+
+describe('openBucketKeys', () => {
+  test('names exactly the three periods accumulating right now', () => {
+    const keys = londonPeriodKeys(NOW);
+
+    expect(openBucketKeys(NOW)).toEqual(
+      new Set([`day:${keys.day}`, `week:${keys.week}`, `month:${keys.month}`]),
+    );
+  });
+
+  test('yesterday is not open — that is what makes it compactable', () => {
+    expect(openBucketKeys(NOW).has('day:2026-09-01')).toBe(false);
+  });
+});
+
+describe('compactBucket', () => {
+  test('keeps the top N of EVERY mode, not the top N overall', () => {
+    // Tube vehicles cover far more ground, so a global cut would erase ships.
+    const full = bucket([...totals('tube', 300, 100_000), ...totals('bus', 300, 10_000), ...totals('ship', 5, 10)]);
+
+    const kept = compactBucket(full, 200);
+
+    const byMode = (mode: VehicleTotal['mode']): number =>
+      [...kept.values()].filter((t) => t.mode === mode).length;
+    expect(byMode('tube')).toBe(200);
+    expect(byMode('bus')).toBe(200);
+    expect(byMode('ship')).toBe(5); // fewer than the cap: all survive
+    expect(kept.size).toBe(405);
+  });
+
+  test('keeps the furthest travelled and drops the tail', () => {
+    const full = bucket(totals('bus', 10));
+
+    const kept = compactBucket(full, 3);
+
+    expect([...kept.values()].map((t) => t.m).sort((a, b) => b - a)).toEqual([9, 8, 7]);
+    expect(kept.has('bus-0')).toBe(false);
+  });
+
+  test('a bucket already under the cap is returned intact', () => {
+    const full = bucket(totals('ship', 4));
+
+    expect(compactBucket(full, 200).size).toBe(4);
+  });
+});

--- a/backend/src/leaderboard.ts
+++ b/backend/src/leaderboard.ts
@@ -38,6 +38,12 @@ const LAST_SEEN_TTL_MS = 15 * 60_000;
 /** Buckets older than roughly two months are pruned from memory + disk. */
 const BUCKET_RETENTION_MS = 62 * 24 * 3_600_000;
 const TOP_N = 20;
+/** A closed period is frozen and can only ever be shown as a ranking, so it is
+ * kept as a per-mode top-N summary instead of every vehicle that moved that
+ * day. Full retention is what let 43 buckets no API can read hold 1.4M totals.
+ * Per MODE matters: a river boat covers a fraction of a tube train's distance,
+ * so a single global cut would erase ships from history entirely. */
+const CLOSED_BUCKET_TOP_N = 200;
 /** Full-bucket rank sorts are cached this long per mode (popup opens are cheap). */
 const RANK_CACHE_TTL_MS = 15_000;
 const EARTH_RADIUS_M = 6_371_000;
@@ -51,12 +57,13 @@ const RIVER_LINE_IDS = new Set(['rb1', 'rb4', 'rb6', 'woolwich-ferry']);
 export type LeaderboardMode = 'tube' | 'bus' | 'ship';
 export type LeaderboardPeriod = 'day' | 'week' | 'month';
 const PERIODS: readonly LeaderboardPeriod[] = ['day', 'week', 'month'];
+const MODES: readonly LeaderboardMode[] = ['tube', 'bus', 'ship'];
 
 /** Public API mode values → internal entry modes ("train" ranks tube/rail). */
 const API_MODES = { train: 'tube', bus: 'bus', ship: 'ship' } as const;
 export type LeaderboardApiMode = keyof typeof API_MODES;
 
-interface VehicleTotal {
+export interface VehicleTotal {
   mode: LeaderboardMode;
   id: string;
   label: string;
@@ -64,6 +71,28 @@ interface VehicleTotal {
   lineId?: string;
   /** cumulative metres in this bucket */
   m: number;
+}
+
+/** Bucket keys for the periods that are still accumulating right now. */
+export function openBucketKeys(now: number): Set<string> {
+  const keys = londonPeriodKeys(now);
+  return new Set(PERIODS.map((period) => `${period}:${keys[period]}`));
+}
+
+/** The bucket reduced to its strongest `topN` entries per mode. */
+export function compactBucket(
+  bucket: ReadonlyMap<string, VehicleTotal>,
+  topN: number,
+): Map<string, VehicleTotal> {
+  const kept = new Map<string, VehicleTotal>();
+  for (const mode of MODES) {
+    const ranked = [...bucket.values()]
+      .filter((total) => total.mode === mode)
+      .sort((a, b) => b.m - a.m)
+      .slice(0, topN);
+    for (const total of ranked) kept.set(total.id, total);
+  }
+  return kept;
 }
 
 interface LastFix {
@@ -523,7 +552,11 @@ export class LeaderboardTracker {
         if (bucket.size > 0) this.buckets.set(bucketKey, bucket);
       }
       this.pruneOldBuckets(Date.now());
-      this.deps.log(`leaderboard: loaded ${this.buckets.size} bucket(s) from ${this.filePath}`);
+      const dropped = this.compactClosedBuckets(Date.now());
+      this.deps.log(
+        `leaderboard: loaded ${this.buckets.size} bucket(s) from ${this.filePath}` +
+          (dropped > 0 ? `, summarised ${dropped} closed-period total(s) away` : ''),
+      );
     } catch (err) {
       this.deps.log(`leaderboard: persisted state unreadable, starting fresh: ${String(err)}`);
     }
@@ -532,6 +565,7 @@ export class LeaderboardTracker {
   private persist(): void {
     if (!this.dirty) return;
     this.pruneOldBuckets(Date.now());
+    this.compactClosedBuckets(Date.now());
     const state: PersistedState = { savedAt: Date.now(), buckets: {} };
     for (const [bucketKey, bucket] of this.buckets) {
       state.buckets[bucketKey] = [...bucket.values()];
@@ -545,6 +579,20 @@ export class LeaderboardTracker {
     } catch (err) {
       this.deps.log(`leaderboard persist failed: ${String(err)}`);
     }
+  }
+
+  /** Summarise every bucket whose period has ended. Open buckets are left
+   * whole: a vehicle ranked 500th at noon can still finish in the top 20. */
+  private compactClosedBuckets(now: number): number {
+    const open = openBucketKeys(now);
+    let dropped = 0;
+    for (const [bucketKey, bucket] of this.buckets) {
+      if (open.has(bucketKey) || bucket.size <= CLOSED_BUCKET_TOP_N) continue;
+      const kept = compactBucket(bucket, CLOSED_BUCKET_TOP_N);
+      dropped += bucket.size - kept.size;
+      this.buckets.set(bucketKey, kept);
+    }
+    return dropped;
   }
 
   private pruneOldBuckets(now: number): void {


### PR DESCRIPTION
## The measurement that found it

#36 added component counters to `/health`. The first production reading, **six seconds after boot, before a single bus poll**:

```
lbVehicleTotals 1496622 | lbBuckets 46 | routeIndexes 1830 | everything else 0
RSS 970MB  heapUsed 783MB
```

1.5M leaderboard totals ≈ 675 MB of that 783 MB heap. Thirty minutes later it had grown by 1,573 (+0.1%) — so this is not a leak, it is a **static baseline** that the process carries every minute of every day, and Railway bills memory as an integral over time.

## Why almost all of it is unreachable

`snapshot()` derives its bucket key from `londonPeriodKeys(now)`, and `/api/leaderboard` accepts only `period` and `mode` — **no date**. So of 46 buckets, 3 can be served and 43 cannot be reached by any code path, while still being loaded at boot, held in memory, and rewritten to disk every minute.

## The change

Closed periods are reduced to their strongest **200 entries per mode**, on load and before each persist.

- **Open buckets are untouched.** A vehicle ranked 500th at noon can still finish in the top 20, so truncating an accumulating bucket would corrupt the ranking.
- **Per mode, not overall.** `TOP_N` display is 20; keeping 200 leaves headroom for a future "past days" view. Cutting globally would erase ships — a river boat covers a fraction of a tube train's distance.

## Measured locally (real data, dev server)

| | before | after |
|---|---|---|
| `lbVehicleTotals` | 180,164 | **50,856** |
| `heapUsed` | 227 MB | **176 MB** |

The survivors are the three open buckets. On production the same reduction applies to a 1.5M-record set.

## Consequence worth stating plainly

**The persisted file follows memory.** Within a minute of deploy, `leaderboard.json` is rewritten with closed periods summarised, so past days keep their top 200 per mode instead of every vehicle that moved. That is the trade that was chosen deliberately — the alternative was dropping closed buckets from memory entirely and keeping the full file, which costs the same memory to load.

## Verification

`tsc --noEmit` clean, **151 backend tests pass** (6 new, covering: the open-bucket key set; that yesterday is not open; per-mode top-N rather than global; that the furthest-travelled survive and the tail is dropped; and that an under-cap bucket is returned intact).