### PR TITLE
fix: bound /api/arrivals by what its entries cost, and make the leak regression test actually run

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -272,7 +272,21 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
   const LIFT_DISRUPTIONS_TTL_MS = 300_000; // network-wide list; changes rarely
   const BIKE_POINTS_TTL_MS = 60_000; // dock occupancy drifts by the minute
 
-  const arrivalsCache = new TtlCache<unknown>(ARRIVALS_CACHE_TTL_MS);
+  /**
+   * A ceiling counted in ENTRIES only bounds memory when entries are small.
+   * These are not: one /api/arrivals body is 0.5 MB for a single line and
+   * ~8.8 MB for the whole network, so the 300-entry default would permit
+   * gigabytes. And the key is attacker-chosen — it is the caller's own list of
+   * line ids, canonicalised but otherwise free, so up to 30 ids give an
+   * astronomically large set of distinct subsets to churn through.
+   *
+   * The legitimate key space is exactly ONE: the frontend always asks for the
+   * whole manifest (trains-controller.ts builds `lineIds` once from every
+   * line). Four leaves room for a second region and an odd subset while
+   * capping this cache at roughly 35 MB rather than 2.6 GB.
+   */
+  const ARRIVALS_MAX_ENTRIES = 4;
+  const arrivalsCache = new TtlCache<unknown>(ARRIVALS_CACHE_TTL_MS, ARRIVALS_MAX_ENTRIES);
   const stopArrivalsCache = new TtlCache<unknown>(ARRIVALS_CACHE_TTL_MS);
   const vehicleArrivalsCache = new TtlCache<unknown>(ARRIVALS_CACHE_TTL_MS);
   const lineStatusCache = new TtlCache<unknown>(LINE_STATUS_TTL_MS);
