### PR TITLE
fix: bound the response caches so they stop filling the heap

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -315,6 +315,15 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
     cacheCrowding: crowdingCache.size,
     cacheLiftDisruptions: liftDisruptionsCache.size,
     cacheBikePoints: bikePointsCache.size,
+    // Evictions on the caches keyed by an id space larger than any working
+    // set. Zero means the ceiling is never reached and costs nothing; a number
+    // that climbs steadily means it is too low and every eviction is a cache
+    // miss a viewer paid for. These are the caches whose unbounded growth
+    // filled the heap on 2026-09-04.
+    evictStopArrivals: stopArrivalsCache.evictions,
+    evictVehicleArrivals: vehicleArrivalsCache.evictions,
+    evictStopDetail: stopDetailCache.evictions,
+    evictCrowding: crowdingCache.evictions,
   }));
   app.addHook('onClose', () => leaderboard.stop());
   registerLeaderboardRoute(app, leaderboard);

--- a/backend/src/cache.test.ts
+++ b/backend/src/cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import { TtlCache } from './cache';
+import { DEFAULT_MAX_ENTRIES, TtlCache } from './cache';
 
 const TTL_MS = 60_000;
 
@@ -14,10 +14,9 @@ describe('TtlCache.size', () => {
     expect(cache.size).toBe(2);
   });
 
