### PR TITLE
chore(deps): take fastify to 5.12.3, closing the four HIGH advisories 5.12.1 left open

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11,7 +11,7 @@
         "@fastify/compress": "^9.1.0",
         "@fastify/cors": "^11.0.1",
         "@fastify/static": "^10.1.2",
-        "fastify": "^5.12.1"
+        "fastify": "^5.12.3"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -1103,6 +1103,7 @@
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1657,9 +1658,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.12.1",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.12.1.tgz",
-      "integrity": "sha512-FWi+tQvwxR/PeRX7Z2mhfEF5ozJ3jn9asiiclzKXNSzJRHAYcU924aIOKAdHFJ+YIKieh3cqr1IwCOvTr41B3Q==",
+      "version": "5.12.3",
+      "resolved": "https://registry.npmmirror.com/fastify/-/fastify-5.12.3.tgz",
+      "integrity": "sha512-reZ8wce5VNCcufIt9AVtzZa3L4u1j8esikn7OEgHWLVpRpL5R7Y2+Xzj70OUkv5zDfzUAxXZT6cu4Rt0zr3EKA==",
       "funding": [
         {
           "type": "github",
@@ -2054,6 +2055,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2537,6 +2539,7 @@
       "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -2577,6 +2580,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,7 +17,7 @@
     "@fastify/compress": "^9.1.0",
     "@fastify/cors": "^11.0.1",
     "@fastify/static": "^10.1.2",
-    "fastify": "^5.12.1"
+    "fastify": "^5.12.3"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",


### PR DESCRIPTION
Dependabot's #39 moved fastify 5.10.0 → 5.12.1, closing two MEDIUM advisories. It was raised before 5.12.2 existed, and **5.12.2 is itself a security release fixing four HIGH advisories** — so #39 alone closed the smaller pair and left the larger four on the graph. 5.12.3 is the current head of the 5.x line.

Verified beyond the suite, because a framework upgrade can typecheck and still fail to boot:

- `npx vitest run` — 396 passed
- `npx tsc --noEmit` clean
- **Started for real**: /health, /api/capabilities, /api/disruptions, /api/bus-stop-closures and /api/arrivals all answered 200

`npm audit` cannot confirm this locally — the configured registry mirror does not implement the advisories endpoint — so the claim rests on upstream release notes and GitHub's own alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6TmZ3M7PcEVpqknXSjGfY