### PR TITLE
fix: copy fields out of the SIRI body instead of slicing views into it — the real cause of the OOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Scratch space (review agents and one-off experiments write here).
 tmp/
+# Heap snapshots from --heapsnapshot-signal: hundreds of MB, and one contains
+# every string the process held, including upstream bodies.
+*.heapsnapshot
 node_modules/
 dist/
 .env

--- a/backend/src/bods-client.test.ts
+++ b/backend/src/bods-client.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, test } from 'vitest';
+import { parseSiriVm } from './bods-client';
+
+const NOW = Date.parse('2026-09-04T15:00:00Z');
+
+function vehicleActivity(fields: Record<string, string>): string {
+  const body = Object.entries(fields)
+    .map(([tag, value]) => `<${tag}>${value}</${tag}>`)
+    .join('');
+  return `<VehicleActivity>${body}</VehicleActivity>`;
+}
+
+function siri(activities: string[]): string {
+  return `<Siri version="2.0" xmlns="http://www.siri.org.uk/siri">${activities.join('')}</Siri>`;
+}
+
+const FULL = {
+  RecordedAtTime: '2026-09-04T14:59:30Z',
+  Longitude: '-0.15824',
+  Latitude: '51.54389',
+  OperatorRef: 'TFLO',
+  VehicleRef: 'LTZ1234',
+  PublishedLineName: '31',
+  DirectionRef: 'inbound',
+  DestinationName: 'Camden_Town',
+};
+
+describe('parseSiriVm', () => {
+  test('reads every field of a well-formed vehicle', () => {
+    // Arrange / Act
+    const [bus] = parseSiriVm(siri([vehicleActivity(FULL)]), NOW);
+
+    // Assert
+    expect(bus).toMatchObject({
+      id: 'TFLO:LTZ1234',
+      line: '31',
+      operator: 'TFLO',
+      dest: 'Camden Town',
+      lat: 51.54389,
+      lon: -0.15824,
+    });
+  });
+
+  test('falls back to LineRef when the published name is absent', () => {
+    const { PublishedLineName: _drop, ...rest } = FULL;
+    const [bus] = parseSiriVm(siri([vehicleActivity({ ...rest, LineRef: 'N31' })]), NOW);
+
+    expect(bus?.line).toBe('N31');
+  });
+
+  test('drops a vehicle with no position, no id, or a stale timestamp', () => {
+    const noPosition = vehicleActivity({ ...FULL, Longitude: '', Latitude: '' });
+    const noId = vehicleActivity({ ...FULL, VehicleRef: '' });
+    const stale = vehicleActivity({ ...FULL, RecordedAtTime: '2026-09-04T10:00:00Z' });
+
+    expect(parseSiriVm(siri([noPosition, noId, stale]), NOW)).toHaveLength(0);
+  });
+
+  test('a missing bearing is null rather than NaN', () => {
+    const [bus] = parseSiriVm(siri([vehicleActivity(FULL)]), NOW);
+
+    expect(bus?.bearing).toBeNull();
+  });
+
+  test('the document header is not mistaken for a vehicle', () => {
+    expect(parseSiriVm(siri([]), NOW)).toHaveLength(0);
+  });
+
+  /**
+   * The regression that matters. `split`/`slice` return VIEWS in V8: they keep
+   * a pointer to the whole parent string. Every field here is cut out of a
+   * multi-megabyte SIRI document and then retained — in the vehicle table, the
+   * wire buffer, the diversion event store — so before the fix one destination
+   * name pinned the entire poll's XML. Sixty-six pinned bodies filled a 2 GB
+   * heap and killed the service on 2026-09-04.
+   *
+   * There is no JavaScript API for "is this string a view", so this measures
+   * the property that actually matters: parse several large documents, drop
+   * them, and see whether the heap keeps them. Needs --expose-gc to be
+   * trustworthy, so it skips rather than pretending when gc is unavailable.
+   */
+  test('retains the fields it parsed, not the documents they came from', () => {
+    const gc = (globalThis as { gc?: () => void }).gc;
+    if (!gc) {
+      // eslint-disable-next-line no-console
+      console.warn('skipping the retention check: run vitest under --expose-gc for it');
+      return;
+    }
+
+    // Arrange — documents far larger than the fields taken out of them.
+    // The document must dwarf the fields taken out of it, or the buses' own
+    // legitimate size swamps the signal: 200 vehicles of real data is well
+    // under a megabyte, while each document is several.
+    const FILLER = 'x'.repeat(40_000);
+    const VEHICLES = 200;
+    const DOCUMENTS = 4;
+    const BYTES_PER_MB = 1_048_576;
+    const makeDocument = (poll: number): string =>
+      siri(
+        Array.from({ length: VEHICLES }, (_unused, i) =>
+          vehicleActivity({
+            ...FULL,
+            VehicleRef: `LTZ${poll}_${i}`,
+            // `line` is stored raw, unlike `dest` which humanize() rewrites
+            // and thereby flattens by accident. V8 only keeps a parent
+            // pointer for a slice of 13 characters or more, so the field that
+            // proves the bug must be long AND untouched after extraction.
+            PublishedLineName: `Route ${poll}-${i} towards somewhere far away`,
+            Filler: FILLER,
+          }),
+        ),
+      );
+    const documentMb = makeDocument(0).length / BYTES_PER_MB;
+
+    gc();
+    const before = process.memoryUsage().heapUsed;
+
+    // Act — parse and keep only the buses, exactly as the poller does. The
+    // document is held in a variable and cleared rather than passed inline:
+    // V8 can keep the last temporary alive in a register, which would look
+    // exactly like one pinned document and make this test lie.
+    const kept = [];
+    for (let poll = 0; poll < DOCUMENTS; poll += 1) {
+      let document = makeDocument(poll);
+      kept.push(parseSiriVm(document, NOW));
+      document = '';
+    }
+    gc();
+    gc();
+    const retainedMb = (process.memoryUsage().heapUsed - before) / BYTES_PER_MB;
+
+    // Assert — the buses are real, and the documents are gone. Half of one
+    // document is a generous ceiling: the fields are a few percent of it, and
+    // pinning even one would blow straight past this.
+    expect(kept.flat()).toHaveLength(VEHICLES * DOCUMENTS);
+    expect(retainedMb).toBeLessThan(documentMb / 2);
+  });
+});

