### PR TITLE
feat: searching a bus route also surfaces its closed stops and diversions, with every overlay off

### DIFF
--- a/frontend/src/layers/bus-stop-closures.test.ts
+++ b/frontend/src/layers/bus-stop-closures.test.ts
@@ -6,11 +6,32 @@
 // (which reaches for `window`), so both are stubbed to keep this in the fast
 // node environment — the emergency-classify.test.ts pattern.
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Map as MaplibreMap } from 'maplibre-gl';
 
 vi.mock('maplibre-gl', () => ({ Popup: class {} }));
 
 const registerPoll = vi.fn<(fn: () => void, ms: number) => void>();
 vi.mock('../util/lifecycle', () => ({ registerPoll: (fn: () => void, ms: number) => registerPoll(fn, ms) }));
+
+// layers/searched-lines is NOT mocked: the join it performs ("does this stop
+// serve a line the rider typed?") is half of what is under test here, and a
+// stubbed matcher would make the 46/146 case prove nothing. Only its dependency
+// on ./buses is replaced — that module value-imports the whole map runtime, and
+// capturing the hook it registers is how a real filter change is simulated.
+type RouteShapeHook = (map: MaplibreMap, lines: ReadonlySet<string> | null) => void | Promise<void>;
+
+let registeredHooks: readonly RouteShapeHook[] = [];
+
+vi.mock('./buses', () => ({
+  setBusRouteShapeHook: (hook: RouteShapeHook) => {
+    registeredHooks = [...registeredHooks, hook];
+  },
+}));
+
+/** Simulate a real bus-line filter change: buses.ts calls every hook it holds. */
+function fireSearch(lines: ReadonlySet<string> | null): void {
+  for (const hook of registeredHooks) hook({} as MaplibreMap, lines);
+}
 
 const {
   BUS_STOP_CLOSURES_HALO_LAYER_ID,
@@ -44,6 +65,71 @@ const stop = (over: Partial<BusStopClosure> = {}): BusStopClosure => ({
 });
 
 const propsOf = (feature: GeoJSON.Feature): ClosureProps => feature.properties as ClosureProps;
+
+/** Enough of a MapLibre map for the layer's own calls, recording setData. */
+function fakeMap() {
+  const painted: GeoJSON.FeatureCollection[] = [];
+  const layerIds = new Set<string>();
+  const visibility = new Map<string, string>();
+  const map = {
+    addSource: () => {},
+    addLayer: (layer: { id: string }) => layerIds.add(layer.id),
+    getLayer: (id: string) => (layerIds.has(id) ? { id } : undefined),
+    getSource: () => ({ setData: (data: GeoJSON.FeatureCollection) => painted.push(data) }),
+    setLayoutProperty: (id: string, _prop: string, value: string) => visibility.set(id, value),
+    queryRenderedFeatures: () => [],
+    getCanvas: () => ({ style: {} }),
+    on: () => {},
+  };
+  return {
+    map: map as unknown as Parameters<typeof startBusStopClosures>[0],
+    painted,
+    layerIds,
+    visibility,
+  };
+}
+
+const body = (stops: BusStopClosure[]) => ({
+  ok: true,
+  json: async () => ({ t: Math.floor(NOW / 1000), stops }),
+  headers: { get: () => null },
+});
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+/** The layer keeps overlay/search/payload state across a start(), so every test
+ * hands its own map back to a neutral state rather than inheriting the last. */
+let lastStarted: ReturnType<typeof fakeMap> | null = null;
+
+beforeEach(() => {
+  registerPoll.mockClear();
+  fetchSpy = vi.fn(async () => body([stop()]));
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+afterEach(() => {
+  if (lastStarted) {
+    fireSearch(null);
+    setBusStopClosuresVisible(lastStarted.map, false);
+    lastStarted = null;
+  }
+  vi.unstubAllGlobals();
+});
+
+/** Start the layer over a map of its own, serving `stops` from the feed. */
+async function startWith(stops: BusStopClosure[]): Promise<ReturnType<typeof fakeMap>> {
+  fetchSpy.mockResolvedValue(body(stops));
+  const harness = fakeMap();
+  lastStarted = harness;
+  await startBusStopClosures(harness.map);
+  return harness;
+}
+
+/** Ids of the features in the most recent paint. */
+function drawnIds(painted: GeoJSON.FeatureCollection[]): string[] {
+  const last = painted[painted.length - 1];
+  return (last?.features ?? []).map((f) => (f.properties as ClosureProps).id);
+}
 
 describe('closureState — only a window covering now may be drawn', () => {
   test('an open-ended closure that has begun is in force', () => {
@@ -233,47 +319,6 @@ describe('closurePopupHtml', () => {
 });
 
 describe('poll gating', () => {
-  /** Enough of a MapLibre map for the layer's own calls, recording setData. */
-  function fakeMap() {
-    const painted: GeoJSON.FeatureCollection[] = [];
-    const layerIds = new Set<string>();
-    const visibility = new Map<string, string>();
-    const map = {
-      addSource: () => {},
-      addLayer: (layer: { id: string }) => layerIds.add(layer.id),
-      getLayer: (id: string) => (layerIds.has(id) ? { id } : undefined),
-      getSource: () => ({ setData: (data: GeoJSON.FeatureCollection) => painted.push(data) }),
-      setLayoutProperty: (id: string, _prop: string, value: string) => visibility.set(id, value),
-      queryRenderedFeatures: () => [],
-      getCanvas: () => ({ style: {} }),
-      on: () => {},
-    };
-    return {
-      map: map as unknown as Parameters<typeof startBusStopClosures>[0],
-      painted,
-      layerIds,
-      visibility,
-    };
-  }
-
-  const body = (stops: BusStopClosure[]) => ({
-    ok: true,
-    json: async () => ({ t: Math.floor(NOW / 1000), stops }),
-    headers: { get: () => null },
-  });
-
-  let fetchSpy: ReturnType<typeof vi.fn>;
-
-  beforeEach(() => {
-    registerPoll.mockClear();
-    fetchSpy = vi.fn(async () => body([stop()]));
-    vi.stubGlobal('fetch', fetchSpy);
-  });
-
-  afterEach(() => {
-    vi.unstubAllGlobals();
-  });
-
   test('makes zero requests while the overlay is off', async () => {
     // Arrange / Act — the overlay ships off, so start must not fetch
     const { map, layerIds } = fakeMap();
@@ -378,8 +423,12 @@ describe('poll gating', () => {
     expect(busStopClosuresStats().pollFailures).toBe(before + 1);
     expect(busStopClosuresStats().lastPollError).toContain('style reloaded');
     expect(error).toHaveBeenCalledWith('[bus-stop-closures]', expect.any(Error));
+
+    // Switching off goes through the source too, so it is contained the same
+    // way rather than throwing out of a legend click; the spy stays installed
+    // over the cleanup that proves it.
+    expect(() => setBusStopClosuresVisible(map, false)).not.toThrow();
     error.mockRestore();
-    setBusStopClosuresVisible(map, false);
   });
 
   test('registers the re-filter tick on its own interval', async () => {
@@ -429,5 +478,178 @@ describe('a row that states no type', () => {
     const blank = propsOf(buildClosureFeatures([stop({ ty: '' })], NOW).features[0]);
     expect(closurePopupHtml(blank)).not.toContain('Bus stop closed');
     expect(closurePopupHtml(blank)).toContain('Disruption');
+  });
+});
+
+// ── search-scoped closures ──
+// The overlay toggle and the Filter tab's bus-line search are two independent
+// inputs, and every row of their truth table is pinned here. The two that
+// matter most: an overlay that is ON keeps showing EVERYTHING (a search must
+// never silently hide a stop the rider asked to see), and an overlay that is
+// OFF with no search must still cost ZERO requests.
+describe('search-scoped closures', () => {
+  /** Two poles on lines that look alike to a substring match but are not. */
+  const on46 = stop({ id: '46', name: 'Lauderdale Road', routes: ['46'] });
+  const on146 = stop({ id: '146', name: 'Bromley Common', routes: ['146'], lat: 51.38, lon: 0.02 });
+
+  test('overlay ON with no search draws every closed stop', async () => {
+    // Arrange
+    const { map, painted } = await startWith([on46, on146]);
+
+    // Act
+    setBusStopClosuresVisible(map, true);
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+
+    // Assert
+    expect(drawnIds(painted)).toEqual(['46', '146']);
+  });
+
+  test('overlay ON with a search STILL draws every closed stop', async () => {
+    // Arrange — the overlay means "show me all of it"
+    const { map, painted } = await startWith([on46, on146]);
+    setBusStopClosuresVisible(map, true);
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+
+    // Act
+    fireSearch(new Set(['46']));
+
+    // Assert — the search narrows nothing while the overlay is asking for all
+    expect(drawnIds(painted)).toEqual(['46', '146']);
+  });
+
+  test('overlay OFF with a search draws only the stops a searched line serves', async () => {
+    // Arrange — the overlay ships off and is never touched
+    const { painted, visibility } = await startWith([on46, on146]);
+
+    // Act — the rider types 46
+    fireSearch(new Set(['46']));
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+
+    // Assert — 146 is a different road, not a longer 46
+    expect(drawnIds(painted)).toEqual(['46']);
+    expect(busStopClosuresStats().droppedOffSearch).toBe(1);
+    expect(visibility.get(BUS_STOP_CLOSURES_CORE_LAYER_ID)).toBe('visible');
+    expect(visibility.get(BUS_STOP_CLOSURES_HALO_LAYER_ID)).toBe('visible');
+  });
+
+  test('overlay OFF with no search draws nothing and makes zero requests', async () => {
+    // Arrange / Act — this is the shipped state
+    const { painted } = await startWith([on46, on146]);
+
+    // Assert — not a request, not a paint
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(painted).toHaveLength(0);
+
+    // An EMPTY selection is no selection: searched-lines normalises it to null,
+    // so it must not wake the feed either.
+    fireSearch(new Set());
+    const tick = registerPoll.mock.calls[0]?.[0] as () => void;
+    tick();
+    await Promise.resolve();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('a search alone pays for the feed, and the poller keeps it fresh', async () => {
+    // Arrange — the invariant most likely to be broken later: the poll gate is
+    // "EITHER input", not "the overlay".
+    const { painted } = await startWith([on46]);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    // Act
+    fireSearch(new Set(['46']));
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+
+    // Assert — one fetch on waking, and the registered poller now runs
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith('/api/bus-stop-closures');
+    const tick = registerPoll.mock.calls[0]?.[0] as () => void;
+    tick();
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+  });
+
+  test('re-searching another line re-scopes from the payload in hand, without refetching', async () => {
+    // Arrange
+    const { painted } = await startWith([on46, on146]);
+    fireSearch(new Set(['46']));
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+
+    // Act — the rider types the other one
+    fireSearch(new Set(['146']));
+
+    // Assert — a keystroke costs a re-filter, not a request
+    expect(drawnIds(painted)).toEqual(['146']);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('turning the overlay off while a search is active keeps the searched subset', async () => {
+    // Arrange — overlay on, everything drawn, then a search
+    const { map, painted, visibility } = await startWith([on46, on146]);
+    setBusStopClosuresVisible(map, true);
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+    fireSearch(new Set(['46']));
+    expect(drawnIds(painted)).toEqual(['46', '146']);
+
+    // Act
+    setBusStopClosuresVisible(map, false);
+
+    // Assert — the layer stays on screen for the search, narrowed to it
+    expect(drawnIds(painted)).toEqual(['46']);
+    expect(visibility.get(BUS_STOP_CLOSURES_CORE_LAYER_ID)).toBe('visible');
+  });
+
+  test('clearing the search with the overlay off empties the layer and stops fetching', async () => {
+    // Arrange
+    const { painted, visibility } = await startWith([on46, on146]);
+    fireSearch(new Set(['46']));
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+    const fetches = fetchSpy.mock.calls.length;
+
+    // Act
+    fireSearch(null);
+
+    // Assert — nothing left in the source, nothing left on screen, no requests
+    expect(drawnIds(painted)).toEqual([]);
+    expect(visibility.get(BUS_STOP_CLOSURES_CORE_LAYER_ID)).toBe('none');
+    const tick = registerPoll.mock.calls[0]?.[0] as () => void;
+    tick();
+    await Promise.resolve();
+    expect(fetchSpy).toHaveBeenCalledTimes(fetches);
+  });
+
+  test('a searched stop looks exactly like a toggled one, searched route first', async () => {
+    // Arrange — styling never changes; only the ORDER of the routes line does,
+    // so the reason this pin is on screen reads first.
+    const { painted } = await startWith([stop({ routes: ['9', '24', '46'] })]);
+
+    // Act
+    fireSearch(new Set(['46']));
+    await vi.waitFor(() => expect(painted.length).toBeGreaterThan(0));
+
+    // Assert
+    const props = propsOf(painted[painted.length - 1].features[0]);
+    expect(props.routes).toBe('46, 9, 24');
+    expect(closurePopupHtml(props)).toContain('Routes: 46, 9, 24');
+    expect(closurePopupHtml(props)).toContain('Bus stop closed');
+  });
+});
+
+describe('buildClosureFeatures — searched route ordering', () => {
+  test('moves a searched line to the front and leaves the rest numerically sorted', () => {
+    // Arrange
+    const stops = [stop({ routes: ['9', '24', '176'] })];
+
+    // Act
+    const built = buildClosureFeatures(stops, NOW, new Set(['24']));
+
+    // Assert
+    expect(propsOf(built.features[0]).routes).toBe('24, 9, 176');
+  });
+
+  test('leaves the list alone when nothing on the stop was searched for', () => {
+    // Arrange / Act — the rider is looking at another road entirely
+    const built = buildClosureFeatures([stop({ routes: ['9', '24', '176'] })], NOW, new Set(['46']));
+
+    // Assert
+    expect(propsOf(built.features[0]).routes).toBe('9, 24, 176');
   });
 });

--- a/frontend/src/layers/bus-stop-closures.ts
+++ b/frontend/src/layers/bus-stop-closures.ts
@@ -17,8 +17,10 @@
 // backend's stop gazetteer, so a pole the gazetteer could not resolve has no
 // position and is dropped (and counted) rather than placed somewhere plausible.
 //
-// Polling is gated on the overlay toggle (default OFF): while hidden the layer
-// makes zero requests.
+// Two independent inputs decide what is drawn — the overlay toggle (default
+// OFF) and the Filter tab's bus-line search — and polling is gated on EITHER of
+// them being active. With neither, the layer makes zero requests. See the
+// display coordinator at the foot of the file for the truth table.
 
 import {
   Popup,
@@ -29,6 +31,7 @@ import {
 } from 'maplibre-gl';
 import { registerPoll } from '../util/lifecycle';
 import { anyFeatureAt, below, DOT_LAYER_IDS } from '../util/layer-order';
+import { matchesSearch, onSearchedLines, type Unsubscribe } from './searched-lines';
 
 export const BUS_STOP_CLOSURES_HALO_LAYER_ID = 'bus-stop-closures-halo';
 export const BUS_STOP_CLOSURES_CORE_LAYER_ID = 'bus-stop-closures-core';
@@ -118,6 +121,9 @@ const stats = {
   droppedNoCoords: 0,
   droppedNotInForce: 0,
   droppedUnreadableWindow: 0,
+  /** In force and positioned, but on no line the rider searched for. Kept
+   * apart so `received` still adds up: drawn + every dropped* = received. */
+  droppedOffSearch: 0,
   pollFailures: 0,
   lastPollError: '',
 };
@@ -204,15 +210,29 @@ function truncate(text: string, max: number): string {
   return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
 }
 
-function toProps(stop: BusStopClosure): ClosureProps {
+/**
+ * The stop's routes as the popup lists them: numeric-aware so "9" sorts before
+ * "24" and "N29" after "176" (the same idiom as listActiveBusLines in
+ * layers/buses.ts), with any line the rider searched for lifted to the front so
+ * the reason this pin is on screen reads first. Ordering only — the routes are
+ * neither filtered nor restyled, and with no search the list is untouched.
+ */
+function orderedRoutes(
+  routes: readonly string[],
+  searched: ReadonlySet<string> | null,
+): readonly string[] {
+  const sorted = [...routes].sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+  if (!searched) return sorted;
+  const wanted = sorted.filter((route) => matchesSearch(route, searched));
+  if (wanted.length === 0) return sorted;
+  return [...wanted, ...sorted.filter((route) => !matchesSearch(route, searched))];
+}
+
+function toProps(stop: BusStopClosure, searched: ReadonlySet<string> | null): ClosureProps {
   return {
     id: stop.id ?? '',
     name: stop.name ?? 'Bus stop',
-    // Numeric-aware so "9" sorts before "24" and "N29" after "176" — the same
-    // idiom as listActiveBusLines in layers/buses.ts.
-    routes: [...(stop.routes ?? [])]
-      .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
-      .join(', '),
+    routes: orderedRoutes(stop.routes ?? [], searched).join(', '),
     towards: stop.towards ?? '',
     // NOT defaulted to "Closure". An absent `ty` states nothing, and inventing
     // the most specific claim the layer can make for a row that made none is
@@ -230,10 +250,18 @@ export interface BuiltClosures {
   readonly droppedUnreadableWindow: number;
 }
 
-/** One point feature per stop that is both positioned and in force right now. */
+/**
+ * One point feature per stop that is both positioned and in force right now.
+ *
+ * `searched` is presentation only — which line the popup names first. WHICH
+ * stops are built is decided before this by scopeToSearch(), because the two
+ * answers differ: with the overlay on, every stop is built while the searched
+ * line still reads first in its popup.
+ */
 export function buildClosureFeatures(
   stops: readonly BusStopClosure[],
   nowMs: number,
+  searched: ReadonlySet<string> | null = null,
 ): BuiltClosures {
   const features: GeoJSON.Feature[] = [];
   let droppedNoCoords = 0;
@@ -256,7 +284,7 @@ export function buildClosureFeatures(
     }
     features.push({
       type: 'Feature',
-      properties: toProps(stop),
+      properties: toProps(stop, searched),
       geometry: { type: 'Point', coordinates: [stop.lon as number, stop.lat as number] },
     });
   }
@@ -376,18 +404,79 @@ function setData(map: MaplibreMap, features: GeoJSON.Feature[]): void {
   }
 }
 
+// ── closure display coordinator ──
+// Two independent inputs decide what this layer draws, so they are resolved
+// together in one place rather than fighting over the same source and the same
+// poll gate — the applyBusDisplay pattern from layers/buses.ts:
+//   • the Bus stop closures overlay toggle (Lines tab) — overlayOn
+//   • the bus line search (Filter tab)                 — searchLines
+// Truth table:
+//   overlay ON,  no search → every closed stop, exactly as before
+//   overlay ON,  search    → STILL every closed stop. The overlay means "show
+//                            me all of it", and a search must never silently
+//                            hide a stop the rider explicitly asked to see.
+//                            The searched line only reads first in the popup.
+//   overlay OFF, search    → only stops a searched line serves
+//   overlay OFF, no search → nothing drawn, and ZERO requests
+// Styling never enters the table: search decides WHICH stops exist, never how
+// they look, so a closed stop looks the same however it got on screen.
+
 /** OFF by default, mirroring the legend row's startOff. */
 let overlayOn = false;
-/** Set by startBusStopClosures so the toggle can force an immediate refresh. */
+/** The lines the rider is searching for; null when not searching (an empty
+ * selection is normalised to null by layers/searched-lines). */
+let searchLines: ReadonlySet<string> | null = null;
+/** The resolved output of the table above: is anything asked for at all? Kept
+ * as state so the waking edge can be told from a change while already awake. */
+let displayActive = false;
+/** Set by startBusStopClosures so the coordinator can go and get a fresh
+ * payload, or redraw from the one already in hand. */
 let refresh: (() => void) | null = null;
+let redraw: (() => void) | null = null;
+/** Dropped and replaced by a second start (a style reload), so subscriptions
+ * never stack up one per call. */
+let unsubscribeSearch: Unsubscribe | null = null;
 
-/** Legend toggle handler: visibility flip + poll gate. */
+/** Whether either input is asking for the layer — the poll gate too: the feed
+ * is paid for when the overlay OR the search needs it, and never otherwise. */
+function closuresRequested(): boolean {
+  return overlayOn || searchLines !== null;
+}
+
+/** The rows to draw from. The overlay wins: while it is on, nothing is scoped
+ * away, so a search can only ever ADD to what the rider already asked for. */
+function scopeToSearch(stops: readonly BusStopClosure[]): readonly BusStopClosure[] {
+  // Read once into a const: narrowing a module-level `let` does not survive
+  // into the closure below, and the alternative is a cast that asserts what
+  // this line already proves.
+  const lines = searchLines;
+  if (overlayOn || !lines) return stops;
+  return stops.filter((stop) => servesSearchedLine(stop, lines));
+}
+
+function servesSearchedLine(stop: BusStopClosure, lines: ReadonlySet<string>): boolean {
+  return (stop.routes ?? []).some((route) => matchesSearch(route, lines));
+}
+
+/** Resolve both inputs onto the map: visibility, then the features, then a
+ * fetch if the layer is only now waking up. */
+function applyClosureDisplay(map: MaplibreMap): void {
+  const active = closuresRequested();
+  // Coming back on, whatever is in hand is however old the layer was when it
+  // stopped fetching, so refresh out of band rather than leaving it stale.
+  const woke = active && !displayActive;
+  displayActive = active;
+  for (const id of BUS_STOP_CLOSURES_LAYER_IDS) {
+    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', active ? 'visible' : 'none');
+  }
+  redraw?.();
+  if (woke) refresh?.();
+}
+
+/** Legend toggle handler: one of the two inputs above. */
 export function setBusStopClosuresVisible(map: MaplibreMap, visible: boolean): void {
   overlayOn = visible;
-  for (const id of BUS_STOP_CLOSURES_LAYER_IDS) {
-    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', visible ? 'visible' : 'none');
-  }
-  if (visible) refresh?.();
+  applyClosureDisplay(map);
 }
 
 export async function startBusStopClosures(map: MaplibreMap): Promise<void> {
@@ -421,17 +510,24 @@ export async function startBusStopClosures(map: MaplibreMap): Promise<void> {
     console.warn(line);
   }
 
-  /** Re-filters the payload in hand against a freshly anchored "now". */
+  /** Re-filters the payload in hand against a freshly anchored "now" and the
+   * current scope. */
   function rebuild(): void {
-    if (!overlayOn || !payload || typeof payload.t !== 'number') return;
+    if (!displayActive || !payload || typeof payload.t !== 'number') return;
     const stops = payload.stops ?? [];
-    const built = buildClosureFeatures(stops, serverNowMs(payload.t, receivedAt, Date.now()));
+    const scoped = scopeToSearch(stops);
+    const built = buildClosureFeatures(
+      scoped,
+      serverNowMs(payload.t, receivedAt, Date.now()),
+      searchLines,
+    );
     stats.received = stops.length;
+    stats.droppedOffSearch = stops.length - scoped.length;
     stats.drawn = built.features.length;
     stats.droppedNoCoords = built.droppedNoCoords;
     stats.droppedNotInForce = built.droppedNotInForce;
     stats.droppedUnreadableWindow = built.droppedUnreadableWindow;
-    logDrops(built, stops.length);
+    logDrops(built, scoped.length);
     setData(map, built.features);
   }
 
@@ -459,7 +555,7 @@ export async function startBusStopClosures(map: MaplibreMap): Promise<void> {
   }
 
   async function poll(): Promise<void> {
-    if (!overlayOn) return;
+    if (!displayActive) return;
     try {
       const res = await fetch(CLOSURES_URL);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -486,10 +582,43 @@ export async function startBusStopClosures(map: MaplibreMap): Promise<void> {
   }
   refresh = () => void poll();
 
+  /**
+   * The coordinator's way into the source, and the second entry point that
+   * fetches nothing — so, like tickRebuild, an unguarded throw here would land
+   * in a legend click handler or a keystroke on the Filter tab with no counter,
+   * no reason and no [bus-stop-closures] line to grep.
+   */
+  redraw = () => {
+    try {
+      if (displayActive) {
+        rebuild();
+        return;
+      }
+      // Gone dark: release the features rather than leave a hidden set in the
+      // source. Before the first poll there is nothing to release, so a page
+      // that never asks for the layer never touches the source at all.
+      if (payload) setData(map, []);
+    } catch (error) {
+      noteFailure(error);
+    }
+  };
+
   wireInteractions(map, BUS_STOP_CLOSURES_CORE_LAYER_ID);
 
-  // No-op while the overlay is off, which is how it ships: zero requests until
-  // someone asks for the layer.
+  // The other half of the display coordinator. The listener fires once, right
+  // here, with whatever the rider has already typed — so a layer that starts
+  // after the search does is scoped from its first paint, not the next one.
+  // It cannot double up with the poll below: displayActive is written by the
+  // same coordinator as both inputs, so it is already true in that case and
+  // this delivery is not a waking edge.
+  unsubscribeSearch?.();
+  unsubscribeSearch = onSearchedLines((lines) => {
+    searchLines = lines;
+    applyClosureDisplay(map);
+  });
+
+  // No-op while neither input is asking, which is how it ships: zero requests
+  // until someone turns the overlay on or searches for a line.
   await poll();
   registerPoll(() => void poll(), POLL_INTERVAL_MS);
   // The window is time-dependent, so it is re-derived without a fetch.

--- a/frontend/src/layers/diversions.test.ts
+++ b/frontend/src/layers/diversions.test.ts
@@ -1,13 +1,66 @@
-// The popup's freshness line. diversions.ts value-imports maplibre-gl (Popup),
-// so that module is stubbed to keep this in the fast node environment — same
-// pattern as bus-filter.test.ts.
-import { describe, expect, test, vi } from 'vitest';
+// The diversion layer's pure halves — the freshness line, the search scope, the
+// popup — and the two-input truth table that decides what reaches the map.
+//
+// Three module stubs, each for a reason:
+//   • maplibre-gl, because diversions.ts value-imports Popup and this run stays
+//     in the fast node environment (the bus-filter.test.ts pattern);
+//   • util/lifecycle, because registerPoll reaches for `window`;
+//   • ./buses, because searched-lines.ts registers its single hook there.
+// searched-lines.ts itself is REAL: the matching rule is exactly what the
+// substring and destination-suffix cases below are about, and calling the
+// captured hook back is how a real filter change is simulated end to end.
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Map as MaplibreMap } from 'maplibre-gl';
 
 vi.mock('maplibre-gl', () => ({ Popup: class {} }));
 
-const { freshnessLabel } = await import('./diversions');
+const registerPoll = vi.fn<(fn: () => void, ms: number) => void>();
+vi.mock('../util/lifecycle', () => ({
+  registerPoll: (fn: () => void, ms: number) => registerPoll(fn, ms),
+}));
+
+type RouteShapeHook = (map: MaplibreMap, lines: ReadonlySet<string> | null) => void | Promise<void>;
+
+/** Every hook searched-lines.ts registered on buses.ts, this test run. */
+let registeredHooks: readonly RouteShapeHook[] = [];
+
+vi.mock('./buses', () => ({
+  setBusRouteShapeHook: (hook: RouteShapeHook) => {
+    registeredHooks = [...registeredHooks, hook];
+  },
+}));
+
+const {
+  DIVERSIONS_SEGMENTS_LAYER_ID,
+  buildDiversionFeatures,
+  diversionPopupHtml,
+  eventsOnSearchedLines,
+  freshnessLabel,
+} = await import('./diversions');
+
+import type { DiversionEvent, DiversionProps } from './diversions';
 
 const NOW = 1_788_100_000;
+
+const SEGMENT: [number, number][] = [
+  [-0.1, 51.5],
+  [-0.11, 51.51],
+];
+
+const event = (over: Partial<DiversionEvent> = {}): DiversionEvent => ({
+  id: 'e1',
+  status: 'active',
+  severity: 'road',
+  startedAt: NOW - 3600,
+  lastEvidenceAt: NOW - 300,
+  routes: ['46'],
+  vehicles: 3,
+  segments: [SEGMENT],
+  ...over,
+});
+
+const propsOf = (feature: GeoJSON.Feature): DiversionProps =>
+  feature.properties as unknown as DiversionProps;
 
 describe('freshnessLabel', () => {
   test('reads as "just now" inside the first minute', () => {
@@ -27,5 +80,315 @@ describe('freshnessLabel', () => {
     expect(freshnessLabel(0, NOW)).toBe('');
     expect(freshnessLabel(Number.NaN, NOW)).toBe('');
     expect(freshnessLabel(NOW + 180, NOW)).toBe('');
+  });
+});
+
+describe('eventsOnSearchedLines', () => {
+  test('surfaces an event that serves the searched line', () => {
+    // Arrange
+    const events = [event({ id: 'a', routes: ['46', '172'] }), event({ id: 'b', routes: ['12'] })];
+
+    // Act
+    const scoped = eventsOnSearchedLines(events, new Set(['46']));
+
+    // Assert
+    expect(scoped.map((ev) => ev.id)).toEqual(['a']);
+  });
+
+  test('does NOT surface 146, 460 or N46 when the rider searched 46', () => {
+    // The properties MapLibre sees carry `routes` as a joined string, so an
+    // `['in', '46', ['get','routes']]` filter would substring-match all three.
+    // Arrange
+    const events = [
+      event({ id: 'one-four-six', routes: ['146'] }),
+      event({ id: 'four-sixty', routes: ['460'] }),
+      event({ id: 'night', routes: ['N46'] }),
+      event({ id: 'wanted', routes: ['46'] }),
+    ];
+
+    // Act
+    const scoped = eventsOnSearchedLines(events, new Set(['46']));
+
+    // Assert
+    expect(scoped.map((ev) => ev.id)).toEqual(['wanted']);
+  });
+
+  test('matches a route label carrying its destination sign', () => {
+    // Arrange — diversion-events.ts labels a diverting route "SL8 → Uxbridge".
+    const events = [event({ id: 'sl8', routes: ['SL8 → Uxbridge'] })];
+
+    // Act
+    const scoped = eventsOnSearchedLines(events, new Set(['SL8']));
+
+    // Assert
+    expect(scoped.map((ev) => ev.id)).toEqual(['sl8']);
+  });
+
+  test('surfaces nothing when the rider is not searching', () => {
+    // Arrange
+    const events = [event()];
+
+    // Act / Assert
+    expect(eventsOnSearchedLines(events, null)).toEqual([]);
+  });
+
+  test('keeps a zero-padded route apart from its unpadded twin', () => {
+    // 025 is National Express, 25 is a London bus — different roads.
+    // Arrange
+    const events = [event({ id: 'natx', routes: ['025'] })];
+
+    // Act / Assert
+    expect(eventsOnSearchedLines(events, new Set(['25']))).toEqual([]);
+    expect(eventsOnSearchedLines(events, new Set(['025'])).map((ev) => ev.id)).toEqual(['natx']);
+  });
+});
+
+describe('buildDiversionFeatures', () => {
+  test('draws a search-scoped event exactly like a toggled one', () => {
+    // Search changes WHICH events are drawn, never how they look, so every
+    // property the paint expressions read must be identical in both modes.
+    // Arrange
+    const events = [event({ routes: ['46', '172'], severity: 'partial', status: 'recovering' })];
+
+    // Act
+    const byToggle = propsOf(buildDiversionFeatures(events, false)[0]);
+    const bySearch = propsOf(buildDiversionFeatures(events, true)[0]);
+
+    // Assert
+    const painted = ({ scoped: _scoped, ...rest }: DiversionProps) => rest;
+    expect(painted(bySearch)).toEqual(painted(byToggle));
+    expect(buildDiversionFeatures(events, true)[0].geometry).toEqual(
+      buildDiversionFeatures(events, false)[0].geometry,
+    );
+  });
+
+  test('keeps every route on the feature, not just the searched one', () => {
+    // Arrange / Act
+    const props = propsOf(buildDiversionFeatures([event({ routes: ['172', '46'] })], true)[0]);
+
+    // Assert
+    expect(props.routes).toBe('46, 172');
+    expect(props.scoped).toBe(true);
+  });
+});
+
+describe('diversionPopupHtml', () => {
+  const propsFor = (over: Partial<DiversionEvent>, scoped: boolean): DiversionProps =>
+    propsOf(buildDiversionFeatures([event(over)], scoped)[0]);
+
+  test('names every affected route and disowns the shape when search drew it', () => {
+    // The geometry merges the bracket slices of every route on the event, so a
+    // popup opened from a search must not read as "your route goes this way".
+    // Arrange
+    const props = propsFor({ routes: ['46', '172'] }, true);
+
+    // Act
+    const html = diversionPopupHtml(props);
+
+    // Assert
+    expect(html).toContain('Affects routes 46, 172');
+    expect(html).toContain('not one route’s path');
+  });
+
+  test('says nothing about scope when the overlay drew it', () => {
+    // Arrange
+    const props = propsFor({ routes: ['46', '172'] }, false);
+
+    // Act
+    const html = diversionPopupHtml(props);
+
+    // Assert
+    expect(html).not.toContain('Affects routes');
+    expect(html).toContain('46, 172');
+  });
+});
+
+describe('the two inputs that decide what is drawn', () => {
+  /** Enough of a MapLibre map for the layer's own calls, recording every write. */
+  function fakeMap() {
+    const painted: GeoJSON.FeatureCollection[] = [];
+    const layerIds = new Set<string>();
+    const specs: { id: string; filter?: unknown }[] = [];
+    const visibility = new Map<string, string>();
+    const filters: unknown[] = [];
+    const paints: string[] = [];
+    const map = {
+      addSource: () => {},
+      addLayer: (layer: { id: string; filter?: unknown }) => {
+        layerIds.add(layer.id);
+        specs.push(layer);
+      },
+      getLayer: (id: string) => (layerIds.has(id) ? { id } : undefined),
+      getSource: () => ({ setData: (data: GeoJSON.FeatureCollection) => painted.push(data) }),
+      setLayoutProperty: (id: string, _prop: string, value: string) => visibility.set(id, value),
+      setFilter: (_id: string, filter: unknown) => filters.push(filter),
+      setPaintProperty: (_id: string, prop: string) => paints.push(prop),
+      getCanvas: () => ({ style: {} }),
+      on: () => {},
+    };
+    return { map: map as unknown as MaplibreMap, painted, visibility, filters, paints, specs };
+  }
+
+  const body = (events: DiversionEvent[]) => ({ ok: true, json: async () => ({ events }) });
+
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  /** Module state (overlay, selection, cached events) outlives one test. */
+  async function freshModule(): Promise<typeof import('./diversions')> {
+    vi.resetModules();
+    registeredHooks = [];
+    registerPoll.mockClear();
+    return await import('./diversions');
+  }
+
+  /** buses.ts hands hooks the map; searched-lines.ts ignores it. */
+  function search(lines: readonly string[] | null): void {
+    const selection = lines === null ? null : new Set(lines);
+    for (const hook of registeredHooks) hook({} as MaplibreMap, selection);
+  }
+
+  const EVENTS = [
+    event({ id: 'wanted', routes: ['46'] }),
+    event({ id: 'lookalike', routes: ['146'] }),
+    event({ id: 'other', routes: ['12'] }),
+  ];
+
+  const drawnRoutes = (fc: GeoJSON.FeatureCollection): string[] =>
+    fc.features.map((f) => propsOf(f).routes);
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    fetchSpy = vi.fn(async () => body(EVENTS));
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  test('overlay off and nothing searched: hidden, and ZERO fetches', async () => {
+    // Arrange / Act — the overlay ships off and no line is searched.
+    const { map, visibility } = fakeMap();
+    const { startDiversions } = await freshModule();
+    await startDiversions(map);
+
+    // Assert
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(visibility.get(DIVERSIONS_SEGMENTS_LAYER_ID)).toBe('none');
+
+    // And the registered poller stays silent too, tick after tick.
+    const tick = registerPoll.mock.calls[0]?.[0] as () => void;
+    tick();
+    await Promise.resolve();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  test('overlay off and a line searched: only that line’s events, from one fetch', async () => {
+    // Arrange
+    const { map, painted, visibility } = fakeMap();
+    const { startDiversions } = await freshModule();
+    await startDiversions(map);
+
+    // Act
+    search(['46']);
+
+    // Assert — 146 is a different road and must not ride along.
+    await vi.waitFor(() => expect(drawnRoutes(painted.at(-1)!)).toEqual(['46']));
+    expect(visibility.get(DIVERSIONS_SEGMENTS_LAYER_ID)).toBe('visible');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith('/api/diversions');
+  });
+
+  test('overlay on: every event, searched line or not', async () => {
+    // Arrange
+    const { map, painted } = fakeMap();
+    const { startDiversions, setDiversionsVisible } = await freshModule();
+    await startDiversions(map);
+
+    // Act
+    setDiversionsVisible(map, true);
+    await vi.waitFor(() => expect(drawnRoutes(painted.at(-1)!)).toEqual(['46', '146', '12']));
+
+    // Assert — a search must not narrow what the toggle already asked for.
+    search(['46']);
+    expect(drawnRoutes(painted.at(-1)!)).toEqual(['46', '146', '12']);
+  });
+
+  test('turning the overlay off mid-search falls back to the searched line', async () => {
+    // Arrange
+    const { map, painted, visibility } = fakeMap();
+    const { startDiversions, setDiversionsVisible } = await freshModule();
+    await startDiversions(map);
+    setDiversionsVisible(map, true);
+    await vi.waitFor(() => expect(painted.at(-1)!.features).toHaveLength(3));
+    search(['46']);
+
+    // Act
+    setDiversionsVisible(map, false);
+
+    // Assert — still on screen, now scoped, and no refetch was needed.
+    expect(drawnRoutes(painted.at(-1)!)).toEqual(['46']);
+    expect(visibility.get(DIVERSIONS_SEGMENTS_LAYER_ID)).toBe('visible');
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('clearing the search with the overlay off empties and hides the layer', async () => {
+    // Arrange
+    const { map, painted, visibility } = fakeMap();
+    const { startDiversions } = await freshModule();
+    await startDiversions(map);
+    search(['46']);
+    await vi.waitFor(() => expect(painted.at(-1)!.features).toHaveLength(1));
+
+    // Act
+    search(null);
+
+    // Assert
+    expect(painted.at(-1)!.features).toEqual([]);
+    expect(visibility.get(DIVERSIONS_SEGMENTS_LAYER_ID)).toBe('none');
+
+    // And it is back to costing nothing.
+    const tick = registerPoll.mock.calls[0]?.[0] as () => void;
+    tick();
+    await Promise.resolve();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('a rider already searching when the layer starts gets one fetch, not two', async () => {
+    // Arrange — subscribing replays the current selection synchronously, and
+    // the awaited start-up poll must stay the only request that follows.
+    const { map } = fakeMap();
+    const { startDiversions } = await freshModule();
+    await startDiversions(map);
+    search(['46']);
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+    // Act — a second layer start with the selection already live.
+    const second = fakeMap();
+    await startDiversions(second.map);
+
+    // Assert
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(drawnRoutes(second.painted.at(-1)!)).toEqual(['46']);
+  });
+
+  test('scopes in JS only — never a map filter, never a repaint', async () => {
+    // A MapLibre filter would see `routes` already joined into one string and
+    // substring-match; and the styling must be identical in both modes.
+    // Arrange
+    const { map, filters, paints, specs } = fakeMap();
+    const { startDiversions, setDiversionsVisible } = await freshModule();
+    await startDiversions(map);
+
+    // Act
+    search(['46']);
+    setDiversionsVisible(map, true);
+    setDiversionsVisible(map, false);
+
+    // Assert
+    expect(filters).toEqual([]);
+    expect(paints).toEqual([]);
+    expect(JSON.stringify(specs[0]?.filter)).not.toContain('routes');
   });
 });

--- a/frontend/src/layers/diversions.test.ts
+++ b/frontend/src/layers/diversions.test.ts
@@ -232,6 +232,7 @@ describe('the two inputs that decide what is drawn', () => {
   const body = (events: DiversionEvent[]) => ({ ok: true, json: async () => ({ events }) });
 
   let fetchSpy: ReturnType<typeof vi.fn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
 
   /** Module state (overlay, selection, cached events) outlives one test. */
   async function freshModule(): Promise<typeof import('./diversions')> {
@@ -258,6 +259,7 @@ describe('the two inputs that decide what is drawn', () => {
 
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     fetchSpy = vi.fn(async () => body(EVENTS));
     vi.stubGlobal('fetch', fetchSpy);
   });
@@ -390,5 +392,132 @@ describe('the two inputs that decide what is drawn', () => {
     expect(filters).toEqual([]);
     expect(paints).toEqual([]);
     expect(JSON.stringify(specs[0]?.filter)).not.toContain('routes');
+  });
+  // ── a failed fetch must never read as "your route is clear" ──
+  // The layer keeps the last picture on a failure, which is right once there IS
+  // one. Before the first good payload there is not: the scoped list is empty
+  // and the map looks exactly like a route with no diversion on it. These pin
+  // the two things that separate the cases — a loud, contextual log, and a
+  // bounded fast retry so the blank window is seconds rather than an interval.
+
+  test('a failed first poll says so loudly, naming what asked for the data', async () => {
+    // Arrange — the rider is searching and the very first fetch fails, so there
+    // is no previous picture to fall back on.
+    const { map, painted } = fakeMap();
+    fetchSpy.mockRejectedValue(new Error('offline'));
+    const { startDiversions, diversionsStats } = await freshModule();
+    await startDiversions(map);
+
+    // Act
+    search(['46']);
+    await vi.waitFor(() => expect(diversionsStats().pollFailures).toBeGreaterThan(0));
+
+    // Assert — console.error (not warn), and the line says which line was typed
+    // and that nothing has ever been received.
+    const line = String(errorSpy.mock.calls.at(-1)?.[0]);
+    expect(line).toContain('[diversions]');
+    expect(line).toContain('46');
+    expect(line).toContain('NO payload');
+    expect(diversionsStats().lastGoodFetchAt).toBe(0);
+    expect(diversionsStats().lastPollError).toBe('offline');
+    expect(painted.at(-1)?.features ?? []).toEqual([]);
+  });
+
+  test('retries within seconds while it has never held a payload', async () => {
+    vi.useFakeTimers();
+    try {
+      // Arrange — first fetch fails, the next one would succeed.
+      const { map, painted } = fakeMap();
+      fetchSpy.mockRejectedValueOnce(new Error('offline'));
+      const { startDiversions, DIVERSIONS_COLD_RETRY_MS } = await freshModule();
+      await startDiversions(map);
+
+      // Act
+      search(['46']);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(painted.at(-1)?.features ?? []).toEqual([]);
+      await vi.advanceTimersByTimeAsync(DIVERSIONS_COLD_RETRY_MS);
+
+      // Assert — the searched line's diversion is on screen long before the
+      // 90 s poll would have come round.
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(drawnRoutes(painted.at(-1)!)).toEqual(['46']);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('gives up fast-retrying after the bounded limit', async () => {
+    vi.useFakeTimers();
+    try {
+      // Arrange — everything fails, forever.
+      const { map } = fakeMap();
+      fetchSpy.mockRejectedValue(new Error('offline'));
+      const { startDiversions, DIVERSIONS_COLD_RETRY_MS, DIVERSIONS_COLD_RETRY_LIMIT } =
+        await freshModule();
+      await startDiversions(map);
+
+      // Act
+      search(['46']);
+      await vi.advanceTimersByTimeAsync(DIVERSIONS_COLD_RETRY_MS * (DIVERSIONS_COLD_RETRY_LIMIT + 4));
+
+      // Assert — the opening attempt plus the bounded retries, and no more:
+      // the 90 s poller carries it from here.
+      expect(fetchSpy).toHaveBeenCalledTimes(DIVERSIONS_COLD_RETRY_LIMIT + 1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('a failure AFTER a good payload keeps that picture and does not fast-retry', async () => {
+    vi.useFakeTimers();
+    try {
+      // Arrange — one good fetch, so there is a last picture worth keeping.
+      const { map, painted } = fakeMap();
+      const { startDiversions, DIVERSIONS_COLD_RETRY_MS, diversionsStats } = await freshModule();
+      await startDiversions(map);
+      search(['46']);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(drawnRoutes(painted.at(-1)!)).toEqual(['46']);
+
+      // Act — the next scheduled poll fails.
+      fetchSpy.mockRejectedValueOnce(new Error('blip'));
+      const tick = registerPoll.mock.calls[0]?.[0] as () => void;
+      tick();
+      await vi.advanceTimersByTimeAsync(DIVERSIONS_COLD_RETRY_MS * 3);
+
+      // Assert — no extra requests beyond that failed tick, the picture stands,
+      // and the log says what is still on screen rather than claiming nothing.
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(drawnRoutes(painted.at(-1)!)).toEqual(['46']);
+      expect(diversionsStats().lastGoodFetchAt).toBeGreaterThan(0);
+      expect(String(errorSpy.mock.calls.at(-1)?.[0])).toContain('last good fetch');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test('a cold retry that lands after the search is cleared fetches nothing', async () => {
+    vi.useFakeTimers();
+    try {
+      // Arrange
+      const { map } = fakeMap();
+      fetchSpy.mockRejectedValue(new Error('offline'));
+      const { startDiversions, DIVERSIONS_COLD_RETRY_MS } = await freshModule();
+      await startDiversions(map);
+      search(['46']);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // Act — the rider clears the box before the retry is due.
+      search(null);
+      await vi.advanceTimersByTimeAsync(DIVERSIONS_COLD_RETRY_MS * 3);
+
+      // Assert — the gate still holds: nothing on screen, nothing fetched.
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/layers/diversions.ts
+++ b/frontend/src/layers/diversions.ts
@@ -1,11 +1,23 @@
 // Live bus-diversion events from the detector (/api/diversions). Each event's
 // bypassed learned-polyline slices draw as a translucent highlighter band
-// (no separate centroid marker — the wide band itself is the click target). The API returns only display-worthy
-// events — the frontend renders exactly what it is given, no filtering.
+// (no separate centroid marker — the wide band itself is the click target).
 //
-// Polling is gated on the overlay toggle (default OFF): the detector output
-// only changes every rollup pass, so a hidden overlay polling anyway would be
-// pure egress waste. Re-enabling refreshes immediately since the last picture
+// TWO ways in, one picture. The Diversions overlay toggle (default OFF) shows
+// every event the API returned; searching a bus line in the Filter tab shows,
+// with the toggle still off, only the events serving that line — see the
+// display coordinator below for the truth table. Search changes WHICH events
+// are drawn and nothing else: same colours, same widths, same popup, so a
+// diversion looks the same however it got on screen.
+//
+// The API still decides what is display-worthy at all, and search does NOT
+// lower that bar: a diversion corroborated by a single vehicle stays hidden
+// here too (DISPLAY_MIN_VEHICLES in backend/src/diversion-events.ts). Search is
+// where the rider is paying most attention, which is the worst place to spend a
+// false positive.
+//
+// Polling is gated on that same pair: the detector output only changes every
+// rollup pass, so a layer nobody is looking at polling anyway would be pure
+// egress waste. Becoming active refreshes immediately since the last picture
 // may be a whole off-interval stale.
 
 import {
@@ -17,6 +29,7 @@ import {
 } from 'maplibre-gl';
 import { registerPoll } from '../util/lifecycle';
 import { below } from '../util/layer-order';
+import { matchesSearch, onSearchedLines } from './searched-lines';
 
 export const DIVERSIONS_SEGMENTS_LAYER_ID = 'diversions-segments';
 export const DIVERSIONS_LAYER_IDS = [DIVERSIONS_SEGMENTS_LAYER_ID];
@@ -48,7 +61,7 @@ const STATUS_OPACITY: ExpressionSpecification =
 
 type LngLat = [number, number];
 
-interface DiversionEvent {
+export interface DiversionEvent {
   id?: string;
   status?: 'active' | 'recovering' | 'stale';
   severity?: 'road' | 'partial';
@@ -69,7 +82,7 @@ interface DiversionsResponse {
 
 /** Flat because maplibre JSON-round-trips feature properties; a nested `tfl`
  * object would come back out of queryRenderedFeatures as a string. */
-interface DiversionProps {
+export interface DiversionProps {
   routes: string;
   vehicles: number;
   status: string;
@@ -80,6 +93,9 @@ interface DiversionProps {
   hasTfl: boolean;
   tflLoc: string;
   tflDist: number;
+  /** True when a line search, not the overlay toggle, put this on screen. Read
+   * by the popup only — nothing in the paint expressions touches it. */
+  scoped: boolean;
 }
 
 const esc = (s: string): string =>
@@ -94,7 +110,23 @@ function isLngLat(value: unknown): value is LngLat {
   );
 }
 
-function toProps(ev: DiversionEvent): DiversionProps {
+/**
+ * The events a search of `lines` surfaces.
+ *
+ * MATCHED IN JS, ON THE ARRAY, and it has to stay that way: `toProps` joins
+ * `routes` into one comma-separated STRING for MapLibre, so the equivalent map
+ * filter (`['in', '46', ['get', 'routes']]`) would substring-match and put 146,
+ * 460 and N46 on screen for a search of 46 — three different roads.
+ */
+export function eventsOnSearchedLines(
+  events: readonly DiversionEvent[],
+  lines: ReadonlySet<string> | null,
+): DiversionEvent[] {
+  if (!lines) return [];
+  return events.filter((ev) => (ev.routes ?? []).some((route) => matchesSearch(route, lines)));
+}
+
+function toProps(ev: DiversionEvent, scoped: boolean): DiversionProps {
   return {
     // Numeric-aware so "9" sorts before "10" and "N136" after "45" — the same
     // idiom as listActiveBusLines in layers/buses.ts.
@@ -110,12 +142,17 @@ function toProps(ev: DiversionEvent): DiversionProps {
     hasTfl: ev.tfl != null,
     tflLoc: ev.tfl?.loc ?? '',
     tflDist: ev.tfl?.dist ?? 0,
+    scoped,
   };
 }
 
-function toFeatures(events: DiversionEvent[]): GeoJSON.Feature[] {
+/** `scoped` only reaches the popup: the drawn shape is identical either way. */
+export function buildDiversionFeatures(
+  events: readonly DiversionEvent[],
+  scoped: boolean,
+): GeoJSON.Feature[] {
   return events.flatMap((ev) => {
-    const props = toProps(ev);
+    const props = toProps(ev, scoped);
     const features: GeoJSON.Feature[] = [];
     // One MultiLineString per event, not a feature per slice: the popup should
     // hit the whole event wherever it is clicked.
@@ -171,7 +208,19 @@ export function freshnessLabel(lastEvidenceAt: number, nowSec: number): string {
   return `last diverting bus ${hours} h ${mins % 60} min ago`;
 }
 
-function popupHtml(p: DiversionProps): string {
+/**
+ * A search surfaces this event because ONE of its routes matched, but the
+ * geometry is the union of the bracket slices of every high-confidence route on
+ * it — there is no per-route shape to draw. Left unsaid, the band would read as
+ * "your route now goes this way". So say what it actually is, and keep listing
+ * every affected route rather than just the one that was typed.
+ */
+function scopeNote(p: DiversionProps): string {
+  if (!p.scoped) return '';
+  return `<div class="vp-dim">Affects routes ${esc(p.routes)} — the band is the whole diversion, not one route’s path</div>`;
+}
+
+export function diversionPopupHtml(p: DiversionProps): string {
   // 'partial' softens everything: one direction of one route is diverting
   // while the road itself flows — "Diversion" + red would read as a closure.
   const partial = p.severity === 'partial';
@@ -188,6 +237,7 @@ function popupHtml(p: DiversionProps): string {
   return `<div class="vp"><div class="sp-title">${title} — ${esc(p.routes)}</div>
     <div>${esc(status)}${ongoing}</div>
     <div>since ${timeLabel(p.startedAt, p.longRunning)} · ${p.vehicles} vehicle${p.vehicles === 1 ? '' : 's'}</div>
+    ${scopeNote(p)}
     ${fresh === '' ? '' : `<div class="vp-dim">${fresh}</div>`}
     <div class="vp-dim">${tfl}</div></div>`;
 }
@@ -197,7 +247,7 @@ function wireInteractions(map: MaplibreMap, layerId: string): void {
   map.on('click', layerId, (e: MapLayerMouseEvent) => {
     const p = e.features?.[0]?.properties as DiversionProps | undefined;
     if (!p) return;
-    detail.setLngLat(e.lngLat).setHTML(popupHtml(p)).addTo(map);
+    detail.setLngLat(e.lngLat).setHTML(diversionPopupHtml(p)).addTo(map);
   });
   map.on('mouseenter', layerId, () => {
     map.getCanvas().style.cursor = 'pointer';
@@ -207,18 +257,64 @@ function wireInteractions(map: MaplibreMap, layerId: string): void {
   });
 }
 
+// ── diversion display coordinator ──
+// Two independent inputs decide what this layer shows, so they are resolved
+// together in one place rather than fighting over the same source:
+//   • the Diversions overlay toggle (Lines tab) — overlayOn
+//   • the bus line search (Filter tab)          — searchedSelection
+// Truth table:
+//   overlay ON,  no search → every event the API returned
+//   overlay ON,  search    → every event, unchanged: the toggle already asked
+//                            for all of them, and searching must not take any
+//                            away from a rider who is looking at the lot
+//   overlay OFF, search    → ONLY events serving a searched line, drawn exactly
+//                            as the toggle draws them
+//   overlay OFF, no search → nothing drawn, and ZERO fetches
+
 /** OFF by default, mirroring the legend row's startOff. */
 let overlayOn = false;
-/** Set by startDiversions so the toggle can force an immediate refresh. */
+/** The Filter tab's selection, or null when the rider is not searching. */
+let searchedSelection: ReadonlySet<string> | null = null;
+/** The resolved output of the truth table, kept as state because poll() reads
+ * it: while nothing is on screen, nothing is fetched. */
+let onScreen = false;
+/** The last events the API returned, so a filter change re-scopes the picture
+ * without spending a request on data we already hold. */
+let lastEvents: readonly DiversionEvent[] = [];
+/** Set by startDiversions so a newly-active input can force an immediate refresh. */
 let refresh: (() => void) | null = null;
 
-/** Legend toggle handler: visibility flip + poll gate. */
+/** Push the currently-drawable events to the source. With neither input active
+ * the scoped list is empty, so `scoped` never reaches a feature in that case. */
+function draw(map: MaplibreMap): void {
+  const src = map.getSource(SOURCE_ID);
+  if (!src || !('setData' in src)) return;
+  const events = overlayOn ? lastEvents : eventsOnSearchedLines(lastEvents, searchedSelection);
+  (src as GeoJSONSource).setData({
+    type: 'FeatureCollection',
+    features: buildDiversionFeatures(events, !overlayOn),
+  });
+}
+
+/** Recompute visibility, the poll gate and the drawn events from both inputs. */
+function applyDiversionDisplay(map: MaplibreMap): void {
+  const active = overlayOn || searchedSelection !== null;
+  // Coming back on, `lastEvents` holds whatever was true when we stopped
+  // fetching — possibly a whole off-interval stale — so refresh out of band
+  // rather than leaving that picture up until the next tick.
+  const resumed = active && !onScreen;
+  onScreen = active;
+  for (const id of DIVERSIONS_LAYER_IDS) {
+    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', active ? 'visible' : 'none');
+  }
+  draw(map);
+  if (resumed) refresh?.();
+}
+
+/** Legend toggle handler: one of the two inputs above. */
 export function setDiversionsVisible(map: MaplibreMap, visible: boolean): void {
   overlayOn = visible;
-  for (const id of DIVERSIONS_LAYER_IDS) {
-    if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', visible ? 'visible' : 'none');
-  }
-  if (visible) refresh?.();
+  applyDiversionDisplay(map);
 }
 
 export async function startDiversions(map: MaplibreMap): Promise<void> {
@@ -233,16 +329,19 @@ export async function startDiversions(map: MaplibreMap): Promise<void> {
   // One wide translucent band — no casing, no dashes: solid saturated lines
   // lose against a basemap full of them (a previous dashed-red pass read as
   // yet another line), while a broad ~30%-opacity wash over the road is a
-  // channel nothing else on the map uses. Since the overlay is opt-in
-  // (default off), subtle is a feature: you turned it on, you are looking
-  // for it.
+  // channel nothing else on the map uses. Since the layer only appears when
+  // asked for (toggle on, or the line searched), subtle is a feature: you went
+  // looking for it, so you know where to look.
+  //
+  // The only `filter` here is on geometry type. Scoping to a searched line is
+  // deliberately NOT expressible here — see eventsOnSearchedLines.
   map.addLayer(
     {
       id: DIVERSIONS_SEGMENTS_LAYER_ID,
       type: 'line',
       source: SOURCE_ID,
       filter: ['==', ['geometry-type'], 'LineString'],
-      // off by default; the legend toggle flips visibility on opt-in
+      // hidden until an input asks for it; applyDiversionDisplay flips this
       layout: { 'line-cap': 'round', 'line-join': 'round', visibility: 'none' },
       paint: {
         'line-color': STATUS_COLOR,
@@ -256,7 +355,7 @@ export async function startDiversions(map: MaplibreMap): Promise<void> {
   );
 
   async function poll(): Promise<void> {
-    if (!overlayOn) return;
+    if (!onScreen) return;
     try {
       const res = await fetch(DIVERSIONS_URL);
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -264,22 +363,27 @@ export async function startDiversions(map: MaplibreMap): Promise<void> {
       // A 200 from an intermediary (error page, captive portal) must not reach
       // setData; empty `events` is fine and clears the layer.
       if (!Array.isArray(body?.events)) throw new Error('unexpected diversions payload shape');
-      const src = map.getSource(SOURCE_ID);
-      if (src && 'setData' in src) {
-        (src as GeoJSONSource).setData({
-          type: 'FeatureCollection',
-          features: toFeatures(body.events),
-        });
-      }
+      lastEvents = body.events;
+      draw(map);
     } catch (error) {
       // Keep the last picture; the next poll retries.
       console.warn('[diversions]', error);
     }
   }
-  refresh = () => void poll();
 
   wireInteractions(map, DIVERSIONS_SEGMENTS_LAYER_ID);
 
+  // Subscribing delivers the CURRENT selection synchronously, so a rider who
+  // typed a line before this layer finished starting gets it resolved here
+  // rather than at their next keystroke. `refresh` is still null during that
+  // first delivery, so it cannot kick a request of its own — the awaited poll
+  // below stays the single start-up fetch.
+  onSearchedLines((lines) => {
+    searchedSelection = lines;
+    applyDiversionDisplay(map);
+  });
+
+  refresh = () => void poll();
   await poll();
   registerPoll(() => void poll(), POLL_INTERVAL_MS);
 }

--- a/frontend/src/layers/diversions.ts
+++ b/frontend/src/layers/diversions.ts
@@ -19,6 +19,16 @@
 // rollup pass, so a layer nobody is looking at polling anyway would be pure
 // egress waste. Becoming active refreshes immediately since the last picture
 // may be a whole off-interval stale.
+//
+// A FAILED FETCH IS NOT AN ALL-CLEAR. Keeping the last picture on a failure is
+// right once there is one; before the first good payload there is not, and an
+// empty scoped list draws exactly like a route with no diversion on it — the
+// false negative that mirrors the false positive the vehicle floor guards
+// against, and the worse of the two, because a rider walks toward a live
+// diversion believing the road is clear. Two things separate the cases: every
+// failure is a console.error naming what asked for the data and whether
+// anything has ever been received (noteFailure), and while nothing has, the
+// retry is seconds rather than a whole poll interval (scheduleColdRetry).
 
 import {
   Popup,
@@ -38,6 +48,13 @@ const SOURCE_ID = 'diversions';
 const DIVERSIONS_URL = '/api/diversions';
 /** The API caches for 60 s; 90 s keeps at most one wasted hit per fresh copy. */
 const POLL_INTERVAL_MS = 90_000;
+/** How soon a failed poll is retried while the layer has NEVER held a payload.
+ * Short because that whole window is a map that cannot say whether a searched
+ * route is clear; not shorter, because a hard outage must not be hammered. */
+export const DIVERSIONS_COLD_RETRY_MS = 5_000;
+/** Consecutive cold retries before falling back to the normal interval — an
+ * outage lasting past ~15 s is not a blip and the 90 s poller can carry it. */
+export const DIVERSIONS_COLD_RETRY_LIMIT = 3;
 
 /** Highlighter-band styling: the basemap is already saturated with coloured
  * transit lines, so competing on colour loses — instead the event is a WIDE,
@@ -257,6 +274,24 @@ function wireInteractions(map: MaplibreMap, layerId: string): void {
   });
 }
 
+// ── fetch health ──
+// Read with `lastEvents`, never apart from it: the pair is what separates "no
+// diversion on your route" from "we do not know yet".
+
+const stats = {
+  polls: 0,
+  pollFailures: 0,
+  lastPollError: '',
+  /** Epoch ms of the last poll that actually returned a payload; 0 = never. */
+  lastGoodFetchAt: 0,
+};
+
+/** Live counters for acceptance tooling and the console, as the stop-closure
+ * layer exposes its own. */
+export function diversionsStats(): typeof stats {
+  return stats;
+}
+
 // ── diversion display coordinator ──
 // Two independent inputs decide what this layer shows, so they are resolved
 // together in one place rather than fighting over the same source:
@@ -317,6 +352,33 @@ export function setDiversionsVisible(map: MaplibreMap, visible: boolean): void {
   applyDiversionDisplay(map);
 }
 
+/** Which input was asking for the data, for the failure log. A failure while a
+ * line is searched is the one that reads back to the rider as "your route is
+ * clear", so the log has to name the line. */
+function describeDemand(): string {
+  const searched = searchedSelection ? [...searchedSelection].join(', ') : '';
+  if (searched && overlayOn) return `overlay on, searching ${searched}`;
+  if (searched) return `searching ${searched}`;
+  if (overlayOn) return 'overlay on';
+  return 'nothing asked for it';
+}
+
+/**
+ * The one place a failed poll is recorded. console.error, not warn: main.ts
+ * already uses error for a layer that fails to deliver its capability, and this
+ * is that — with no payload in hand the layer is answering a search with a
+ * blank map it has no evidence for.
+ */
+function noteFailure(error: unknown): void {
+  stats.pollFailures += 1;
+  stats.lastPollError = error instanceof Error ? error.message : String(error);
+  const held =
+    stats.lastGoodFetchAt === 0
+      ? 'NO payload ever received — the map cannot say whether a route is clear'
+      : `keeping ${lastEvents.length} event(s) from the last good fetch`;
+  console.error(`[diversions] poll failed (${describeDemand()}); ${held}`, error);
+}
+
 export async function startDiversions(map: MaplibreMap): Promise<void> {
   map.addSource(SOURCE_ID, {
     type: 'geojson',
@@ -354,6 +416,25 @@ export async function startDiversions(map: MaplibreMap): Promise<void> {
     below(map, 'stations-circle'),
   );
 
+  /** Consecutive fast retries spent since the layer last held a payload. */
+  let coldRetries = 0;
+
+  /**
+   * A failure with nothing ever received leaves a blank map that a searching
+   * rider reads as "clear", so waiting out the 90 s interval is the wrong
+   * trade — try again in seconds. Bounded, and only while `lastGoodFetchAt` is
+   * still 0: once there IS a last picture, keeping it until the next scheduled
+   * poll is honest and a retry would only add load to a struggling origin.
+   */
+  function scheduleColdRetry(): void {
+    if (stats.lastGoodFetchAt !== 0) return;
+    if (coldRetries >= DIVERSIONS_COLD_RETRY_LIMIT) return;
+    coldRetries += 1;
+    // The retry re-enters poll(), which re-checks `onScreen`, so a rider who
+    // clears the box in the meantime costs nothing.
+    setTimeout(() => void poll(), DIVERSIONS_COLD_RETRY_MS);
+  }
+
   async function poll(): Promise<void> {
     if (!onScreen) return;
     try {
@@ -364,10 +445,15 @@ export async function startDiversions(map: MaplibreMap): Promise<void> {
       // setData; empty `events` is fine and clears the layer.
       if (!Array.isArray(body?.events)) throw new Error('unexpected diversions payload shape');
       lastEvents = body.events;
+      stats.polls += 1;
+      stats.lastGoodFetchAt = Date.now();
+      stats.lastPollError = '';
       draw(map);
     } catch (error) {
-      // Keep the last picture; the next poll retries.
-      console.warn('[diversions]', error);
+      // Keep the last picture — but never silently: an outage and a genuine
+      // all-clear must not read the same.
+      noteFailure(error);
+      scheduleColdRetry();
     }
   }
 

--- a/frontend/src/layers/searched-lines.test.ts
+++ b/frontend/src/layers/searched-lines.test.ts
@@ -1,0 +1,278 @@
+// Unit tests for the shared bus-line search selection: the matching rule that
+// every search-scoped layer compares route labels with, and the fan-out that
+// keeps N layers down to ONE hook on buses.ts.
+//
+// ./buses is mocked wholesale — it value-imports maplibre-gl (Popup), and
+// setBusRouteShapeHook is precisely the seam under test: capturing what gets
+// registered is how "one hook regardless of subscriber count" is pinned, and
+// calling it back is how a filter change is simulated.
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { Map as MaplibreMap } from 'maplibre-gl';
+
+type RouteShapeHook = (map: MaplibreMap, lines: ReadonlySet<string> | null) => void | Promise<void>;
+
+/** Every hook the module under test registered on buses.ts, this test run. */
+let registeredHooks: readonly RouteShapeHook[] = [];
+
+vi.mock('./buses', () => ({
+  setBusRouteShapeHook: (hook: RouteShapeHook) => {
+    registeredHooks = [...registeredHooks, hook];
+  },
+}));
+
+/** The listener list, the latest selection and "have we hooked yet" are module
+ * state that outlives a single test, so every test drives a fresh copy. */
+async function freshModule(): Promise<typeof import('./searched-lines')> {
+  vi.resetModules();
+  registeredHooks = [];
+  return await import('./searched-lines');
+}
+
+/** buses.ts hands hooks the map; this module ignores it, so a bare object does. */
+const fakeMap = {} as MaplibreMap;
+
+/** Simulate a real filter change: buses.ts calls every registered hook. */
+function fireFilterChange(lines: ReadonlySet<string> | null): void {
+  for (const hook of registeredHooks) hook(fakeMap, lines);
+}
+
+/** Let an async listener's rejection settle and its containment run. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+beforeEach(() => {
+  // The containment path logs; keep the expected warnings out of the run.
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('matchesSearch', () => {
+  test('matches case-insensitively in both directions', async () => {
+    // Arrange
+    const { matchesSearch } = await freshModule();
+
+    // Act
+    const lowerLabel = matchesSearch('n1', new Set(['N1']));
+    const upperLabel = matchesSearch('N1', new Set(['n1']));
+
+    // Assert
+    expect(lowerLabel).toBe(true);
+    expect(upperLabel).toBe(true);
+  });
+
+  test('ignores a destination suffix on a diversion route label', async () => {
+    // Arrange
+    const { matchesSearch } = await freshModule();
+
+    // Act
+    const matched = matchesSearch('SL8 → Uxbridge', new Set(['SL8']));
+
+    // Assert
+    expect(matched).toBe(true);
+  });
+
+  test('never folds a zero-padded route into its unpadded twin', async () => {
+    // Arrange — 025 (National Express) and 25 (a London bus) are both real and
+    // are different roads; folding them would show a rider the wrong one.
+    const { matchesSearch } = await freshModule();
+
+    // Act
+    const paddedLabelUnpaddedSearch = matchesSearch('025', new Set(['25']));
+    const unpaddedLabelPaddedSearch = matchesSearch('25', new Set(['025']));
+    const exact = matchesSearch('025', new Set(['025']));
+
+    // Assert
+    expect(paddedLabelUnpaddedSearch).toBe(false);
+    expect(unpaddedLabelPaddedSearch).toBe(false);
+    expect(exact).toBe(true);
+  });
+
+  test('matches nothing for an empty or whitespace-only label', async () => {
+    // Arrange
+    const { matchesSearch } = await freshModule();
+
+    // Act
+    const empty = matchesSearch('', new Set(['25']));
+    const blank = matchesSearch('   ', new Set(['25']));
+    const emptyAgainstEmpty = matchesSearch('', new Set(['']));
+
+    // Assert
+    expect(empty).toBe(false);
+    expect(blank).toBe(false);
+    expect(emptyAgainstEmpty).toBe(false);
+  });
+
+  test('trims surrounding whitespace around a real label', async () => {
+    // Arrange
+    const { matchesSearch } = await freshModule();
+
+    // Act
+    const matched = matchesSearch('  24  ', new Set(['24']));
+
+    // Assert
+    expect(matched).toBe(true);
+  });
+
+  test('matches nothing when nothing is searched for', async () => {
+    // Arrange
+    const { matchesSearch } = await freshModule();
+
+    // Act
+    const noSelection = matchesSearch('24', null);
+    const emptySelection = matchesSearch('24', new Set<string>());
+
+    // Assert
+    expect(noSelection).toBe(false);
+    expect(emptySelection).toBe(false);
+  });
+});
+
+describe('onSearchedLines', () => {
+  test('publishes the current selection to a late subscriber', async () => {
+    // Arrange — the filter changed BEFORE this layer started.
+    const { onSearchedLines } = await freshModule();
+    onSearchedLines(() => {});
+    fireFilterChange(new Set(['24']));
+    const late = vi.fn();
+
+    // Act
+    onSearchedLines(late);
+
+    // Assert
+    expect(late).toHaveBeenCalledTimes(1);
+    expect(late).toHaveBeenCalledWith(new Set(['24']));
+  });
+
+  test('publishes null to a subscriber that starts before any search', async () => {
+    // Arrange
+    const { onSearchedLines } = await freshModule();
+    const listener = vi.fn();
+
+    // Act
+    onSearchedLines(listener);
+
+    // Assert
+    expect(listener).toHaveBeenCalledWith(null);
+  });
+
+  test('delivers one change to every subscriber', async () => {
+    // Arrange
+    const { onSearchedLines } = await freshModule();
+    const first = vi.fn();
+    const second = vi.fn();
+    onSearchedLines(first);
+    onSearchedLines(second);
+
+    // Act
+    fireFilterChange(new Set(['N1']));
+
+    // Assert — the immediate publish on subscribe, then the change.
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+    expect(first).toHaveBeenLastCalledWith(new Set(['N1']));
+    expect(second).toHaveBeenLastCalledWith(new Set(['N1']));
+  });
+
+  test('stops delivering after unsubscribe', async () => {
+    // Arrange
+    const { onSearchedLines } = await freshModule();
+    const dropped = vi.fn();
+    const kept = vi.fn();
+    const unsubscribe = onSearchedLines(dropped);
+    onSearchedLines(kept);
+
+    // Act
+    unsubscribe();
+    fireFilterChange(new Set(['24']));
+
+    // Assert
+    expect(dropped).toHaveBeenCalledTimes(1); // the subscribe-time publish only
+    expect(kept).toHaveBeenCalledTimes(2);
+  });
+
+  test('registers exactly one buses.ts hook however many subscribe', async () => {
+    // Arrange
+    const { onSearchedLines, searchedLines } = await freshModule();
+
+    // Act
+    onSearchedLines(() => {});
+    onSearchedLines(() => {});
+    onSearchedLines(() => {});
+    searchedLines();
+
+    // Assert
+    expect(registeredHooks).toHaveLength(1);
+  });
+
+  test('a throwing listener does not stop the ones behind it', async () => {
+    // Arrange
+    const { onSearchedLines } = await freshModule();
+    const behind = vi.fn();
+    onSearchedLines(() => {
+      throw new Error('listener blew up');
+    });
+    onSearchedLines(behind);
+
+    // Act
+    fireFilterChange(new Set(['24']));
+
+    // Assert
+    expect(behind).toHaveBeenLastCalledWith(new Set(['24']));
+  });
+
+  test('a rejecting async listener does not surface an unhandled rejection', async () => {
+    // Arrange
+    const { onSearchedLines } = await freshModule();
+    const behind = vi.fn();
+    onSearchedLines(async () => {
+      await Promise.reject(new Error('fetch failed'));
+    });
+    onSearchedLines(behind);
+
+    // Act
+    fireFilterChange(new Set(['24']));
+    await flushMicrotasks();
+
+    // Assert
+    expect(behind).toHaveBeenLastCalledWith(new Set(['24']));
+    expect(console.warn).toHaveBeenCalled();
+  });
+});
+
+describe('searchedLines', () => {
+  test('reports the latest selection', async () => {
+    // Arrange
+    const { onSearchedLines, searchedLines } = await freshModule();
+    onSearchedLines(() => {});
+
+    // Act
+    fireFilterChange(new Set(['24', 'N1']));
+
+    // Assert
+    expect(searchedLines()).toEqual(new Set(['24', 'N1']));
+  });
+
+  test('reports null for a cleared filter and for an empty selection', async () => {
+    // Arrange
+    const { onSearchedLines, searchedLines } = await freshModule();
+    const listener = vi.fn();
+    onSearchedLines(listener);
+    fireFilterChange(new Set(['24']));
+
+    // Act
+    fireFilterChange(new Set<string>());
+    const afterEmpty = searchedLines();
+    fireFilterChange(null);
+
+    // Assert — an empty set is normalised away, so `if (!lines)` is complete.
+    expect(afterEmpty).toBe(null);
+    expect(searchedLines()).toBe(null);
+    expect(listener).toHaveBeenLastCalledWith(null);
+  });
+});

--- a/frontend/src/layers/searched-lines.ts
+++ b/frontend/src/layers/searched-lines.ts
@@ -1,0 +1,162 @@
+// One subscription to "which bus lines is the rider searching for?", shared by
+// every layer that scopes itself to the Filter tab's selection.
+//
+// buses.ts fires setBusRouteShapeHook on a REAL filter change only. Two things
+// follow, and this module exists to handle both once instead of in every layer:
+//
+//   • ONE hook, many listeners. The hook list tolerates several registrants
+//     (buses.ts:316-321), but a layer that registers its own has no way to learn
+//     what the selection ALREADY is, and every extra hook is another thing
+//     buses.ts must contain on each change. So exactly one hook is registered
+//     here, ever, and fanned out from there.
+//   • LATE SUBSCRIBERS ARE PUBLISHED TO. "On change only" means a layer whose
+//     start() resolves after the rider has already typed would otherwise sit
+//     blank until the next keystroke. Subscribing hands you the current value
+//     immediately, so a listener never has to ask how it got there.
+//
+// ── THE MATCHING RULE — derived from live data. Do not "improve" it. ──
+//
+// Both name spaces are BODS `PublishedLineName` (backend/src/bods-client.ts:95),
+// so a route label needs no normalisation beyond these four steps:
+//
+//   1. Strip a destination suffix. diversion-events.ts:206 labels a diverting
+//      route `${line} → ${dest}` when the majority destination sign is known
+//      ("SL8 → Uxbridge"), and the bare line when it is not. The live feed and
+//      the closure feed never carry one.
+//   2. Compare case-folded and EXACT. BODS ships mixed case in the wild ("Go2",
+//      "x80", "N1"), so "n1" typed by the rider must match "N1" on the wire.
+//   3. NEVER strip leading zeros and NEVER compare numerically. A zero-padded
+//      route and its unpadded namesake are DIFFERENT ROADS. Measured today,
+//      seven padded routes are live and every one has an unpadded twin run by a
+//      different operator — 007/7, 022/22, 025/25, 030/30, 032/32, 035/35 and
+//      040/40. All seven padded ones are National Express and NOTHING else
+//      (NATX_0xx in the learned index); every unpadded twin is served by TFLO,
+//      a London bus. The same seven, and only those seven, appear in the
+//      diversion archive too, so the two feeds agree exactly and neither needs
+//      padding-tolerant matching. Reproduce with:
+//        ls data/bus-routes/learned | sed -E 's/\.json$//; s/^[A-Za-z0-9]+_//; s/_[a-z]+$//' | sort -u | grep -E '^0[0-9]+$'
+//        cat ~/bus-archive/diversions/*.jsonl | grep -o '"routes":\[[^]]*\]' | grep -oE '"0[0-9]+"' | sort -u
+//      Folding 025 into 25 would put a rider on the wrong road.
+//   4. Trim surrounding whitespace; an empty label matches nothing.
+
+import { setBusRouteShapeHook } from './buses';
+
+/** Separator diversion-events.ts puts between a line and its destination sign.
+ * Matched on the arrow alone rather than " → " because step 4's trim absorbs
+ * the spaces either way, and an arrow never occurs inside a PublishedLineName. */
+const DESTINATION_SEPARATOR = '→';
+
+/**
+ * Handed the new selection on every real filter change, and once on subscribing.
+ * `Promise<void>` is spelled out because a listener that fetches is expected
+ * (the stop-closure scope does) and TypeScript would silently accept an async
+ * one against a `=> void` slot — saying so is what makes the rejection handling
+ * in `callListener` part of the contract instead of an accident.
+ */
+export type SearchedLinesListener = (lines: ReadonlySet<string> | null) => void | Promise<void>;
+
+/** Drops a listener registered with onSearchedLines. Idempotent. */
+export type Unsubscribe = () => void;
+
+let listeners: readonly SearchedLinesListener[] = [];
+
+/** The latest selection, already normalised: never an empty set. */
+let selection: ReadonlySet<string> | null = null;
+
+let hookRegistered = false;
+
+/** An empty selection is no selection. Normalising here means `searchedLines()`
+ * never returns an empty set, so a consumer's `if (!lines)` is a complete test
+ * for "the rider is not searching" and cannot miss the empty-set case. */
+function normalizeSelection(lines: ReadonlySet<string> | null): ReadonlySet<string> | null {
+  if (!lines || lines.size === 0) return null;
+  return lines;
+}
+
+function logListenerFailure(index: number, error: unknown): void {
+  console.warn(`[searched-lines] listener ${index} failed`, error);
+}
+
+/** True for anything with a `.then` — an async listener's return value. */
+function isThenable(value: void | Promise<void>): value is Promise<void> {
+  return typeof (value as Promise<void> | undefined)?.then === 'function';
+}
+
+/**
+ * Calls one listener, contained. Two containments, because there are two ways to
+ * fail: a synchronous throw lands in the catch, while an async listener throws
+ * nothing here at all and instead returns a rejected promise that would sail
+ * past into an unhandled rejection. Neither may take down the listeners behind
+ * it — the same containment buses.ts applies to its own hooks.
+ *
+ * The rejection is observed, never awaited: a listener must reach the map in the
+ * same turn as the filter change, and a slow one must not hold up the rest.
+ */
+function callListener(listener: SearchedLinesListener, index: number): void {
+  try {
+    const result = listener(selection);
+    if (isThenable(result)) result.catch((error: unknown) => logListenerFailure(index, error));
+  } catch (error) {
+    logListenerFailure(index, error);
+  }
+}
+
+/** Registers the single buses.ts hook, on first use of this module. */
+function ensureRouteShapeHook(): void {
+  if (hookRegistered) return;
+  // Set before registering, so a listener that subscribes from inside the very
+  // first delivery cannot register a second hook.
+  hookRegistered = true;
+  setBusRouteShapeHook((_map, lines) => publish(lines));
+}
+
+/** Fan a new selection out to every listener. */
+function publish(lines: ReadonlySet<string> | null): void {
+  selection = normalizeSelection(lines);
+  // forEach walks the array captured now; a listener that unsubscribes mid-fanout
+  // replaces `listeners` rather than mutating it, so this pass stays intact.
+  listeners.forEach(callListener);
+}
+
+/**
+ * Subscribe to the searched lines. The listener is called immediately with the
+ * current selection, then on every real filter change. Returns an unsubscribe.
+ */
+export function onSearchedLines(listener: SearchedLinesListener): Unsubscribe {
+  ensureRouteShapeHook();
+  const index = listeners.length;
+  listeners = [...listeners, listener];
+  callListener(listener, index);
+  return () => {
+    listeners = listeners.filter((registered) => registered !== listener);
+  };
+}
+
+/** The lines currently searched for, or null when the rider is not searching. */
+export function searchedLines(): ReadonlySet<string> | null {
+  ensureRouteShapeHook();
+  return selection;
+}
+
+/** The comparable form of a route label: destination dropped, trimmed, folded. */
+function foldLabel(label: string): string {
+  const arrow = label.indexOf(DESTINATION_SEPARATOR);
+  const line = arrow === -1 ? label : label.slice(0, arrow);
+  return line.trim().toLowerCase();
+}
+
+/**
+ * Does `routeLabel` — a line from a diversion event or a closed stop — belong to
+ * the searched set? See THE MATCHING RULE at the top of this file.
+ */
+export function matchesSearch(routeLabel: string, lines: ReadonlySet<string> | null): boolean {
+  if (!lines || lines.size === 0) return false;
+  // Feed payloads are external data: a malformed `routes` entry must not throw.
+  if (typeof routeLabel !== 'string') return false;
+  const wanted = foldLabel(routeLabel);
+  if (wanted === '') return false;
+  for (const line of lines) {
+    if (foldLabel(line) === wanted) return true;
+  }
+  return false;
+}

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -537,8 +537,11 @@ async function addTransitOverlays(target: maplibregl.Map): Promise<void> {
       overlay: {
         // Default OFF (user call after a live-map session): the base map is
         // already dense with coloured lines, so this ships as an opt-in tool
-        // layer. The custom handler gates the 90 s poll on the toggle, so
-        // while hidden it also costs zero fetches.
+        // layer. The toggle is no longer its only way on screen though —
+        // searching a bus line in the Filter tab draws that line's diversions
+        // with this still off — so the 90 s poll is gated on "toggled on OR a
+        // line searched", and it is hidden AND unsearched that costs zero
+        // fetches. See the truth table in layers/diversions.ts.
         label: 'Diversions',
         layerIds: DIVERSIONS_LAYER_IDS,
         startOff: true,


### PR DESCRIPTION
## What this adds

Searching a bus route already highlights its vehicles and draws its learned polyline with every overlay off. The same search now also surfaces, for that route only:

- the **TfL stop closures** on it
- the **diversions** detected on it

Styling is unchanged — search decides *which* features exist, never how they look, so the same closed stop looks identical however it got on screen.

## The truth table, written out in both layers

| overlay | search | drawn | fetches |
|---|---|---|---|
| ON | — | everything, as before | yes |
| ON | active | **still everything** — "show me all of it" must not be narrowed by a search | yes |
| OFF | active | only features serving a searched line | yes |
| OFF | — | nothing, sources released | **zero** |

Row 4 is the invariant most likely to be broken later, so it is pinned by tests in both layers and was verified by driving the real modules with a fetch spy: neither input active ⇒ 0 calls after invoking all three pollers by hand.

## The three hazards, and what was done about them

**1. The substring trap.** `toProps` joins `ev.routes` into a comma-separated string before it reaches MapLibre properties, so a `['in', '46', ['get','routes']]` filter would have matched `146`, `460` and `N46`. The route filter runs in JS inside `toFeatures`, where `ev.routes` is still an array. Verified live: searching `46` with the overlay off drew 3 stops, and the 6 closed stops serving `146`/`460`/`N46`/`46A` were **not** drawn.

**2. Zero padding.** Measured on the live feed: `025` is National Express, 3 vehicles; `25` is a London bus, 28 vehicles. **Seven** such pairs exist (`007 022 025 030 032 035 040`), every padded one National Express and every twin TfL — genuinely different routes. Matching therefore never strips zeros and never compares numerically. The brief said six; the data said seven, and the module header cites the measured number with both reproduction commands.

**3. The destination suffix.** Live diversion labels carry `102 → Heathrow Airport  Heathrow Central Bus Station` (58 of 59 live labels have one; the archive has zero because it predates the API path that adds it). Matching strips at the first arrow.

## Architecture

One new shared module, `frontend/src/layers/searched-lines.ts`, built **first** because both layers depend on it — the join belongs in one place, not copied twice. It registers exactly one hook on `buses.ts` and fans out, publishes the current selection to late subscribers, and normalises an empty selection to `null` so `if (!lines)` is a complete "not searching" test.

Both layers changed **in place**. No parallel "diversions-for-the-searched-line" module: that would be a near-duplicate of a shipped file.

## Behaviour change worth knowing

The diversions toggle was previously the sole authority over whether that layer fetches, and `main.ts` advertised "while hidden it also costs zero fetches". A search can now make it fetch while the switch is off. The comment is corrected and the new invariant is tested.

The 2-vehicle corroboration floor is **not** relaxed for search. It is enforced server-side before the payload leaves; the frontend only narrows what the API already gated. Live histogram of 33 events: minimum 2 vehicles.

## A review finding that mattered

A failed `/api/diversions` poll was only `console.warn`'d, and before the first successful fetch `lastEvents` was `[]` — so a searched route painted an empty map **indistinguishable from "this route is clear"**. Diversions now tracks fetch health beside the data, logs failures naming the searched line and whether anything has ever been received, and retries in 5 s (bounded to 3 attempts) while nothing has ever arrived instead of waiting out the 90 s interval.

## Verification

A skeptic attacked the matching with real data — 522 archive labels, 327 live closure labels, 59 live arrow-form labels, 668 live BODS line names, **606,500 comparisons** — across seven attack lines: substring, zero padding, arrow form, case and whitespace, coverage, the fetch gate, and whether search relaxes the vehicle floor. **All seven refuted; nothing needed fixing.**

Live spot checks through the real modules against real payloads (258 stops, 33 events):

| search | drawn | check |
|---|---|---|
| `122` | 9 stops | every routes list leads with 122 |
| `188` | 7 stops | 7 drawn, 251 dropped, 7+251 = 258 |
| `46` | 3 stops | the 6 serving 146/460/N46/46A stayed away |

All 50 distinct live diversion route labels were typed through the real search path: 0 unreachable.

## Test plan

- [x] `cd frontend && npx vitest run` — **255 passed** (208 before)
- [x] `cd backend && npx vitest run` — 396 passed, backend untouched
- [x] Both typechecks clean, frontend build clean
- [ ] After deploy: search a route on production, where 38 diversions are live — the local detector rebuilds from zero after every restart, so the diversion half cannot be demonstrated locally straight after a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6TmZ3M7PcEVpqknXSjGfY