-  test('expired entries still count — nothing is evicted, by design', () => {
-    // getStale() serves these when the upstream is down, so they are kept.
-    // That is why size only ever grows, and why it is worth reporting for
-    // caches keyed by stop or vehicle id.
+  test('an expired entry is kept for getStale rather than dropped on read', () => {
+    // getStale() serves these when the upstream is down, so expiry alone never
+    // removes an entry; only the size ceiling does.
     const cache = new TtlCache<string>(TTL_MS);
     const t0 = 1_000_000;
 
@@ -27,5 +26,103 @@ describe('TtlCache.size', () => {
     expect(cache.getFresh('stop-490000001', later)).toBeUndefined();
     expect(cache.getStale('stop-490000001')).toBe('arrivals');
     expect(cache.size).toBe(1);
+  });
+});
+
+describe('TtlCache eviction', () => {
+  test('holds at the ceiling instead of growing without bound', () => {
+    // Arrange — a cache keyed the way /api/stop-arrivals is, asked for far
+    // more distinct ids than it may hold. Before the ceiling existed this is
+    // exactly what filled a 2 GB heap and killed the London service.
+    const cache = new TtlCache<string>(TTL_MS, 3);
+
+    // Act
+    for (let i = 0; i < 100; i += 1) cache.set(`stop-${i}`, `body-${i}`);
+
+    // Assert
+    expect(cache.size).toBe(3);
+    expect(cache.evictions).toBe(97);
+  });
+
+  test('evicts the least recently used, not the oldest written', () => {
+    // Arrange
+    const cache = new TtlCache<string>(TTL_MS, 3);
+    cache.set('a', '1');
+    cache.set('b', '2');
+    cache.set('c', '3');
+
+    // Act — reading 'a' makes it the most recent, so 'b' becomes the victim.
+    expect(cache.getFresh('a')).toBe('1');
+    cache.set('d', '4');
+
+    // Assert
+    expect(cache.getStale('b')).toBeUndefined();
+    expect(cache.getFresh('a')).toBe('1');
+    expect(cache.getFresh('c')).toBe('3');
+    expect(cache.getFresh('d')).toBe('4');
+  });
+
+  test('serving stale rescues a key from eviction', () => {
+    // An upstream outage must not cost the very entries the fallback leans on.
+    const cache = new TtlCache<string>(TTL_MS, 2);
+    const t0 = 1_000_000;
+    cache.set('a', '1', t0);
+    cache.set('b', '2', t0);
+
+    expect(cache.getStale('a')).toBe('1');
+    cache.set('c', '3', t0);
+
+    expect(cache.getStale('b')).toBeUndefined();
+    expect(cache.getStale('a')).toBe('1');
+  });
+
+  test('an expired entry does not earn a place at the back of the queue', () => {
+    // A miss on an expired key is not a use, so it stays first in line to go.
+    const cache = new TtlCache<string>(TTL_MS, 2);
+    const t0 = 1_000_000;
+    cache.set('stale', 'old', t0);
+    // Written two TTLs later, so at `now` below it is 1 ms old while 'stale'
+    // is long expired — the two must not share a fate.
+    const now = t0 + TTL_MS * 2 + 1;
+    cache.set('fresh', 'new', now - 1);
+
+    expect(cache.getFresh('stale', now)).toBeUndefined();
+    cache.set('newest', 'newer', now);
+
+    expect(cache.getStale('stale')).toBeUndefined();
+    expect(cache.getFresh('fresh', now)).toBe('new');
+  });
+
+  test('re-setting an existing key never evicts', () => {
+    const cache = new TtlCache<string>(TTL_MS, 2);
+    cache.set('a', '1');
+    cache.set('b', '2');
+
+    for (let i = 0; i < 50; i += 1) cache.set('a', `${i}`);
+
+    expect(cache.size).toBe(2);
+    expect(cache.evictions).toBe(0);
+    expect(cache.getFresh('b')).toBe('2');
+  });
+
+  test('a fixed-key cache never reaches the ceiling, so its behaviour is unchanged', () => {
+    // Most caches here hold exactly one key (bike points, tide gauges, road
+    // disruptions). The default ceiling must be invisible to them.
+    const cache = new TtlCache<string>(TTL_MS);
+
+    for (let i = 0; i < 5_000; i += 1) cache.set('', `body-${i}`);
+
+    expect(cache.size).toBe(1);
+    expect(cache.evictions).toBe(0);
+    expect(cache.getFresh('')).toBe('body-4999');
+  });
+
+  test('the default ceiling applies when a caller names none', () => {
+    const cache = new TtlCache<string>(TTL_MS);
+
+    for (let i = 0; i < DEFAULT_MAX_ENTRIES + 50; i += 1) cache.set(`k${i}`, 'v');
+
+    expect(cache.size).toBe(DEFAULT_MAX_ENTRIES);
+    expect(cache.evictions).toBe(50);
   });
 });

--- a/backend/src/cache.ts
+++ b/backend/src/cache.ts
@@ -4,37 +4,96 @@ interface CacheEntry<T> {
 }
 
 /**
+ * Ceiling on entries in one cache, applied unless a caller names its own.
+ *
+ * It is a DEFAULT rather than an opt-in because the absence of one killed the
+ * London service on 2026-09-04: the heap filled to its 2,053 MB limit and a
+ * Mark-Compact freed 0.6 MB, because nothing was garbage — every response body
+ * the process had ever cached was still reachable. Several caches are keyed by
+ * an id space far larger than any working set: NaPTAN stop id (~19,000 stops)
+ * for stop-arrivals, stop-detail and crowding, vehicle id for vehicle-arrivals,
+ * and aircraft callsign — with a one-hour TTL — for callsign. Opting in would
+ * have left the next route keyed by an id to reintroduce the same crash.
+ *
+ * 300 is chosen against the working set, not the key space: a cache is useful
+ * only for keys asked for again inside its TTL, which is 8 s for arrivals and
+ * 10 min for stop detail. Hundreds of distinct stops in flight at once is
+ * already a busier map than this serves, so evictions should be rare — watch
+ * `evictions` on /health and raise this if they are not.
+ */
+export const DEFAULT_MAX_ENTRIES = 300;
+
+/**
  * In-memory TTL cache (per ARCHITECTURE.md: a Map, no Redis until proven needed).
  * Entries past their TTL are still retrievable via `getStale` so the server can
  * degrade gracefully when the upstream is down or the rate budget is exhausted.
+ *
+ * Bounded, least-recently-used. A Map iterates in insertion order, so "move a
+ * key to the end whenever it is used, drop the first key when full" is exact
+ * LRU with no second structure: the first key is by construction the one
+ * nothing has touched for longest.
  */
 export class TtlCache<T> {
   private readonly entries = new Map<string, CacheEntry<T>>();
+  private evicted = 0;
 
-  constructor(private readonly ttlMs: number) {}
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries: number = DEFAULT_MAX_ENTRIES,
+  ) {}
+
+  /** Re-insert so this key becomes the most recently used. */
+  private touch(key: string, entry: CacheEntry<T>): void {
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+  }
 
   /** Returns the value only if it is younger than the TTL. */
   getFresh(key: string, now: number = Date.now()): T | undefined {
     const entry = this.entries.get(key);
     if (entry === undefined) return undefined;
-    return now - entry.storedAt < this.ttlMs ? entry.value : undefined;
+    // An expired entry is not a hit, so it does not earn a place at the back
+    // of the queue: it should be the first thing evicted, not the last.
+    if (now - entry.storedAt >= this.ttlMs) return undefined;
+    this.touch(key, entry);
+    return entry.value;
   }
 
   /** Returns the value regardless of age (for stale-serving fallbacks). */
   getStale(key: string): T | undefined {
-    return this.entries.get(key)?.value;
+    const entry = this.entries.get(key);
+    if (entry === undefined) return undefined;
+    // Serving stale IS using the entry — an upstream outage must not cost the
+    // very keys the fallback is holding up.
+    this.touch(key, entry);
+    return entry.value;
   }
 
   set(key: string, value: T, now: number = Date.now()): void {
+    if (!this.entries.has(key) && this.entries.size >= this.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest !== undefined) {
+        this.entries.delete(oldest);
+        this.evicted += 1;
+      }
+    }
+    // Delete first so a re-set moves the key to the back of the queue rather
+    // than updating it in place and leaving it looking stale to the evictor.
+    this.entries.delete(key);
     this.entries.set(key, { value, storedAt: now });
   }
 
-  /** Entry count. Nothing is ever evicted here — expired entries are kept on
-   * purpose so `getStale` can degrade gracefully — so this only ever grows,
-   * once per distinct key the process has seen. Reported on /health because
-   * "how many keys has it seen" is exactly the question that matters for
-   * caches keyed by stop or vehicle id. */
+  /** Entry count, now bounded by `maxEntries`. Reported on /health because
+   * "how many keys is it holding" is the question that matters for caches
+   * keyed by stop or vehicle id. */
   get size(): number {
     return this.entries.size;
+  }
+
+  /** Keys dropped to stay under the ceiling. Zero means the working set fits;
+   * a number that climbs steadily means `maxEntries` is too small for the
+   * traffic and every eviction is a cache miss someone paid for. */
+  get evictions(): number {
+    return this.evicted;
   }
 }