--- a/backend/src/bods-client.ts
+++ b/backend/src/bods-client.ts
@@ -41,7 +41,32 @@ export interface BusWire {
   readonly t: number;
 }
 
-/** First `<tag>…</tag>` text inside `chunk`, or '' — indexOf scan, no regex. */
+/**
+ * A string that shares no storage with the one it came from.
+ *
+ * V8's `slice`/`split` do not copy: they return a view that keeps a pointer to
+ * the WHOLE parent string. Every field below is cut out of a ~7 MB SIRI
+ * document, so one retained route number or destination name pins the entire
+ * poll's XML — and those fields are retained, in the vehicle table, the wire
+ * buffer and the diversion event store.
+ *
+ * That is what killed the London service on 2026-09-04: a heap snapshot of the
+ * reproduction showed 66 SIRI bodies, 480 MB of a 673 MB heap, held by nothing
+ * larger than a bus destination. The heap grew ~690 MB/h until it hit V8's
+ * 2 GB ceiling, and the final Mark-Compact freed 0.6 MB because none of it was
+ * garbage.
+ *
+ * Buffer round-trip rather than a `slice` trick: it decodes bytes into a fresh
+ * flat string with no parent, which is the property being bought, and it says
+ * so plainly. Cost is ~5 fields x ~6,700 vehicles per poll of very short
+ * strings, against a parse that already takes 60-120 ms.
+ */
+function copyOut(text: string): string {
+  return text.length === 0 ? '' : Buffer.from(text, 'utf8').toString('utf8');
+}
+
+/** First `<tag>…</tag>` text inside `chunk`, or '' — indexOf scan, no regex.
+ * The result is copied out of `chunk`; see `copyOut`. */
 function tagText(chunk: string, tag: string): string {
   const open = `<${tag}>`;
   const start = chunk.indexOf(open);
@@ -49,7 +74,7 @@ function tagText(chunk: string, tag: string): string {
   const from = start + open.length;
   const end = chunk.indexOf(`</${tag}>`, from);
   if (end === -1) return '';
-  return chunk.slice(from, end);
+  return copyOut(chunk.slice(from, end));
 }
 
 /** SIRI names use underscores for spaces ("Bus_Station"); undo for display. */


### PR DESCRIPTION
## The actual cause of the 2026-09-04 outage

**This is urgent: production is on track to crash again.** At the time of writing the heap is climbing ~680 MB/h with no sign of levelling off, from 202 MB to 993 MB in 70 minutes, and V8's ceiling is 2,053 MB.

The cache-eviction fix that shipped earlier today (#43) was argued structurally and was **not** the main cause. This is.

### What leaks

`split()` and `slice()` do not copy in V8. They return a view that keeps a pointer to the **whole parent string**.

`parseSiriVm` splits a ~7 MB SIRI document into per-vehicle chunks and slices each field out of them. Those fields are then retained — in the vehicle table, in the wire buffer that serves `/api/buses`, and in the diversion event store. So one bus destination or route name keeps that entire poll's XML alive. Once every 15 seconds.

### The proof

A heap snapshot of a local reproduction, which grew at the same rate as production:

```
self size by node type
  string     505.5 MB      ← of a 673 MB heap
  array       71.9 MB
  object      49.8 MB

single objects over 200 KB: 79, most of them
  7.3 MB  string  <Siri version="2.0" xmlns="http://www.siri.org.uk/siri" …
```

Retainer chains, walked backwards from the giant strings:

```
7.3 MB SIRI body ← .parent ← sliced string
                    ← .d    ← Object ← [1487] ← Array ← BodsClient.wire
                    ← .dest ← Object ← members[] ← events ← diversion store
```

66 whole documents, 480 MB, held by nothing larger than a destination name. That matches the production symptom exactly: the crash log's final Mark-Compact freed 0.6 MB because none of it was garbage.

### The fix

`tagText` copies its result out through a `Buffer` round-trip, which decodes bytes into a fresh flat string with no parent. Cost is five short strings per vehicle, against a parse that already takes 60–120 ms.

Measured on a standalone harness — five 2.4 MB documents parsed and dropped:

| | retained |
|---|---|
| before | 13 MB (every document pinned) |
| after | 4 MB (the fields themselves) |

### Tests

The parser that took the site down **had no test file at all**. It gets one: six cases covering field extraction, the `LineRef` fallback, dropped vehicles, a missing bearing, the header not being mistaken for a vehicle, and a retention regression.

The regression test was checked against the unfixed code and **fails there at 31 MB retained versus a 3.85 MB bound**. Two details it needs to be real, both found the hard way when an earlier draft passed against the bug:

- It uses a long `PublishedLineName`, because V8 only keeps a parent pointer for slices of **13 characters or more**, and the shorter fields are copied automatically.
- It uses a field stored raw. `dest` is flattened by accident when `humanize()` rewrites an underscore, so a test built on it proves nothing.

It skips rather than lying when `--expose-gc` is unavailable, and it clears the document reference explicitly because V8 can keep the last temporary alive in a register, which looks exactly like one pinned document.

Heap snapshots are gitignored — hundreds of megabytes, and one contains every string the process held, upstream bodies included.

## Test plan

- [x] `cd backend && npx vitest run` — **396 passed** (390 before, +6)
- [x] `NODE_OPTIONS=--expose-gc npx vitest run src/bods-client.test.ts` — 6 passed, and the retention case verified to fail on the unfixed parser
- [x] `npx tsc --noEmit` clean
- [ ] After deploy: `heapUsedMB` on `/health` levels off instead of climbing ~680 MB/h. A sampler is recording every 5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6TmZ3M7PcEVpqknXSjGfY