@@ -386,8 +400,11 @@ export async function buildApp(config: AppConfig): Promise<FastifyInstance> {
     // Evictions on the caches keyed by an id space larger than any working
     // set. Zero means the ceiling is never reached and costs nothing; a number
     // that climbs steadily means it is too low and every eviction is a cache
-    // miss a viewer paid for. These are the caches whose unbounded growth
-    // filled the heap on 2026-09-04.
+    // miss a viewer paid for. These caches were the FIRST suspect for the
+    // 2026-09-04 out-of-memory crash and were not the cause — a heap snapshot
+    // later named it as SIRI response strings retained by slice views
+    // (bods-client.ts). Bounding them was still right, but nothing here should
+    // be read as an account of that incident.
     evictStopArrivals: stopArrivalsCache.evictions,
     evictVehicleArrivals: vehicleArrivalsCache.evictions,
     evictStopDetail: stopDetailCache.evictions,

--- a/backend/src/bods-client.test.ts
+++ b/backend/src/bods-client.test.ts
@@ -80,12 +80,13 @@ describe('parseSiriVm', () => {
    * trustworthy, so it skips rather than pretending when gc is unavailable.
    */
   test('retains the fields it parsed, not the documents they came from', () => {
+    // vitest.config.ts runs the suite with --expose-gc precisely so this test
+    // is never skipped. Assert that rather than skipping: a regression test
+    // that quietly opts out still reports the suite green, which is how the
+    // bug it guards would come back unnoticed.
     const gc = (globalThis as { gc?: () => void }).gc;
-    if (!gc) {
-      // eslint-disable-next-line no-console
-      console.warn('skipping the retention check: run vitest under --expose-gc for it');
-      return;
-    }
+    expect(gc, 'the suite must run with --expose-gc; see vitest.config.ts').toBeTypeOf('function');
+    if (!gc) return;
 
     // Arrange — documents far larger than the fields taken out of them.
     // The document must dwarf the fields taken out of it, or the buses' own

--- a/backend/src/cache.ts
+++ b/backend/src/cache.ts
@@ -6,20 +6,26 @@ interface CacheEntry<T> {
 /**
  * Ceiling on entries in one cache, applied unless a caller names its own.
  *
- * It is a DEFAULT rather than an opt-in because the absence of one killed the
- * London service on 2026-09-04: the heap filled to its 2,053 MB limit and a
- * Mark-Compact freed 0.6 MB, because nothing was garbage — every response body
- * the process had ever cached was still reachable. Several caches are keyed by
- * an id space far larger than any working set: NaPTAN stop id (~19,000 stops)
- * for stop-arrivals, stop-detail and crowding, vehicle id for vehicle-arrivals,
- * and aircraft callsign — with a one-hour TTL — for callsign. Opting in would
- * have left the next route keyed by an id to reintroduce the same crash.
+ * It is a DEFAULT rather than an opt-in because several caches are keyed by an
+ * id space far larger than any working set — NaPTAN stop id (~19,000 stops) for
+ * stop-arrivals, stop-detail and crowding, vehicle id for vehicle-arrivals, and
+ * aircraft callsign, on a one-hour TTL, for callsign — and opting in would
+ * leave the next route keyed by an id free to grow without limit.
+ *
+ * History, because the comment here used to claim otherwise: this ceiling was
+ * the first suspect for the 2026-09-04 out-of-memory crash and was NOT its
+ * cause. A heap snapshot later named that: SIRI response strings retained by
+ * slice views, fixed in `bods-client.ts`, which is where that incident is
+ * written up. Bounding these caches was still worth doing.
  *
  * 300 is chosen against the working set, not the key space: a cache is useful
  * only for keys asked for again inside its TTL, which is 8 s for arrivals and
- * 10 min for stop detail. Hundreds of distinct stops in flight at once is
- * already a busier map than this serves, so evictions should be rare — watch
- * `evictions` on /health and raise this if they are not.
+ * 10 min for stop detail. Watch `evictions` on /health and raise it if they
+ * climb.
+ *
+ * **It bounds entries, not bytes.** A cache whose entries are megabytes needs
+ * its own, far smaller ceiling — `/api/arrivals` bodies reach ~8.8 MB, so 300
+ * of them would be 2.6 GB. See `ARRIVALS_MAX_ENTRIES` in app.ts.
  */
 export const DEFAULT_MAX_ENTRIES = 300;
 

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * The suite runs with `--expose-gc`.
+ *
+ * `bods-client.test.ts` guards the cause of the 2026-09-04 out-of-memory crash
+ * by parsing documents far larger than the fields taken from them and asserting
+ * the heap did not keep them. Without `global.gc` that test cannot tell a
+ * retained document from one V8 simply has not collected yet, so it skips —
+ * and a regression test that silently skips is worse than none, because the
+ * suite still reports green. Exposing gc here means it runs on `npm test`, in
+ * every checkout, rather than behind a script someone has to remember.
+ */
+export default defineConfig({
+  test: {
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        execArgv: ['--expose-gc'],
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Why

A post-incident audit of the deployed code found three things, all downstream of one mistake in the cache fix that shipped earlier today (#43): **a ceiling counted in entries only bounds memory when entries are small.**

### 1. `/api/arrivals` could still be driven to an out-of-memory, remotely (CRITICAL)

Its entries are not small. Measured on production:

| request | body |
|---|---|
| `?lines=central` | 0.5 MB |
| `?lines=central,victoria,northern` | 1.5 MB |
| whole network | ~8.8 MB |

The 300-entry default therefore permitted roughly **2.6 GB** — comfortably past the ceiling the service already died at once today. And the cache key is `parsed.ids.join(',')`: the caller's own list of line ids. It is canonicalised (sorted, deduplicated), so ordering games do not work, but with up to 30 valid ids there is an enormous set of distinct *subsets*, and nothing stops an unauthenticated client walking through them. The audit put the time-to-OOM from a single client at about three minutes, within the 60/min TfL budget.

The legitimate key space is exactly **one**: `trains-controller.ts` builds `lineIds` from the whole manifest, once, and never varies it. `ARRIVALS_MAX_ENTRIES = 4` leaves room for a second region and an odd subset while capping this cache near 35 MB.

### 2. The regression test guarding the real crash never ran (HIGH)

`bods-client.test.ts` needs `global.gc` to distinguish a retained document from one V8 simply has not collected yet. Without it, it skipped with a `console.warn` — and it was always without it, because `npm test` is a plain `vitest run`.

**A regression test that quietly opts out is worse than none, because the suite still reports green.** That is precisely how the bug it guards would come back unnoticed.

A `vitest.config.ts` now runs the whole suite under `--expose-gc`, and the test **asserts** gc is present rather than skipping. Verified both directions: with the config moved aside it fails with `the suite must run with --expose-gc; see vitest.config.ts`; restored, it passes.

### 3. The repository asserted two different causes for one incident (HIGH)

`cache.ts` and `app.ts` still said these caches filled the heap on 2026-09-04. They were the first suspect and they were **wrong** — a heap snapshot named it as SIRI response strings retained by slice views (#45). Both comments now point at `bods-client.ts`, where the incident is written up, and `cache.ts` records the entries-versus-bytes distinction that made this PR necessary.

## What this does not claim

Bounding these caches was still worth doing, and #45 is confirmed: an independent reproduction measured the post-fix process at **-6.5 MB/h over 33 minutes**, against +750 MB/h before. This PR closes an attack path that survived both fixes.

## Test plan

- [x] `cd backend && npx vitest run` — **396 passed**, now including the retention test that previously skipped
- [x] `npx tsc --noEmit` clean
- [x] Verified the retention test fails when the vitest config is removed, and passes with it
- [ ] After deploy: `/health` `cacheArrivals` stays at or below 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6TmZ3M7PcEVpqknXSjGfY