### PR DESCRIPTION
## Why

The London service died at **08:39 on 2026-09-04** on a deploy that had run 41 hours. Railway's deploy log:

```
Mark-Compact 2044.1 (2053.1) -> 2043.5 (2053.1) MB
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

The heap was at 2,044 MB of its 2,053 MB limit and the last Mark-Compact freed **0.6 MB**. Nothing was garbage — every response body the process had ever cached was still reachable. This is a leak of live objects, not GC pressure, so a bigger container or a raised `--max-old-space-size` would only have moved the crash later.

## What leaked

`TtlCache` deliberately keeps expired entries so `getStale` can serve them while an upstream is down. It had no ceiling, and several caches are keyed by an id space far larger than any working set:

| Cache | Key | Key space | TTL |
|---|---|---|---|
| `stop-arrivals` | NaPTAN stop id | ~19,000 | 8 s |
| `vehicle-arrivals` | vehicle id | ~9,000, and they churn | 8 s |
| `stop-detail` | NaPTAN stop id | ~19,000 | 10 min |
| `crowding` | NaPTAN stop id | ~19,000 | 60 s |
| `callsign` | aircraft callsign | unbounded | **1 hour** |

Every stop, vehicle and aircraft a viewer ever opened stayed resident for the life of the process. The crash surfaced inside `JSON.parse` only because the 15 s BODS poll (6,700 vehicles) is the largest recurring allocation, so it is what tips an already-full heap over.

This was a known, previously-deferred finding ("the TtlCache instances never evict — read them off /health before assuming they are small"). It has now cost an outage.

## The fix

Bounded, least-recently-used. A `Map` iterates in insertion order, so moving a key to the end whenever it is used and dropping the first key when full is exact LRU with no second structure.

- **Serving a stale entry counts as using it**, so an upstream outage cannot evict the very entries its own fallback leans on.
- **An expired entry read as a miss does not**, so it stays first in line to be dropped.
- The ceiling is a **default (300), not an opt-in**: opting in would leave the next route keyed by an id free to reintroduce the same crash. It is sized against the working set, not the key space — a cache earns its keep only for keys asked for again inside a TTL of 8 s to 10 min.
- Caches holding a single fixed key (bike points, tide gauges, road disruptions, jam cams, aircraft, lift disruptions) never reach the ceiling and behave exactly as before; a test pins that.
- `/health` gains `evictStopArrivals`, `evictVehicleArrivals`, `evictStopDetail` and `evictCrowding` so the ceiling can be raised on evidence rather than guessed at again.

Branched from `main`, not from the disruption work, so it can go out on its own.

## Test plan

- [x] `cd backend && npx vitest run` — **158 passed**, including 7 new cases: the ceiling holds; LRU evicts the least recently *used* rather than the oldest written; a stale read rescues a key; an expired read does not; re-setting an existing key never evicts; a fixed-key cache is untouched; the default ceiling applies when none is named
- [x] `cd backend && npx tsc --noEmit` clean
- [ ] After deploy: `/health` `evict*` counters stay at or near zero (if they climb steadily the ceiling is too low), and `heapUsedMB` stops trending upward across days

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6TmZ3M7PcEVpqknXSjGfY
